### PR TITLE
feat: add RFC7807 error handling

### DIFF
--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ProblemDetail(BaseModel):
+    """RFC 7807 compliant error response."""
+
+    type: str = "about:blank"
+    title: str
+    detail: Optional[str] = None
+    status: int
+    instance: Optional[str] = None
+
+
+class DomainException(Exception):
+    """Base class for domain-specific exceptions."""
+
+    def __init__(self, status_code: int, title: str, detail: str | None = None, type_: str = "about:blank") -> None:
+        self.status_code = status_code
+        self.title = title
+        self.detail = detail
+        self.type = type_
+
+
+class PlayerAlreadyExists(DomainException):
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            status_code=400,
+            title="Player exists",
+            detail=f"player name '{name}' already exists",
+        )
+
+
+class PlayerNotFound(DomainException):
+    def __init__(self, player_id: str) -> None:
+        super().__init__(
+            status_code=404,
+            title="Player not found",
+            detail=f"player '{player_id}' not found",
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
 # backend/app/main.py
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from .routers import sports, rulesets, players, matches, leaderboards, streams
+from .exceptions import DomainException, ProblemDetail
 import os
 
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
@@ -21,6 +23,42 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(DomainException)
+async def domain_exception_handler(request: Request, exc: DomainException) -> JSONResponse:
+    problem = ProblemDetail(
+        type=exc.type,
+        title=exc.title,
+        detail=exc.detail,
+        status=exc.status_code,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    problem = ProblemDetail(title=detail, detail=detail, status=exc.status_code)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    problem = ProblemDetail(title="Internal Server Error", status=500, detail=str(exc))
+    return JSONResponse(
+        status_code=500,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
 
 @app.get("/api/healthz")
 def healthz():

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,21 +1,26 @@
 import uuid
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
 from ..models import Player
 from ..schemas import PlayerCreate, PlayerOut, PlayerListOut
+from ..exceptions import ProblemDetail, PlayerAlreadyExists, PlayerNotFound
 
 # Resource-only prefix; versioning added in main.py
-router = APIRouter(prefix="/players", tags=["players"])
+router = APIRouter(
+    prefix="/players",
+    tags=["players"],
+    responses={400: {"model": ProblemDetail}, 404: {"model": ProblemDetail}},
+)
 
 # POST /api/v0/players
 @router.post("", response_model=PlayerOut)
 async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_session)):
     exists = (await session.execute(select(Player).where(Player.name == body.name))).scalar_one_or_none()
     if exists:
-        raise HTTPException(400, "player name already exists")
+        raise PlayerAlreadyExists(body.name)
     pid = uuid.uuid4().hex
     p = Player(id=pid, name=body.name, club_id=body.club_id)
     session.add(p)
@@ -46,5 +51,5 @@ async def list_players(
 async def get_player(player_id: str, session: AsyncSession = Depends(get_session)):
     p = await session.get(Player, player_id)
     if not p:
-        raise HTTPException(404, "player not found")
+        raise PlayerNotFound(player_id)
     return PlayerOut(id=p.id, name=p.name, club_id=p.club_id)


### PR DESCRIPTION
## Summary
- add `ProblemDetail` model and domain exceptions
- convert errors to RFC7807 responses globally
- raise domain-specific player errors and document error responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b309f0d92483239ac0a636a8a265db