### PR TITLE
Validate database URL and seed rule sets idempotently

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,11 +1,13 @@
-import asyncio, uuid
+import asyncio
+import os
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from app.models import Sport, RuleSet
-import os
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable is required")
 if DATABASE_URL.startswith("postgresql://"):
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 
@@ -22,14 +24,33 @@ async def main():
         await s.commit()
 
         # basic rulesets
-        rs = (await s.execute(select(RuleSet))).scalars().all()
-        if not rs:
-            s.add_all([
-                RuleSet(id=str(uuid.uuid4()), sport_id="padel", name="Padel default", config={"goldenPoint": False, "tiebreakTo": 7, "sets": 3}),
-                RuleSet(id=str(uuid.uuid4()), sport_id="padel", name="Padel golden point", config={"goldenPoint": True, "tiebreakTo": 7, "sets": 3}),
-                RuleSet(id=str(uuid.uuid4()), sport_id="bowling", name="Bowling standard", config={"frames": 10, "tenthFrameBonus": True}),
-            ])
-            await s.commit()
+        existing_rs = {
+            x.id for x in (await s.execute(select(RuleSet))).scalars().all()
+        }
+        rulesets = [
+            RuleSet(
+                id="padel-default",
+                sport_id="padel",
+                name="Padel default",
+                config={"goldenPoint": False, "tiebreakTo": 7, "sets": 3},
+            ),
+            RuleSet(
+                id="padel-golden",
+                sport_id="padel",
+                name="Padel golden point",
+                config={"goldenPoint": True, "tiebreakTo": 7, "sets": 3},
+            ),
+            RuleSet(
+                id="bowling-standard",
+                sport_id="bowling",
+                name="Bowling standard",
+                config={"frames": 10, "tenthFrameBonus": True},
+            ),
+        ]
+        for rs in rulesets:
+            if rs.id not in existing_rs:
+                s.add(rs)
+        await s.commit()
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- ensure `DATABASE_URL` is set before seeding
- use stable IDs for initial rule sets to avoid duplicates
- insert rule sets only when missing

## Testing
- `python seed.py`
- `python seed.py` (idempotency check)
- `sqlite3 test.db 'select count(*) from sport;'`
- `sqlite3 test.db 'select count(*) from ruleset;'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b288d70574832391e3257ff73d0aa9