### PR TITLE
Use tennis ball icon and simplify sport labels

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -44,7 +44,7 @@ export default async function HomePage() {
                   ) : (
                     s.name
                   )}
-                  <span className="text-gray-500">({s.id})</span>
+                  <span className="text-gray-500">{s.id}</span>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- replace padel icon with tennis ball as fallback
- remove parentheses around sport identifiers

## Testing
- `npm test -- --run` *(fails: Failed to resolve import "@testing-library/react")*
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68b304dd04a48323bf0abf128be879ef