### PR TITLE
Validate player names before adding

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PlayersPage from "./page";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("PlayersPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("disables add button for blank names", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
+    // @ts-expect-error override global fetch for test
+    global.fetch = fetchMock;
+
+    render(<PlayersPage />);
+
+    const button = screen.getByRole("button", { name: /add/i });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    // Only initial load should trigger fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
@@ -29,12 +29,17 @@ export default function PlayersPage() {
   }, []);
 
   async function create() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name cannot be empty");
+      return;
+    }
     setError(null);
     try {
       const res = await fetch(`${base}/v0/players`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name: trimmed }),
       });
       if (!res.ok) {
         const data = (await res.json().catch(() => null)) as
@@ -72,7 +77,11 @@ export default function PlayersPage() {
         onChange={(e) => setName(e.target.value)}
         placeholder="name"
       />
-      <button className="button" onClick={create}>
+      <button
+        className="button"
+        onClick={create}
+        disabled={name.trim() === ""}
+      >
         Add
       </button>
       {error && <p className="text-red-500 mt-2">{error}</p>}


### PR DESCRIPTION
## Summary
- prevent creating players with empty names and display inline error
- disable Add button when input is blank
- add unit test to ensure blank submissions remain blocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30a131fcc83239a9941edf966bee4