### PR TITLE
Add pagination support for player listing

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -15,8 +15,13 @@ export default function PlayersPage() {
   const [name, setName] = useState("");
 
   async function load() {
-    const res = await fetch(`${base}/v0/players`, { cache: "no-store" });
-    if (res.ok) setPlayers(await res.json());
+    const res = await fetch(`${base}/v0/players?limit=100&offset=0`, {
+      cache: "no-store",
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPlayers(data.players);
+    }
   }
   useEffect(() => {
     load();

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -23,9 +23,10 @@ export default function RecordPage() {
   useEffect(() => {
     async function loadPlayers() {
       try {
-        const res = await fetch(`${base}/v0/players`);
+        const res = await fetch(`${base}/v0/players?limit=100&offset=0`);
         if (res.ok) {
-          setPlayers(await res.json());
+          const data = await res.json();
+          setPlayers(data.players);
         }
       } catch {
         // ignore errors

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,7 +1,7 @@
 # backend/app/routers/players.py
 import uuid
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
@@ -25,12 +25,24 @@ async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_
 
 # GET /api/v0/players
 @router.get("")
-async def list_players(q: str = "", session: AsyncSession = Depends(get_session)):
+async def list_players(
+    q: str = "",
+    limit: int = 50,
+    offset: int = 0,
+    session: AsyncSession = Depends(get_session),
+):
     stmt = select(Player)
+    count_stmt = select(func.count()).select_from(Player)
     if q:
         stmt = stmt.where(Player.name.ilike(f"%{q}%"))
+        count_stmt = count_stmt.where(Player.name.ilike(f"%{q}%"))
+    total = (await session.execute(count_stmt)).scalar()
+    stmt = stmt.limit(limit).offset(offset)
     rows = (await session.execute(stmt)).scalars().all()
-    return [{"id": p.id, "name": p.name, "club_id": p.club_id} for p in rows]
+    players = [
+        {"id": p.id, "name": p.name, "club_id": p.club_id} for p in rows
+    ]
+    return {"players": players, "total": total, "limit": limit, "offset": offset}
 
 # GET /api/v0/players/{player_id}
 @router.get("/{player_id}")

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -1,0 +1,44 @@
+import os, sys, asyncio, pytest
+
+# Ensure the backend app modules can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Set up an in-memory SQLite database for tests
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app.db import Base, engine
+from app.routers import players
+from app.models import Player, Club
+
+app = FastAPI()
+app.include_router(players.router)
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    async def init_models():
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                Base.metadata.create_all,
+                tables=[Club.__table__, Player.__table__],
+            )
+    asyncio.run(init_models())
+    yield
+    if os.path.exists("./test_players.db"):
+        os.remove("./test_players.db")
+
+def test_list_players_pagination() -> None:
+    with TestClient(app) as client:
+        # Create some players
+        for i in range(5):
+            resp = client.post("/players", json={"name": f"P{i}"})
+            assert resp.status_code == 200
+        # Request a limited subset
+        resp = client.get("/players", params={"limit": 2, "offset": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["limit"] == 2
+        assert data["offset"] == 1
+        assert data["total"] == 5
+        assert len(data["players"]) == 2


### PR DESCRIPTION
## Summary
- add limit/offset pagination and metadata to player listing endpoint
- update frontend to request and handle paginated player results
- test player list pagination

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f8512b3c8323a55907852c706418