### PR TITLE
chore(web): add dockerignore

### DIFF
--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore node dependencies
+node_modules
+
+# Ignore Next.js build output
+.next
+
+# Ignore logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.log
+
+# Ignore coverage and build artifacts
+coverage
+dist
+
+# Ignore IDE files
+.vscode
+.DS_Store
+
+# Ignore git metadata
+.git
+.gitignore


### PR DESCRIPTION
## Summary
- avoid sending dev artifacts in web build context by adding dockerignore

## Testing
- `npm test`
- `docker build --no-cache -t cst-web-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b288cd7e6c832396fe36b6ffa6106a