### PR TITLE
style: center nav and add sport icons

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -83,10 +83,24 @@ a {
 }
 .nav ul {
   display: flex;
+  justify-content: center;
   gap: 1rem;
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+/* Sport list */
+.sport-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.sport-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .mt-8 {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,10 @@ import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 
 type Sport = { id: string; name: string };
+const sportIcons: Record<string, string> = {
+  padel: '🎾',
+  bowling: '🎳',
+};
 
 export default async function HomePage() {
   let sports: Sport[] = [];
@@ -28,17 +32,27 @@ export default async function HomePage() {
         {sports.length === 0 ? (
           <p className="text-gray-600">No sports found.</p>
         ) : (
-          <ul className="list-disc pl-6">
-            {sports.map((s) => (
-              <li key={s.id}>
-                {s.name} <span className="text-gray-500">({s.id})</span>
-              </li>
-            ))}
+          <ul className="sport-list">
+            {sports.map((s) => {
+              const icon = sportIcons[s.id];
+              return (
+                <li key={s.id} className="sport-item">
+                  {icon ? (
+                    <span role="img" aria-label={s.name} title={s.name}>
+                      {icon}
+                    </span>
+                  ) : (
+                    s.name
+                  )}
+                  <span className="text-gray-500">({s.id})</span>
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>
 
-      <nav className="space-x-3">
+      <nav className="flex gap-3">
         <Link href="/players">Players</Link>
         <Link href="/matches">Matches</Link>
         <Link href="/record">Record</Link>


### PR DESCRIPTION
## Summary
- center top navigation links
- show padel and bowling using emoji icons
- space home page links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f84863848323b72cb8f836c22aff