### PR TITLE
Handle player creation errors

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -13,6 +13,7 @@ interface Player {
 export default function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   async function load() {
     const res = await fetch(`${base}/v0/players`, { cache: "no-store" });
@@ -23,11 +24,29 @@ export default function PlayersPage() {
   }, []);
 
   async function create() {
-    await fetch(`${base}/v0/players`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name }),
-    });
+    setError(null);
+    try {
+      const res = await fetch(`${base}/v0/players`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | Record<string, unknown>
+          | null;
+        let message = "Failed to create player.";
+        if (data) {
+          if (typeof data["detail"] === "string") message = data["detail"];
+          else if (typeof data["message"] === "string") message = data["message"];
+        }
+        setError(message);
+        return;
+      }
+    } catch {
+      setError("Failed to create player.");
+      return;
+    }
     setName("");
     load();
   }
@@ -51,6 +70,7 @@ export default function PlayersPage() {
       <button className="button" onClick={create}>
         Add
       </button>
+      {error && <p className="text-red-500 mt-2">{error}</p>}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- handle failed player creation by parsing server errors and surfacing them to the user

## Testing
- `npm run lint --prefix apps/web`
- `npm test --prefix apps/web -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b2f8591e5c8323b92a219532c4e94f