### PR TITLE
Validate padel set scores

### DIFF
--- a/backend/app/scoring/padel.py
+++ b/backend/app/scoring/padel.py
@@ -61,6 +61,12 @@ def validate_set_scores(set_scores) -> None:
         if not isinstance(a, int) or not isinstance(b, int):
             raise ValueError(f"Set #{idx} scores must be integers")
 
+        if a < 0 or b < 0:
+            raise ValueError(f"Set #{idx} scores must be non-negative")
+
+        if a == b:
+            raise ValueError(f"Set #{idx} scores cannot be tied")
+
 
 def record_sets(set_scores, state=None):
     """Generate point events to reach the provided set scores.

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -1,4 +1,6 @@
 import os, sys
+import pytest
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.scoring import padel, bowling
 
@@ -27,3 +29,13 @@ def test_record_sets():
 def test_validate_tuple_set_scores():
     # Should not raise when provided with tuple-based scores
     padel.validate_set_scores([(6, 4), (6, 2)])
+
+
+def test_validate_set_scores_negative():
+    with pytest.raises(ValueError, match="non-negative"):
+        padel.validate_set_scores([(6, -4)])
+
+
+def test_validate_set_scores_tie():
+    with pytest.raises(ValueError, match="cannot be tied"):
+        padel.validate_set_scores([(4, 4)])


### PR DESCRIPTION
## Summary
- ensure padel set scores are non-negative and not tied
- test padel set score validation for negative and tied inputs

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85684408323aa0b398ab2c0b263