### PR TITLE
refactor: lazily create database engine

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,20 +1,49 @@
 import os
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from typing import Optional
+from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine, create_async_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-if not DATABASE_URL:
-    raise RuntimeError("DATABASE_URL environment variable is required")
 
-if DATABASE_URL.startswith("postgresql://"):
-    DATABASE_URL = DATABASE_URL.replace(
-        "postgresql://", "postgresql+asyncpg://", 1
-    )
-
-engine = create_async_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
-AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+engine: Optional[AsyncEngine] = None
+AsyncSessionLocal: Optional[sessionmaker] = None
 Base = declarative_base()
 
-async def get_session():
+
+def get_engine() -> AsyncEngine:
+    """Return a lazily created SQLAlchemy engine.
+
+    The engine is created on first use using the ``DATABASE_URL`` environment
+    variable. Importing this module has no side effects so tests can set the
+    environment variable at runtime. A ``RuntimeError`` is raised only if the
+    function is called without ``DATABASE_URL`` being configured.
+    """
+
+    global engine, AsyncSessionLocal
+
+    if engine is None:
+        database_url = os.getenv("DATABASE_URL")
+        if not database_url:
+            raise RuntimeError("DATABASE_URL environment variable is required")
+
+        if database_url.startswith("postgresql://"):
+            database_url = database_url.replace(
+                "postgresql://", "postgresql+asyncpg://", 1
+            )
+
+        engine = create_async_engine(database_url, echo=False, pool_pre_ping=True)
+        AsyncSessionLocal = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    return engine
+
+
+async def get_session() -> AsyncSession:
+    """Provide a database session for FastAPI dependencies."""
+
+    if AsyncSessionLocal is None:
+        get_engine()
+
+    assert AsyncSessionLocal is not None  # for type checkers
     async with AsyncSessionLocal() as session:
         yield session


### PR DESCRIPTION
## Summary
- add `get_engine` to build SQLAlchemy engine only when needed
- allow importing `app.db` without `DATABASE_URL`
- have `get_session` use `get_engine` for runtime configuration

## Testing
- `python - <<'PY'
import sys
sys.path.append('backend')
import app.db
import app.models
import app.routers.players
import app.routers.matches
import app.routers.sports
import app.routers.leaderboards
import app.routers.rulesets
import app.routers.streams
print('imports ok')
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85326bc8323ba59aeccb7693673