### PR TITLE
fix(api): ignore redis errors when broadcasting

### DIFF
--- a/backend/tests/test_broadcast.py
+++ b/backend/tests/test_broadcast.py
@@ -1,0 +1,20 @@
+import asyncio
+import os
+import sys
+
+import redis.asyncio as redis
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routers import streams
+
+
+def test_broadcast_connection_error(monkeypatch):
+    async def fake_publish(channel, message):
+        raise redis.ConnectionError("unavailable")
+    monkeypatch.setattr(streams.redis_client, "publish", fake_publish)
+
+    async def call():
+        await streams.broadcast("m1", {"foo": "bar"})
+
+    asyncio.run(call())


### PR DESCRIPTION
## Summary
- avoid failing match operations when Redis is unavailable by swallowing connection errors during broadcast
- add test covering broadcast error handling

## Testing
- `pytest -q`
- `npm test` (fails: TypeError: Cannot read properties of undefined (reading 'map'))

------
https://chatgpt.com/codex/tasks/task_e_68b305c7237c8323b2f575b857029333