### PR TITLE
feat: improve fetch error handling

### DIFF
--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-
-const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+import { apiFetch } from "../../lib/api";
 const sports = ["padel", "bowling"];
 
 interface Leader {
@@ -18,13 +17,11 @@ export default function LeaderboardPage() {
   async function load() {
     setLoading(true);
     try {
-      const res = await fetch(`${base}/v0/leaderboards?sport=${sport}`, { cache: "no-store" });
-      if (res.ok) {
-        const data = await res.json();
-        setLeaders((data.leaders || []) as Leader[]);
-      } else {
-        setLeaders([]);
-      }
+      const res = await apiFetch(`/v0/leaderboards?sport=${sport}`, {
+        cache: "no-store",
+      });
+      const data = await res.json();
+      setLeaders((data.leaders || []) as Leader[]);
     } catch (e) {
       console.error(e);
       setLeaders([]);

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { apiFetch } from '../../../lib/api';
 
 type Participant = {
   id: string;
@@ -27,9 +28,6 @@ type MatchDetail = {
   summary: unknown;
 };
 
-const BASE: string =
-  (process.env.NEXT_PUBLIC_API_BASE_URL as string | undefined) ?? '/api';
-
 // type guard for numbers
 const isNumber = (x: unknown): x is number => typeof x === 'number';
 
@@ -55,10 +53,7 @@ export default function MatchDetailPage({
     setLoading(true);
     setError(null);
     try {
-      const r = await fetch(`${BASE}/v0/matches/${mid}`, { cache: 'no-store' });
-      if (!r.ok) {
-        throw new Error(`HTTP ${r.status}`);
-      }
+      const r = await apiFetch(`/v0/matches/${mid}`, { cache: 'no-store' });
       const j = (await r.json()) as MatchDetail;
       setData(j);
     } catch (e) {

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -11,7 +11,6 @@ type MatchRow = {
 
 async function getMatches(): Promise<MatchRow[]> {
   const r = await apiFetch("/v0/matches", { cache: "no-store" });
-  if (!r.ok) throw new Error(`Failed to load matches: ${r.status}`);
   return (await r.json()) as MatchRow[];
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,9 +13,7 @@ export default async function HomePage() {
   let sports: Sport[] = [];
   try {
     const r = await apiFetch('/v0/sports', { cache: 'no-store' });
-    if (r.ok) {
-      sports = (await r.json()) as Sport[];
-    }
+    sports = (await r.json()) as Sport[];
   } catch {
     // ignore; render with empty list
   }

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-
-const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+import { apiFetch } from "../../../lib/api";
 
 interface Player {
   id: string;
@@ -9,13 +8,22 @@ interface Player {
 }
 
 export default async function PlayerPage({ params }: { params: { id: string } }) {
-  const res = await fetch(`${base}/v0/players/${params.id}`, { cache: "no-store" });
-  const p: Player = await res.json();
-  return (
-    <main className="container">
-      <h1 className="heading">{p.name}</h1>
-      {p.club_id && <p>Club: {p.club_id}</p>}
-      <Link href="/players">Back to players</Link>
-    </main>
-  );
+  try {
+    const res = await apiFetch(`/v0/players/${params.id}`, { cache: "no-store" });
+    const p: Player = await res.json();
+    return (
+      <main className="container">
+        <h1 className="heading">{p.name}</h1>
+        {p.club_id && <p>Club: {p.club_id}</p>}
+        <Link href="/players">Back to players</Link>
+      </main>
+    );
+  } catch (e) {
+    return (
+      <main className="container">
+        <p>Failed to load player.</p>
+        <Link href="/players">Back to players</Link>
+      </main>
+    );
+  }
 }

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -7,9 +7,7 @@ export default async function RecordPage() {
   let sports: Sport[] = [];
   try {
     const res = await apiFetch("/v0/sports", { cache: "no-store" });
-    if (res.ok) {
-      sports = (await res.json()) as Sport[];
-    }
+    sports = (await res.json()) as Sport[];
   } catch {
     // ignore errors
   }


### PR DESCRIPTION
## Summary
- add ApiError wrapper around fetch with status/body details
- update pages to use apiFetch and surface errors

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30a19e2288323acbe0022f3128409