### PR TITLE
Add player detail page and backend player retrieval

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+
+interface Player {
+  id: string;
+  name: string;
+  club_id?: string | null;
+}
+
+export default async function PlayerPage({ params }: { params: { id: string } }) {
+  const res = await fetch(`${base}/v0/players/${params.id}`, { cache: "no-store" });
+  const p: Player = await res.json();
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>{p.name}</h1>
+      {p.club_id && <p>Club: {p.club_id}</p>}
+      <Link href="/players">Back to players</Link>
+    </main>
+  );
+}
+

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import Link from "next/link";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -26,7 +27,13 @@ export default function PlayersPage() {
   return (
     <main style={{ padding: 24 }}>
       <h1>Players</h1>
-      <ul>{players.map(p => <li key={p.id}>{p.name}</li>)}</ul>
+      <ul>
+        {players.map(p => (
+          <li key={p.id}>
+            <Link href={`/players/${p.id}`}>{p.name}</Link>
+          </li>
+        ))}
+      </ul>
       <input value={name} onChange={e => setName(e.target.value)} placeholder="name" />
       <button onClick={create}>Add</button>
     </main>

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -31,3 +31,11 @@ async def list_players(q: str = "", session: AsyncSession = Depends(get_session)
         stmt = stmt.where(Player.name.ilike(f"%{q}%"))
     rows = (await session.execute(stmt)).scalars().all()
     return [{"id": p.id, "name": p.name, "club_id": p.club_id} for p in rows]
+
+# GET /api/v0/players/{player_id}
+@router.get("/{player_id}")
+async def get_player(player_id: str, session: AsyncSession = Depends(get_session)):
+    p = await session.get(Player, player_id)
+    if not p:
+        raise HTTPException(404, "player not found")
+    return {"id": p.id, "name": p.name, "club_id": p.club_id}


### PR DESCRIPTION
## Summary
- Wrap player names in links to individual player pages
- Add player detail page that fetches player info and links back to list
- Expose backend `GET /players/{id}` endpoint

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29ac443e48323a28abdfe933d7913