### PR TITLE
Add pagination to leaderboards endpoint

### DIFF
--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -1,32 +1,38 @@
 from fastapi import APIRouter, Query, Depends
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
 from ..models import Rating, Player
+from ..schemas import LeaderboardEntryOut, LeaderboardOut
 
 # Resource-only prefix; no /api or /api/v0 here
 router = APIRouter(prefix="/leaderboards", tags=["leaderboards"])
 
 
 # GET /api/v0/leaderboards?sport=padel
-@router.get("")
+@router.get("", response_model=LeaderboardOut)
 async def leaderboard(
     sport: str = Query(..., description="Sport id, e.g. 'padel' or 'bowling'"),
+    limit: int = 50,
+    offset: int = 0,
     session: AsyncSession = Depends(get_session),
 ):
-    rows = (
-        await session.execute(
-            select(Rating, Player)
-            .join(Player, Player.id == Rating.player_id)
-            .where(Rating.sport_id == sport)
-            .order_by(Rating.value.desc())
+    stmt = (
+        select(Rating, Player)
+        .join(Player, Player.id == Rating.player_id)
+        .where(Rating.sport_id == sport)
+        .order_by(Rating.value.desc())
+    )
+    count_stmt = select(func.count()).select_from(Rating).where(Rating.sport_id == sport)
+    total = (await session.execute(count_stmt)).scalar()
+    rows = (await session.execute(stmt.limit(limit).offset(offset))).all()
+    leaders = [
+        LeaderboardEntryOut(
+            playerId=r.Rating.player_id, playerName=r.Player.name, rating=r.Rating.value
         )
-    ).all()
-    return {
-        "sport": sport,
-        "leaders": [
-            {"playerId": r.Rating.player_id, "playerName": r.Player.name, "rating": r.Rating.value}
-            for r in rows
-        ],
-    }
+        for r in rows
+    ]
+    return LeaderboardOut(
+        sport=sport, leaders=leaders, total=total, limit=limit, offset=offset
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -29,6 +29,20 @@ class PlayerListOut(BaseModel):
     limit: int
     offset: int
 
+
+class LeaderboardEntryOut(BaseModel):
+    playerId: str
+    playerName: str
+    rating: float
+
+
+class LeaderboardOut(BaseModel):
+    sport: str
+    leaders: List[LeaderboardEntryOut]
+    total: int
+    limit: int
+    offset: int
+
 class Participant(BaseModel):
     side: Literal["A", "B"]
     playerIds: List[str]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27,<1.0
 sqlalchemy[asyncio]>=2.0,<3.0
 asyncpg>=0.29,<1.0
+aiosqlite>=0.20,<1.0
 alembic>=1.12,<2.0
 pydantic>=2.4,<3.0
 pydantic-settings>=2.2,<3.0

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -1,0 +1,56 @@
+import os, sys, asyncio, pytest
+
+# Ensure backend app modules can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Set up an in-memory SQLite database for tests
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_leaderboards.db"
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app import db
+from app.routers import leaderboards
+from app.models import Player, Rating, Sport
+
+app = FastAPI()
+app.include_router(leaderboards.router)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    async def init_models():
+        if os.path.exists("./test_leaderboards.db"):
+            os.remove("./test_leaderboards.db")
+        db.engine = None
+        db.AsyncSessionLocal = None
+        engine = db.get_engine()
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                db.Base.metadata.create_all,
+                tables=[Sport.__table__, Player.__table__, Rating.__table__],
+            )
+        async with db.AsyncSessionLocal() as session:
+            sport = Sport(id="padel", name="Padel")
+            session.add(sport)
+            for i in range(5):
+                player = Player(id=str(i), name=f"P{i}")
+                rating = Rating(id=str(i), player_id=player.id, sport_id="padel", value=1000 + i)
+                session.add_all([player, rating])
+            await session.commit()
+    asyncio.run(init_models())
+    yield
+    if os.path.exists("./test_leaderboards.db"):
+        os.remove("./test_leaderboards.db")
+
+
+def test_leaderboard_pagination():
+    with TestClient(app) as client:
+        resp = client.get("/leaderboards", params={"sport": "padel", "limit": 2, "offset": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["limit"] == 2
+        assert data["offset"] == 1
+        assert data["total"] == 5
+        assert len(data["leaders"]) == 2
+        assert data["leaders"][0]["rating"] == 1003
+        assert data["leaders"][1]["rating"] == 1002


### PR DESCRIPTION
## Summary
- support pagination on `/leaderboards` via `limit` and `offset`
- return total count metadata using new response models
- add aiosqlite dependency and unit test for leaderboard pagination

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b309fb6bec832384a40d3d682d9519