### PR TITLE
Handle match fetch errors with retry option

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -9,28 +9,44 @@ type MatchRow = {
   location: string | null;
 };
 
-export default async function MatchesPage() {
+async function getMatches(): Promise<MatchRow[]> {
   const r = await apiFetch("/v0/matches", { cache: "no-store" });
   if (!r.ok) throw new Error(`Failed to load matches: ${r.status}`);
-  const matches = (await r.json()) as MatchRow[];
+  return (await r.json()) as MatchRow[];
+}
 
-  return (
-    <main className="mx-auto max-w-3xl p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Matches</h1>
-      <ul className="space-y-2">
-        {matches.map((m) => (
-          <li key={m.id} className="rounded border p-3">
-            <div className="font-medium">
-              <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
-            </div>
-            <div className="text-sm text-gray-700">
-              {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-              {m.playedAt ? new Date(m.playedAt).toLocaleString() : "—"} ·{" "}
-              {m.location ?? "—"}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </main>
-  );
+export default async function MatchesPage() {
+  try {
+    const matches = await getMatches();
+
+    return (
+      <main className="mx-auto max-w-3xl p-6 space-y-4">
+        <h1 className="text-2xl font-semibold">Matches</h1>
+        <ul className="space-y-2">
+          {matches.map((m) => (
+            <li key={m.id} className="rounded border p-3">
+              <div className="font-medium">
+                <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+              </div>
+              <div className="text-sm text-gray-700">
+                {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
+                {m.playedAt ? new Date(m.playedAt).toLocaleString() : "—"} ·{" "}
+                {m.location ?? "—"}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </main>
+    );
+  } catch {
+    return (
+      <main className="mx-auto max-w-3xl p-6 space-y-4">
+        <h1 className="text-2xl font-semibold">Matches</h1>
+        <p className="text-red-600">Failed to load matches.</p>
+        <Link href="/matches" className="text-blue-600 underline">
+          Retry
+        </Link>
+      </main>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap match fetching in a try/catch on `MatchesPage`
- Show a friendly error with a retry link when fetching fails

## Testing
- `npx vitest run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85c00588323aeecd7042e8775f2