### PR TITLE
fix: support tuple set scores

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -173,6 +173,22 @@ async def record_sets_endpoint(mid: str, body: SetsIn, session: AsyncSession = D
     for old in existing:
         state = padel_engine.apply(old.payload, state)
 
+    # Validate set scores before applying them. Normalize any supported
+    # structure (dict, object with ``A``/``B`` attributes, or 2-item tuple)
+    # into a list of {"A": int, "B": int} for the validator.
+    try:
+        normalized_sets = []
+        for s in body.sets:
+            if isinstance(s, dict):
+                normalized_sets.append({"A": s.get("A"), "B": s.get("B")})
+            elif isinstance(s, (list, tuple)) and len(s) == 2:
+                normalized_sets.append({"A": s[0], "B": s[1]})
+            else:
+                normalized_sets.append({"A": getattr(s, "A", None), "B": getattr(s, "B", None)})
+        padel_engine.validate_set_scores(normalized_sets)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
     new_events, state = padel_engine.record_sets(body.sets, state)
 
     for ev in new_events:

--- a/backend/app/scoring/padel.py
+++ b/backend/app/scoring/padel.py
@@ -42,15 +42,65 @@ def summary(state: Dict) -> Dict:
     }
 
 
+def validate_set_scores(set_scores) -> None:
+    """Validate a sequence of set score objects.
+
+    Each element may be a mapping with ``A``/``B`` keys, a two-item tuple/list,
+    or an object exposing ``A`` and ``B`` attributes.  All values must be
+    integers.  Raises ``ValueError`` with a descriptive message on failure.
+    """
+
+    for idx, s in enumerate(set_scores, start=1):
+        if isinstance(s, dict):
+            a, b = s.get("A"), s.get("B")
+        elif isinstance(s, (list, tuple)) and len(s) == 2:
+            a, b = s[0], s[1]
+        else:
+            a, b = getattr(s, "A", None), getattr(s, "B", None)
+
+        if not isinstance(a, int) or not isinstance(b, int):
+            raise ValueError(f"Set #{idx} scores must be integers")
+
+
 def record_sets(set_scores, state=None):
+    """Generate point events to reach the provided set scores.
+
+    ``set_scores`` is an iterable of ``(games_A, games_B)`` tuples.  The
+    returned state represents the scoreboard after applying all generated
+    events.
+    """
+
     state = state or init_state({})
     events = []
+
     for ga, gb in set_scores:
-        target = {"A": ga, "B": gb}
-        while state["games"]["A"] < target["A"] or state["games"]["B"] < target["B"]:
-            side = "A" if state["games"]["A"] < target["A"] else "B"
+        # Determine winner/loser for this set.
+        if ga == gb:
+            raise ValueError("sets cannot be tied")
+        winner = "A" if ga > gb else "B"
+        loser = "B" if winner == "A" else "A"
+        win_games = ga if winner == "A" else gb
+        lose_games = gb if winner == "A" else ga
+
+        # Winner captures all but the final game first, then the loser wins
+        # their games, and finally the winner secures the set with the last
+        # game.  This yields a deterministic sequence that respects the final
+        # game totals.
+        for _ in range(win_games - 1):
             for _ in range(4):
-                ev = {"type": "POINT", "by": side}
+                ev = {"type": "POINT", "by": winner}
                 events.append(ev)
                 state = apply(ev, state)
+
+        for _ in range(lose_games):
+            for _ in range(4):
+                ev = {"type": "POINT", "by": loser}
+                events.append(ev)
+                state = apply(ev, state)
+
+        for _ in range(4):
+            ev = {"type": "POINT", "by": winner}
+            events.append(ev)
+            state = apply(ev, state)
+
     return events, state

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -22,3 +22,8 @@ def test_record_sets():
     events, state = padel.record_sets([(6, 4), (6, 2)])
     assert state["sets"]["A"] == 2
     assert len(events) == (6 + 4 + 6 + 2) * 4
+
+
+def test_validate_tuple_set_scores():
+    # Should not raise when provided with tuple-based scores
+    padel.validate_set_scores([(6, 4), (6, 2)])


### PR DESCRIPTION
## Summary
- validate set scores from tuples, dicts, or objects
- generate deterministic point events for provided set scores
- cover tuple-based sets in scoring tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1255879948323b1d7936a40247af7