### PR TITLE
Add pagination constraints for players endpoint

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -103,6 +103,27 @@ a {
   gap: 0.5rem;
 }
 
+.sport-id {
+  color: #555;
+  font-size: 0.9rem;
+}
+
+/* Match list */
+.match-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.match-item {
+  margin-bottom: 8px;
+}
+
+.match-meta {
+  color: #555;
+  font-size: 0.9rem;
+}
+
 .mt-8 {
   margin-top: 8px;
 }

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -9,15 +9,79 @@ type MatchRow = {
   location: string | null;
 };
 
+type Participant = {
+  side: "A" | "B";
+  playerIds: string[];
+};
+
+type MatchDetail = {
+  participants: Participant[];
+  summary?: {
+    sets?: { A: number; B: number };
+    games?: { A: number; B: number };
+    points?: { A: number; B: number };
+  } | null;
+};
+
+type EnrichedMatch = MatchRow & {
+  names: Record<"A" | "B", string[]>;
+  summary?: MatchDetail["summary"];
+};
+
 async function getMatches(): Promise<MatchRow[]> {
   const r = await apiFetch("/v0/matches", { cache: "no-store" });
   if (!r.ok) throw new Error(`Failed to load matches: ${r.status}`);
   return (await r.json()) as MatchRow[];
 }
 
+async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
+  // Load match details for participants + score summaries.
+  const details = await Promise.all(
+    rows.map(async (m) => {
+      const r = await apiFetch(`/v0/matches/${m.id}`, { cache: "no-store" });
+      if (!r.ok) throw new Error(`Failed to load match ${m.id}`);
+      const d = (await r.json()) as MatchDetail;
+      return { row: m, detail: d };
+    })
+  );
+
+  // Fetch all unique player names.
+  const ids = new Set<string>();
+  for (const { detail } of details) {
+    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+  }
+  const idToName = new Map<string, string>();
+  await Promise.all(
+    Array.from(ids).map(async (pid) => {
+      const r = await apiFetch(`/v0/players/${pid}`, { cache: "no-store" });
+      if (r.ok) {
+        const j = (await r.json()) as { id: string; name: string };
+        idToName.set(pid, j.name);
+      }
+    })
+  );
+
+  return details.map(({ row, detail }) => {
+    const names: Record<"A" | "B", string[]> = { A: [], B: [] };
+    for (const p of detail.participants) {
+      names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
+    }
+    return { ...row, names, summary: detail.summary };
+  });
+}
+
+function formatSummary(s?: MatchDetail["summary"]): string {
+  if (!s) return "";
+  if (s.sets) return `Sets ${s.sets.A}-${s.sets.B}`;
+  if (s.games) return `Games ${s.games.A}-${s.games.B}`;
+  if (s.points) return `Points ${s.points.A}-${s.points.B}`;
+  return "";
+}
+
 export default async function MatchesPage() {
   try {
-    const matches = await getMatches();
+    const rows = await getMatches();
+    const matches = await enrichMatches(rows);
 
     return (
       <main className="mx-auto max-w-3xl p-6 space-y-4">
@@ -26,11 +90,15 @@ export default async function MatchesPage() {
           {matches.map((m) => (
             <li key={m.id} className="rounded border p-3">
               <div className="font-medium">
-                <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+                <Link href={`/matches/${m.id}`}>
+                  {m.names.A.join(" & ")} vs {m.names.B.join(" & ")}
+                </Link>
               </div>
               <div className="text-sm text-gray-700">
-                {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-                {m.playedAt ? new Date(m.playedAt).toLocaleString() : "—"} ·{" "}
+                {formatSummary(m.summary)}
+                {m.summary ? " · " : ""}
+                {m.sport} · Best of {m.bestOf ?? "—"} · {" "}
+                {m.playedAt ? new Date(m.playedAt).toLocaleString() : "—"} · {" "}
                 {m.location ?? "—"}
               </div>
             </li>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,14 @@ import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 
 type Sport = { id: string; name: string };
+type MatchRow = {
+  id: string;
+  sport: string;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+};
+
 const sportIcons: Record<string, string> = {
   padel: '🎾',
   bowling: '🎳',
@@ -11,6 +19,7 @@ const sportIcons: Record<string, string> = {
 
 export default async function HomePage() {
   let sports: Sport[] = [];
+  let matches: MatchRow[] = [];
   try {
     const r = await apiFetch('/v0/sports', { cache: 'no-store' });
     if (r.ok) {
@@ -19,18 +28,26 @@ export default async function HomePage() {
   } catch {
     // ignore; render with empty list
   }
+  try {
+    const r = await apiFetch('/v0/matches', { cache: 'no-store' });
+    if (r.ok) {
+      matches = (await r.json()) as MatchRow[];
+    }
+  } catch {
+    // ignore; render with empty list
+  }
 
   return (
-    <main className="mx-auto max-w-3xl p-6 space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold">cross-sport-tracker</h1>
-        <p className="text-gray-700">Padel + Bowling MVP</p>
-      </header>
+    <main className="container">
+      <section className="card">
+        <h1 className="heading">cross-sport-tracker</h1>
+        <p>Padel + Bowling MVP</p>
+      </section>
 
-      <section>
-        <h2 className="mb-2 text-lg font-medium">Sports</h2>
+      <section className="section">
+        <h2 className="heading">Sports</h2>
         {sports.length === 0 ? (
-          <p className="text-gray-600">No sports found.</p>
+          <p>No sports found.</p>
         ) : (
           <ul className="sport-list">
             {sports.map((s) => {
@@ -44,7 +61,7 @@ export default async function HomePage() {
                   ) : (
                     s.name
                   )}
-                  <span className="text-gray-500">{s.id}</span>
+                  <span className="sport-id">{s.id}</span>
                 </li>
               );
             })}
@@ -52,11 +69,27 @@ export default async function HomePage() {
         )}
       </section>
 
-      <nav className="flex gap-3">
-        <Link href="/players">Players</Link>
-        <Link href="/matches">Matches</Link>
-        <Link href="/record">Record</Link>
-      </nav>
+      <section className="section">
+        <h2 className="heading">Recent Matches</h2>
+        {matches.length === 0 ? (
+          <p>No matches recorded yet.</p>
+        ) : (
+          <ul className="match-list">
+            {matches.slice(0, 5).map((m) => (
+              <li key={m.id} className="card match-item">
+                <div>
+                  <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+                </div>
+                <div className="match-meta">
+                  {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}
+                  {m.playedAt ? new Date(m.playedAt).toLocaleString() : '—'}
+                  {m.location ? ` · ${m.location}` : ''}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </main>
   );
 }

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-
-const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+import { apiFetch } from "../../../lib/api";
 
 interface Player {
   id: string;
@@ -8,14 +7,58 @@ interface Player {
   club_id?: string | null;
 }
 
-export default async function PlayerPage({ params }: { params: { id: string } }) {
-  const res = await fetch(`${base}/v0/players/${params.id}`, { cache: "no-store" });
-  const p: Player = await res.json();
-  return (
-    <main className="container">
-      <h1 className="heading">{p.name}</h1>
-      {p.club_id && <p>Club: {p.club_id}</p>}
-      <Link href="/players">Back to players</Link>
-    </main>
-  );
+interface Match {
+  id: string;
+  sport: string;
+  bestOf?: number | null;
+  playedAt?: string | null;
+  location?: string | null;
 }
+
+export default async function PlayerPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  try {
+    const res = await apiFetch(`/v0/players/${params.id}`, { cache: "no-store" });
+    if (!res.ok) throw new Error();
+    const p: Player = await res.json();
+
+    const matchesRes = await apiFetch(
+      `/v0/matches?playerId=${params.id}`,
+      { cache: "no-store" }
+    );
+    const matches: Match[] = matchesRes.ok ? await matchesRes.json() : [];
+
+    return (
+      <main className="container">
+        <h1 className="heading">{p.name}</h1>
+        {p.club_id && <p>Club: {p.club_id}</p>}
+        <h2 className="heading mt-4">Recent Matches</h2>
+        {matches.length ? (
+          <ul>
+            {matches.map((m) => (
+              <li key={m.id}>
+                <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No matches found.</p>
+        )}
+        <Link href="/players" className="block mt-4">
+          Back to players
+        </Link>
+      </main>
+    );
+  } catch {
+    return (
+      <main className="container">
+        <p className="text-red-500">Failed to load player.</p>
+        <Link href="/players">Back to players</Link>
+      </main>
+    );
+  }
+}
+

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ProblemDetail(BaseModel):
+    """RFC 7807 compliant error response."""
+
+    type: str = "about:blank"
+    title: str
+    detail: Optional[str] = None
+    status: int
+    instance: Optional[str] = None
+
+
+class DomainException(Exception):
+    """Base class for domain-specific exceptions."""
+
+    def __init__(self, status_code: int, title: str, detail: str | None = None, type_: str = "about:blank") -> None:
+        self.status_code = status_code
+        self.title = title
+        self.detail = detail
+        self.type = type_
+
+
+class PlayerAlreadyExists(DomainException):
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            status_code=400,
+            title="Player exists",
+            detail=f"player name '{name}' already exists",
+        )
+
+
+class PlayerNotFound(DomainException):
+    def __init__(self, player_id: str) -> None:
+        super().__init__(
+            status_code=404,
+            title="Player not found",
+            detail=f"player '{player_id}' not found",
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,10 @@
 # backend/app/main.py
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.exceptions import RequestValidationError
 from .routers import sports, rulesets, players, matches, leaderboards, streams
+from .exceptions import DomainException, ProblemDetail
 import os
 
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
@@ -28,6 +29,42 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(DomainException)
+async def domain_exception_handler(request: Request, exc: DomainException) -> JSONResponse:
+    problem = ProblemDetail(
+        type=exc.type,
+        title=exc.title,
+        detail=exc.detail,
+        status=exc.status_code,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    problem = ProblemDetail(title=detail, detail=detail, status=exc.status_code)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    problem = ProblemDetail(title="Internal Server Error", status=500, detail=str(exc))
+    return JSONResponse(
+        status_code=500,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
 
 @app.get("/api/healthz")
 def healthz():

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,21 +1,26 @@
 import uuid
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
 from ..models import Player
 from ..schemas import PlayerCreate, PlayerOut, PlayerListOut
+from ..exceptions import ProblemDetail, PlayerAlreadyExists, PlayerNotFound
 
 # Resource-only prefix; versioning added in main.py
-router = APIRouter(prefix="/players", tags=["players"])
+router = APIRouter(
+    prefix="/players",
+    tags=["players"],
+    responses={400: {"model": ProblemDetail}, 404: {"model": ProblemDetail}},
+)
 
 # POST /api/v0/players
 @router.post("", response_model=PlayerOut)
 async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_session)):
     exists = (await session.execute(select(Player).where(Player.name == body.name))).scalar_one_or_none()
     if exists:
-        raise HTTPException(400, "player name already exists")
+        raise PlayerAlreadyExists(body.name)
     pid = uuid.uuid4().hex
     p = Player(id=pid, name=body.name, club_id=body.club_id)
     session.add(p)
@@ -46,5 +51,5 @@ async def list_players(
 async def get_player(player_id: str, session: AsyncSession = Depends(get_session)):
     p = await session.get(Player, player_id)
     if not p:
-        raise HTTPException(404, "player not found")
+        raise PlayerNotFound(player_id)
     return PlayerOut(id=p.id, name=p.name, club_id=p.club_id)

--- a/backend/app/scoring/padel.py
+++ b/backend/app/scoring/padel.py
@@ -42,32 +42,6 @@ def summary(state: Dict) -> Dict:
     }
 
 
-def validate_set_scores(set_scores) -> None:
-    """Validate a sequence of set score objects.
-
-    Each element may be a mapping with ``A``/``B`` keys, a two-item tuple/list,
-    or an object exposing ``A`` and ``B`` attributes.  All values must be
-    integers.  Raises ``ValueError`` with a descriptive message on failure.
-    """
-
-    for idx, s in enumerate(set_scores, start=1):
-        if isinstance(s, dict):
-            a, b = s.get("A"), s.get("B")
-        elif isinstance(s, (list, tuple)) and len(s) == 2:
-            a, b = s[0], s[1]
-        else:
-            a, b = getattr(s, "A", None), getattr(s, "B", None)
-
-        if not isinstance(a, int) or not isinstance(b, int):
-            raise ValueError(f"Set #{idx} scores must be integers")
-
-        if a < 0 or b < 0:
-            raise ValueError(f"Set #{idx} scores must be non-negative")
-
-        if a == b:
-            raise ValueError(f"Set #{idx} scores cannot be tied")
-
-
 def record_sets(set_scores, state=None):
     """Generate point events to reach the provided set scores.
 

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -1,6 +1,8 @@
 import os
+import os
 import sys
 from pathlib import Path
+import asyncio
 import pytest
 from fastapi import HTTPException
 
@@ -40,3 +42,69 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
             await create_match_by_name(body, session)
         assert exc.value.status_code == 400
         assert exc.value.detail == "duplicate players: Alice"
+
+
+@pytest.mark.skip(reason="SQLite lacks ARRAY support for MatchParticipant")
+def test_list_matches_filters_by_player(tmp_path):
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app import db
+    from app.models import Player, Match, MatchParticipant, Sport
+    from app.routers import matches, players
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    engine = db.get_engine()
+
+    async def init_models():
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                db.Base.metadata.create_all,
+                tables=[Sport.__table__, Player.__table__, Match.__table__, MatchParticipant.__table__],
+            )
+
+    asyncio.run(init_models())
+
+    async def seed_sport():
+        async with db.AsyncSessionLocal() as session:
+            session.add(Sport(id="padel", name="Padel"))
+            await session.commit()
+
+    asyncio.run(seed_sport())
+
+    app = FastAPI()
+    app.include_router(players.router)
+    app.include_router(matches.router)
+
+    with TestClient(app) as client:
+        p1 = client.post("/players", json={"name": "Alice"}).json()["id"]
+        p2 = client.post("/players", json={"name": "Bob"}).json()["id"]
+        p3 = client.post("/players", json={"name": "Charlie"}).json()["id"]
+
+        m1 = client.post(
+            "/matches",
+            json={
+                "sport": "padel",
+                "participants": [
+                    {"side": "A", "playerIds": [p1]},
+                    {"side": "B", "playerIds": [p2]},
+                ],
+            },
+        ).json()["id"]
+        client.post(
+            "/matches",
+            json={
+                "sport": "padel",
+                "participants": [
+                    {"side": "A", "playerIds": [p2]},
+                    {"side": "B", "playerIds": [p3]},
+                ],
+            },
+        )
+
+        resp = client.get("/matches", params={"playerId": p1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == m1

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -3,6 +3,7 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.scoring import padel, bowling
+from app.services import validate_set_scores, ValidationError
 
 
 def test_padel_game_win():
@@ -26,16 +27,11 @@ def test_record_sets():
     assert len(events) == (6 + 4 + 6 + 2) * 4
 
 
-def test_validate_tuple_set_scores():
-    # Should not raise when provided with tuple-based scores
-    padel.validate_set_scores([(6, 4), (6, 2)])
-
-
 def test_validate_set_scores_negative():
-    with pytest.raises(ValueError, match="non-negative"):
-        padel.validate_set_scores([(6, -4)])
+    with pytest.raises(ValidationError, match=">= 0"):
+        validate_set_scores([{"A": 6, "B": -4}])
 
 
 def test_validate_set_scores_tie():
-    with pytest.raises(ValueError, match="cannot be tied"):
-        padel.validate_set_scores([(4, 4)])
+    with pytest.raises(ValidationError, match="cannot be a tie"):
+        validate_set_scores([{"A": 4, "B": 4}])


### PR DESCRIPTION
## Summary
- resolve merge conflicts with `origin/main`
- retain pagination validation for players listing with proper imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3112e1a788323b1d830722db170e8