### PR TITLE
docs: add Postgres host to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Example (no secrets)
 DOMAIN=www.YourDomain.com
+# Required for health and backup services
+POSTGRES_HOST=postgresql16
 POSTGRES_USER=postgresql16
 POSTGRES_DB=crosssport
 POSTGRES_PASSWORD=


### PR DESCRIPTION
## Summary
- add POSTGRES_HOST to `.env.example`
- note variable is required for health and backup services

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b288da363083239544526fb378e779