### PR TITLE
Use Redis pub/sub for match streams

### DIFF
--- a/backend/app/routers/streams.py
+++ b/backend/app/routers/streams.py
@@ -1,23 +1,46 @@
-from collections import defaultdict
-from typing import Dict, Set
+import asyncio
+import json
+import os
+from contextlib import suppress
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import redis.asyncio as redis
+
 
 router = APIRouter()
-_connections: Dict[str, Set[WebSocket]] = defaultdict(set)
 
-async def broadcast(mid: str, message: dict):
-    for ws in list(_connections.get(mid, [])):
-        try:
-            await ws.send_json(message)
-        except Exception:
-            _connections[mid].discard(ws)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+
+
+async def broadcast(mid: str, message: dict) -> None:
+    """Publish a message for a match to all subscribers."""
+    await redis_client.publish(mid, json.dumps(message))
+
 
 @router.websocket("/matches/{mid}/stream")
-async def match_stream(ws: WebSocket, mid: str):
+async def match_stream(ws: WebSocket, mid: str) -> None:
+    """Stream match updates via a Redis pub/sub channel."""
     await ws.accept()
-    _connections[mid].add(ws)
+    pubsub = redis_client.pubsub()
+    await pubsub.subscribe(mid)
+
+    async def sender() -> None:
+        async for msg in pubsub.listen():
+            if msg.get("type") == "message":
+                await ws.send_json(json.loads(msg["data"]))
+
+    send_task = asyncio.create_task(sender())
     try:
         while True:
             await ws.receive_text()
     except WebSocketDisconnect:
-        _connections[mid].discard(ws)
+        pass
+    finally:
+        send_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await send_task
+        await pubsub.unsubscribe(mid)
+        await pubsub.close()
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,4 +6,7 @@ alembic>=1.12,<2.0
 pydantic>=2.4,<3.0
 pydantic-settings>=2.2,<3.0
 python-multipart>=0.0.9,<1.0
+redis>=4.0,<5.0
+fakeredis>=2.0,<3.0
+httpx>=0.23,<1.0
 

--- a/backend/tests/test_streams.py
+++ b/backend/tests/test_streams.py
@@ -1,0 +1,20 @@
+import fakeredis.aioredis
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import streams
+
+
+app = FastAPI()
+app.include_router(streams.router)
+
+
+def test_broadcast_reaches_multiple_clients() -> None:
+    streams.redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    with TestClient(app) as client1, TestClient(app) as client2:
+        with client1.websocket_connect("/matches/m1/stream") as ws1, \
+             client2.websocket_connect("/matches/m1/stream") as ws2:
+            client1.portal.call(streams.broadcast, "m1", {"msg": 1})
+            assert ws1.receive_json() == {"msg": 1}
+            assert ws2.receive_json() == {"msg": 1}
+


### PR DESCRIPTION
## Summary
- replace in-memory WebSocket tracking with Redis-based pub/sub
- update broadcast and stream handlers to publish/subscribe
- add tests verifying messages reach multiple clients

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b288dc5f2c8323a3e554c913eb194e