### PR TITLE
Add name-based padel match recording with player search and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ API (v0)
 GET  /api/v0/sports
 GET  /api/v0/rulesets?sport=padel
 POST /api/v0/players
+GET  /api/v0/players?q=name
 POST /api/v0/matches
+POST /api/v0/matches/by-name
 GET  /api/v0/matches/{id}
 POST /api/v0/matches/{id}/events
+POST /api/v0/matches/{id}/sets
 GET  /api/v0/leaderboards?sport=padel
 WS   /api/v0/matches/{id}/stream
 
@@ -131,7 +134,9 @@ POST /api/v0/matches
     { "side": "A", "playerIds": ["p1","p2"] },
     { "side": "B", "playerIds": ["p3","p4"] }
   ],
-  "bestOf": 3
+  "bestOf": 3,
+  "playedAt": "2024-06-01T10:00:00Z",
+  "location": "Local Club"
 }
 
 
@@ -142,6 +147,11 @@ POST /api/v0/matches/m_123/events
 
 POST /api/v0/matches/m_456/events
 { "type": "ROLL", "pins": 7 }     // bowling
+
+Record completed padel sets
+
+POST /api/v0/matches/m_123/sets
+{ "sets": [[2,6],[6,4],[1,6]] }
 
 Dev Quickstart (local)
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -18,7 +18,7 @@ export default async function Page() {
         {sports.map((s: any) => <li key={s.id}>{s.name} ({s.id})</li>)}
       </ul>
       <nav>
-        <a href="/players">Players</a> | <a href="/matches">Matches</a>
+        <a href="/players">Players</a> | <a href="/matches">Matches</a> | <a href="/record">Record</a>
       </nav>
     </main>
   );

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+
+export default function RecordPage() {
+  const router = useRouter();
+  const [names, setNames] = useState({ a1: "", a2: "", b1: "", b2: "" });
+  const [suggest, setSuggest] = useState<Record<string, any[]>>({});
+  const [sets, setSets] = useState([{ A: "", B: "" }]);
+  const [playedAt, setPlayedAt] = useState("");
+  const [location, setLocation] = useState("");
+
+  async function search(term: string, key: string) {
+    if (!term) return;
+    const res = await fetch(`${base}/v0/players?q=${encodeURIComponent(term)}`);
+    if (res.ok) setSuggest(s => ({ ...s, [key]: await res.json() }));
+  }
+
+  function onNameChange(key: string, value: string) {
+    setNames({ ...names, [key]: value });
+    search(value, key);
+  }
+
+  function onSetChange(idx: number, field: "A" | "B", value: string) {
+    const copy = sets.slice();
+    copy[idx][field] = value;
+    setSets(copy);
+  }
+
+  function addSet() {
+    setSets([...sets, { A: "", B: "" }]);
+  }
+
+  async function submit() {
+    const body = {
+      sport: "padel",
+      participants: [
+        { side: "A", playerNames: [names.a1, names.a2] },
+        { side: "B", playerNames: [names.b1, names.b2] }
+      ],
+      bestOf: 3,
+      playedAt: playedAt ? new Date(playedAt).toISOString() : undefined,
+      location: location || undefined,
+    };
+    const res = await fetch(`${base}/v0/matches/by-name`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return;
+    const { id } = await res.json();
+    const payload = { sets: sets.map(s => [Number(s.A), Number(s.B)]) };
+    await fetch(`${base}/v0/matches/${id}/sets`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    router.push(`/matches/${id}`);
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Record Match</h1>
+      <div>
+        <input value={names.a1} onChange={e => onNameChange("a1", e.target.value)} list="a1" placeholder="Player A1" />
+        <datalist id="a1">{(suggest.a1 || []).map(p => <option key={p.id} value={p.name} />)}</datalist>
+        <input value={names.a2} onChange={e => onNameChange("a2", e.target.value)} list="a2" placeholder="Player A2" />
+        <datalist id="a2">{(suggest.a2 || []).map(p => <option key={p.id} value={p.name} />)}</datalist>
+      </div>
+      <div>
+        <input value={names.b1} onChange={e => onNameChange("b1", e.target.value)} list="b1" placeholder="Player B1" />
+        <datalist id="b1">{(suggest.b1 || []).map(p => <option key={p.id} value={p.name} />)}</datalist>
+        <input value={names.b2} onChange={e => onNameChange("b2", e.target.value)} list="b2" placeholder="Player B2" />
+        <datalist id="b2">{(suggest.b2 || []).map(p => <option key={p.id} value={p.name} />)}</datalist>
+      </div>
+      <div>
+        {sets.map((s, idx) => (
+          <div key={idx}>
+            <input value={s.A} onChange={e => onSetChange(idx, "A", e.target.value)} placeholder="A" />
+            -
+            <input value={s.B} onChange={e => onSetChange(idx, "B", e.target.value)} placeholder="B" />
+          </div>
+        ))}
+        <button onClick={addSet}>Add Set</button>
+      </div>
+      <div>
+        <input type="date" value={playedAt} onChange={e => setPlayedAt(e.target.value)} />
+        <input value={location} onChange={e => setLocation(e.target.value)} placeholder="Location" />
+      </div>
+      <button onClick={submit}>Save</button>
+    </main>
+  );
+}

--- a/backend/alembic/versions/0003_match_meta_and_unique_player_names.py
+++ b/backend/alembic/versions/0003_match_meta_and_unique_player_names.py
@@ -1,0 +1,18 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003_match_meta_and_unique_player_names'
+down_revision = '0002_match_details'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('match', sa.Column('played_at', sa.DateTime(), nullable=True))
+    op.add_column('match', sa.Column('location', sa.String(), nullable=True))
+    op.create_unique_constraint('uq_player_name', 'player', ['name'])
+
+
+def downgrade():
+    op.drop_constraint('uq_player_name', 'player', type_='unique')
+    op.drop_column('match', 'location')
+    op.drop_column('match', 'played_at')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -25,7 +25,7 @@ class Player(Base):
     __tablename__ = "player"
     id = Column(String, primary_key=True)
     user_id = Column(String, nullable=True)
-    name = Column(String, nullable=False)
+    name = Column(String, nullable=False, unique=True)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
 
 class Team(Base):
@@ -53,6 +53,8 @@ class Match(Base):
     stage_id = Column(String, ForeignKey("stage.id"), nullable=True)
     ruleset_id = Column(String, ForeignKey("ruleset.id"), nullable=True)
     best_of = Column(Integer, nullable=True)
+    played_at = Column(DateTime, nullable=True)
+    location = Column(String, nullable=True)
     details = Column(JSON, nullable=True)
 
 class MatchParticipant(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,5 @@
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple
+from datetime import datetime
 from pydantic import BaseModel
 
 # Basic DTOs
@@ -30,6 +31,26 @@ class MatchCreate(BaseModel):
     rulesetId: Optional[str] = None
     participants: List[Participant]
     bestOf: Optional[int] = None
+    playedAt: Optional[datetime] = None
+    location: Optional[str] = None
+
+
+class ParticipantByName(BaseModel):
+    side: Literal["A", "B"]
+    playerNames: List[str]
+
+
+class MatchCreateByName(BaseModel):
+    sport: str
+    rulesetId: Optional[str] = None
+    participants: List[ParticipantByName]
+    bestOf: Optional[int] = None
+    playedAt: Optional[datetime] = None
+    location: Optional[str] = None
+
+
+class SetsIn(BaseModel):
+    sets: List[Tuple[int, int]]
 
 class EventIn(BaseModel):
     type: Literal["POINT", "ROLL", "UNDO"]

--- a/backend/app/scoring/padel.py
+++ b/backend/app/scoring/padel.py
@@ -40,3 +40,17 @@ def summary(state: Dict) -> Dict:
         "games": state["games"],
         "sets": state["sets"],
     }
+
+
+def record_sets(set_scores, state=None):
+    state = state or init_state({})
+    events = []
+    for ga, gb in set_scores:
+        target = {"A": ga, "B": gb}
+        while state["games"]["A"] < target["A"] or state["games"]["B"] < target["B"]:
+            side = "A" if state["games"]["A"] < target["A"] else "B"
+            for _ in range(4):
+                ev = {"type": "POINT", "by": side}
+                events.append(ev)
+                state = apply(ev, state)
+    return events, state

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -16,3 +16,9 @@ def test_bowling_simple_score():
         state = bowling.apply({"type": "ROLL", "pins": 1}, state)
     summary = bowling.summary(state)
     assert summary["total"] == 20
+
+
+def test_record_sets():
+    events, state = padel.record_sets([(6, 4), (6, 2)])
+    assert state["sets"]["A"] == 2
+    assert len(events) == (6 + 4 + 6 + 2) * 4


### PR DESCRIPTION
## Summary
- allow creating matches with player names and optional date/location
- enable set-level padel results via new API and scoring helper
- add player name search endpoint and simple record page in web UI

## Testing
- `pytest` *(fails: process killed after running tests)*
- `npm test` *(fails: missing dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68aea38ba0c88323ae7ffa1cf0c5c1df