### PR TITLE
feat: seed demo club and player

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,14 @@ cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 alembic upgrade head
+python seed.py  # adds default sports, rulesets, demo club/player
 uvicorn app.main:app --reload  # http://localhost:8000, docs at /docs
+
+Seed inserts:
+- Sports: Padel, Bowling
+- RuleSets: padel-default, padel-golden, bowling-standard
+- Club: Demo Club (id: demo-club)
+- Player: Demo Player (id: demo-player, club: Demo Club)
 
 # Web
 cd ../../apps/web

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -3,7 +3,7 @@ import os
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from app.models import Sport, RuleSet
+from app.models import Sport, RuleSet, Club, Player
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
@@ -50,6 +50,27 @@ async def main():
         for rs in rulesets:
             if rs.id not in existing_rs:
                 s.add(rs)
+        await s.commit()
+
+        # sample club
+        existing_clubs = {
+            x.id for x in (await s.execute(select(Club))).scalars().all()
+        }
+        for cid, name in [("demo-club", "Demo Club")]:
+            if cid not in existing_clubs:
+                s.add(Club(id=cid, name=name))
+        await s.commit()
+
+        # sample player
+        existing_players = {
+            x.id for x in (await s.execute(select(Player))).scalars().all()
+        }
+        players = [
+            Player(id="demo-player", name="Demo Player", club_id="demo-club"),
+        ]
+        for p in players:
+            if p.id not in existing_players:
+                s.add(p)
         await s.commit()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend seed script to add demo Club and Player rows if missing
- document seeded data and seeding step in README

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85c67388323985ff738cd1843b2