### PR TITLE
style: centralize form control styling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,3 +1,46 @@
 /* apps/web/src/app/globals.css */
 :root { color-scheme: light dark; }
 html, body { padding: 0; margin: 0; font-family: system-ui, sans-serif; }
+
+/* basic button styling */
+.btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #0070f3;
+  border-radius: 4px;
+  background-color: #0070f3;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.btn:hover {
+  background-color: #005bb5;
+  border-color: #005bb5;
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 118, 255, 0.4);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* basic input/select styling */
+.input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.input:hover {
+  border-color: #999;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #0070f3;
+  box-shadow: 0 0 0 2px rgba(0, 118, 255, 0.4);
+}

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -41,8 +41,8 @@ export default function MatchDetail({ params }: { params: { mid: string } }) {
     <main style={{ padding: 24 }}>
       <h1>Match {mid}</h1>
       <div>Summary: {JSON.stringify(summary)}</div>
-      <button onClick={() => send("A")}>Point A</button>
-      <button onClick={() => send("B")}>Point B</button>
+      <button className="btn" onClick={() => send("A")}>Point A</button>
+      <button className="btn" onClick={() => send("B")}>Point B</button>
       <ul>
         {events.map((e: any) => <li key={e.id}>{e.type || e.event?.type} {JSON.stringify(e.payload || e)}</li>)}
       </ul>

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -244,8 +244,8 @@ export default function MatchPage({ params }: { params: { mid: string } }) {
             <h2 style={{ marginTop: 0 }}>Add Event</h2>
             {match.sport === "padel" && (
               <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                <button disabled={posting} onClick={() => sendPadelPoint("A")}>Point A</button>
-                <button disabled={posting} onClick={() => sendPadelPoint("B")}>Point B</button>
+                <button className="btn" disabled={posting} onClick={() => sendPadelPoint("A")}>Point A</button>
+                <button className="btn" disabled={posting} onClick={() => sendPadelPoint("B")}>Point B</button>
               </div>
             )}
 
@@ -290,6 +290,7 @@ function BowlingControls({
   return (
     <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
       <input
+        className="input"
         type="number"
         min={0}
         max={10}
@@ -300,6 +301,7 @@ function BowlingControls({
         aria-label="Pins knocked down"
       />
       <button
+        className="btn"
         disabled={disabled || pins === "" || Number(pins) < 0 || Number(pins) > 10}
         onClick={() => {
           const n = Number(pins);

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -27,8 +27,13 @@ export default function PlayersPage() {
     <main style={{ padding: 24 }}>
       <h1>Players</h1>
       <ul>{players.map(p => <li key={p.id}>{p.name}</li>)}</ul>
-      <input value={name} onChange={e => setName(e.target.value)} placeholder="name" />
-      <button onClick={create}>Add</button>
+      <input
+        className="input"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="name"
+      />
+      <button className="btn" onClick={create}>Add</button>
     </main>
   );
 }

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -111,10 +111,11 @@ export default function RecordPage() {
         <h2>Players</h2>
         <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
           <div>
-            <select
-              value={ids.a1}
-              onChange={(e) => onIdChange("a1", e.target.value)}
-            >
+              <select
+                className="input"
+                value={ids.a1}
+                onChange={(e) => onIdChange("a1", e.target.value)}
+              >
               <option value="">Player A1</option>
               {players.map((p: any) => (
                 <option key={p.id} value={p.id}>
@@ -124,10 +125,11 @@ export default function RecordPage() {
             </select>
           </div>
           <div>
-            <select
-              value={ids.a2}
-              onChange={(e) => onIdChange("a2", e.target.value)}
-            >
+              <select
+                className="input"
+                value={ids.a2}
+                onChange={(e) => onIdChange("a2", e.target.value)}
+              >
               <option value="">Player A2</option>
               {players.map((p: any) => (
                 <option key={p.id} value={p.id}>
@@ -137,10 +139,11 @@ export default function RecordPage() {
             </select>
           </div>
           <div>
-            <select
-              value={ids.b1}
-              onChange={(e) => onIdChange("b1", e.target.value)}
-            >
+              <select
+                className="input"
+                value={ids.b1}
+                onChange={(e) => onIdChange("b1", e.target.value)}
+              >
               <option value="">Player B1</option>
               {players.map((p: any) => (
                 <option key={p.id} value={p.id}>
@@ -150,10 +153,11 @@ export default function RecordPage() {
             </select>
           </div>
           <div>
-            <select
-              value={ids.b2}
-              onChange={(e) => onIdChange("b2", e.target.value)}
-            >
+              <select
+                className="input"
+                value={ids.b2}
+                onChange={(e) => onIdChange("b2", e.target.value)}
+              >
               <option value="">Player B2</option>
               {players.map((p: any) => (
                 <option key={p.id} value={p.id}>
@@ -170,50 +174,54 @@ export default function RecordPage() {
         <div style={{ display: "grid", gap: 8 }}>
           {sets.map((s, idx) => (
             <div key={idx} style={{ display: "flex", gap: 8, alignItems: "center" }}>
-              <input
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={s.A}
-                onChange={(e) => onSetChange(idx, "A", e.target.value)}
-                placeholder="A"
-                style={{ width: 64 }}
-              />
+                <input
+                  className="input"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={s.A}
+                  onChange={(e) => onSetChange(idx, "A", e.target.value)}
+                  placeholder="A"
+                  style={{ width: 64 }}
+                />
               <span>-</span>
-              <input
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={s.B}
-                onChange={(e) => onSetChange(idx, "B", e.target.value)}
-                placeholder="B"
-                style={{ width: 64 }}
-              />
+                <input
+                  className="input"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={s.B}
+                  onChange={(e) => onSetChange(idx, "B", e.target.value)}
+                  placeholder="B"
+                  style={{ width: 64 }}
+                />
             </div>
           ))}
         </div>
-        <button style={{ marginTop: 8 }} onClick={addSet} type="button">
-          Add Set
-        </button>
+          <button className="btn" style={{ marginTop: 8 }} onClick={addSet} type="button">
+            Add Set
+          </button>
       </section>
 
       <section style={{ marginBottom: 16 }}>
         <h2>Details</h2>
         <div style={{ display: "flex", gap: 8 }}>
-          <input
-            type="date"
-            value={playedAt}
-            onChange={(e) => setPlayedAt(e.target.value)}
-          />
-          <input
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="Location"
-          />
+            <input
+              className="input"
+              type="date"
+              value={playedAt}
+              onChange={(e) => setPlayedAt(e.target.value)}
+            />
+            <input
+              className="input"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="Location"
+            />
         </div>
       </section>
 
-      <button onClick={submit} type="button">
-        Save
-      </button>
+        <button className="btn" onClick={submit} type="button">
+          Save
+        </button>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- define reusable `.btn` and `.input` classes in global styles for consistent padding, borders, and focus states
- apply new form control classes across players, record, and matches pages

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b29ac757088323add751a6744cb681