### PR TITLE
feat(record): support multiple sports

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import RecordPage from "./page";
+import RecordSportPage from "./page";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useParams: () => ({ sport: "padel" }),
 }));
 
-describe("RecordPage", () => {
+describe("RecordSportPage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -21,13 +22,13 @@ describe("RecordPage", () => {
 
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => players });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) });
     // @ts-expect-error override global fetch for test
     global.fetch = fetchMock;
 
     const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
-    render(<RecordPage />);
+    render(<RecordSportPage />);
 
     await screen.findAllByText("Alice");
 
@@ -46,7 +47,7 @@ describe("RecordPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(alertMock).toHaveBeenCalledWith("Please select four unique players.");
+    expect(alertMock).toHaveBeenCalledWith("Please select unique players.");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+
+const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+
+interface Player {
+  id: string;
+  name: string;
+  club_id?: string | null;
+}
+
+export default function RecordSportPage() {
+  const router = useRouter();
+  const params = useParams();
+  const sport = typeof params.sport === "string" ? params.sport : "";
+  const isPadel = sport === "padel";
+
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [ids, setIds] = useState({ a1: "", a2: "", b1: "", b2: "" });
+  const [sets, setSets] = useState<Array<{ A: string; B: string }>>(
+    isPadel ? [{ A: "", B: "" }] : []
+  );
+  const [playedAt, setPlayedAt] = useState("");
+  const [location, setLocation] = useState("");
+
+  useEffect(() => {
+    async function loadPlayers() {
+      try {
+        const res = await fetch(`${base}/v0/players?limit=100&offset=0`);
+        if (res.ok) {
+          const data = await res.json();
+          setPlayers(data.players);
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    loadPlayers();
+  }, []);
+
+  function onIdChange(key: keyof typeof ids, value: string) {
+    setIds((n) => ({ ...n, [key]: value }));
+  }
+
+  function onSetChange(idx: number, field: "A" | "B", value: string) {
+    setSets((prev) => {
+      const copy = prev.slice();
+      copy[idx] = { ...copy[idx], [field]: value };
+      return copy;
+    });
+  }
+
+  function addSet() {
+    setSets((prev) => [...prev, { A: "", B: "" }]);
+  }
+
+  async function submit() {
+    const parsedSets = isPadel
+      ? sets
+          .map((s) => [parseInt(s.A, 10), parseInt(s.B, 10)] as [number, number])
+          .filter(([a, b]) => Number.isFinite(a) && Number.isFinite(b))
+      : [];
+
+    if (isPadel && parsedSets.length === 0) {
+      alert("Please enter at least one completed set score.");
+      return;
+    }
+
+    const requiredIds = isPadel
+      ? [ids.a1, ids.a2, ids.b1, ids.b2]
+      : [ids.a1, ids.b1];
+    if (!requiredIds.every(Boolean)) {
+      alert(
+        isPadel
+          ? "Please select all four players."
+          : "Please select at least one player per side."
+      );
+      return;
+    }
+
+    const idValues = [ids.a1, ids.a2, ids.b1, ids.b2].filter(Boolean);
+    if (new Set(idValues).size !== idValues.length) {
+      alert("Please select unique players.");
+      return;
+    }
+
+    const body: any = {
+      sport,
+      participants: [
+        { side: "A", playerIds: [ids.a1, ids.a2].filter(Boolean) },
+        { side: "B", playerIds: [ids.b1, ids.b2].filter(Boolean) },
+      ],
+      // Avoid sending timezone-aware timestamps; the API expects a naive
+      // datetime string.  Using Date#toISOString() would include a "Z" suffix
+      // (UTC) which caused the backend to reject the request.  Instead, send
+      // an ISO date without timezone information if a value was provided.
+      playedAt: playedAt ? `${playedAt}T00:00:00` : undefined,
+      location: location || undefined,
+    };
+    if (isPadel) {
+      body.bestOf = 3;
+    }
+
+    const createRes = await fetch(`${base}/v0/matches`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!createRes.ok) {
+      alert("Failed to create match.");
+      return;
+    }
+    const { id } = (await createRes.json()) as { id: string };
+
+    if (isPadel && parsedSets.length > 0) {
+      const setsRes = await fetch(`${base}/v0/matches/${id}/sets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sets: parsedSets }),
+      });
+      if (!setsRes.ok) {
+        alert("Failed to submit set scores.");
+        return;
+      }
+    }
+
+    router.push(`/matches/${id}`);
+  }
+
+  function isUsedElsewhere(id: string, key: keyof typeof ids) {
+    return Object.entries(ids).some(([k, v]) => k !== key && v === id);
+  }
+
+  return (
+    <main className="container">
+      <h1 className="heading">Record {sport} Match</h1>
+
+      <section className="section">
+        <h2 className="heading">Players</h2>
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
+          <div>
+            <select
+              className="input"
+              value={ids.a1}
+              onChange={(e) => onIdChange("a1", e.target.value)}
+            >
+              <option value="">Player A1</option>
+              {players.map((p) => (
+                <option
+                  key={p.id}
+                  value={p.id}
+                  disabled={isUsedElsewhere(p.id, "a1")}
+                >
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <select
+              className="input"
+              value={ids.a2}
+              onChange={(e) => onIdChange("a2", e.target.value)}
+            >
+              <option value="">Player A2</option>
+              {players.map((p) => (
+                <option
+                  key={p.id}
+                  value={p.id}
+                  disabled={isUsedElsewhere(p.id, "a2")}
+                >
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <select
+              className="input"
+              value={ids.b1}
+              onChange={(e) => onIdChange("b1", e.target.value)}
+            >
+              <option value="">Player B1</option>
+              {players.map((p) => (
+                <option
+                  key={p.id}
+                  value={p.id}
+                  disabled={isUsedElsewhere(p.id, "b1")}
+                >
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <select
+              className="input"
+              value={ids.b2}
+              onChange={(e) => onIdChange("b2", e.target.value)}
+            >
+              <option value="">Player B2</option>
+              {players.map((p) => (
+                <option
+                  key={p.id}
+                  value={p.id}
+                  disabled={isUsedElsewhere(p.id, "b2")}
+                >
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {isPadel && (
+        <section className="section">
+          <h2 className="heading">Sets</h2>
+          <div style={{ display: "grid", gap: 8 }}>
+            {sets.map((s, idx) => (
+              <div key={idx} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  className="input"
+                  value={s.A}
+                  onChange={(e) => onSetChange(idx, "A", e.target.value)}
+                  placeholder="A"
+                />
+                <span>–</span>
+                <input
+                  className="input"
+                  value={s.B}
+                  onChange={(e) => onSetChange(idx, "B", e.target.value)}
+                  placeholder="B"
+                />
+              </div>
+            ))}
+          </div>
+          <button className="button mt-8" onClick={addSet} type="button">
+            Add Set
+          </button>
+        </section>
+      )}
+
+      <section className="section">
+        <h2 className="heading">Details</h2>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            className="input"
+            type="date"
+            value={playedAt}
+            onChange={(e) => setPlayedAt(e.target.value)}
+          />
+          <input
+            className="input"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Location"
+          />
+        </div>
+      </section>
+
+      <button className="button" onClick={submit} type="button">
+        Save
+      </button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- show sport options before recording a match
- handle sport-specific match recording with padel sets support

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30523b8b48323b0f7b0d6d09fee1b