### PR TITLE
Expose validation helpers and tidy configs

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,6 @@
 """Internal application services (pure helpers, no I/O)."""
 
-__all__ = ["validation"]
+from .validation import ValidationError, validate_set_scores
+
+__all__ = ["validate_set_scores", "ValidationError"]
 

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -47,3 +47,5 @@ def validate_set_scores(sets: List[Dict[str, Any]], max_sets: int = 5) -> None:
         if a == b:
             raise ValidationError(f"Set #{i} cannot be a tie.")
 
+    return None
+

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from app.services.validation import validate_set_scores, ValidationError
+from app.services import validate_set_scores, ValidationError
 
 def test_accepts_valid_sets() -> None:
     validate_set_scores([{"A": 21, "B": 18}])

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -41,3 +41,4 @@ services:
       retries: 5
       start_period: 30s
 
+# End of healthcheck configuration

--- a/docker-compose.unraid.yml.bak.2025-08-27_0916
+++ b/docker-compose.unraid.yml.bak.2025-08-27_0916
@@ -1,4 +1,5 @@
 services:
+  # Backup snapshot created on 2025-08-27
   web:
     build:
       context: ./apps/web


### PR DESCRIPTION
## Summary
- expose validation helpers at the services package level
- clarify validation helper's return value
- document healthcheck and backup compose files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b146a2ede88323979d68f032748acf