### PR TITLE
Add pagination constraints for players endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 # backend/app/main.py
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
 from .routers import sports, rulesets, players, matches, leaderboards, streams
 import os
 
@@ -13,6 +15,11 @@ app = FastAPI(
     redoc_url="/api/redoc",
     openapi_url="/api/openapi.json",
 )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(status_code=400, content={"detail": exc.errors()})
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,5 +1,5 @@
 import uuid
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,8 +26,8 @@ async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_
 @router.get("", response_model=PlayerListOut)
 async def list_players(
     q: str = "",
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = select(Player)


### PR DESCRIPTION
## Summary
- validate `limit` and `offset` query params in `/players` with FastAPI `Query`
- convert request validation errors into HTTP 400 responses
- test pagination validation for player listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b309f34f88832389b14134710c355b