### PR TITLE
feat: add global navigation header

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/app/layout.tsx
 import './globals.css';
+import Link from 'next/link';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -13,7 +14,38 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body style={{ margin: 0 }}>{children}</body>
+      <body style={{ margin: 0 }}>
+        <header style={{ backgroundColor: '#f5f5f5', padding: '1rem' }}>
+          <nav>
+            <ul
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                listStyle: 'none',
+                margin: 0,
+                padding: 0,
+              }}
+            >
+              <li>
+                <Link href="/">Home</Link>
+              </li>
+              <li>
+                <Link href="/players">Players</Link>
+              </li>
+              <li>
+                <Link href="/matches">Matches</Link>
+              </li>
+              <li>
+                <Link href="/record">Record</Link>
+              </li>
+              <li>
+                <Link href="/leaderboard">Leaderboard</Link>
+              </li>
+            </ul>
+          </nav>
+        </header>
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- display a global navigation bar across pages with links to Home, Players, Matches, Record, and Leaderboard

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b29ac0cd8483239541bc384f861cfc