### PR TITLE
Use ULIDs for entity identifiers

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -1,5 +1,5 @@
 # backend/app/routers/matches.py
-import uuid
+import ulid
 import json
 import importlib
 from collections import Counter
@@ -46,7 +46,7 @@ async def list_matches(session: AsyncSession = Depends(get_session)):
 # POST /api/v0/matches
 @router.post("", response_model=MatchIdOut)
 async def create_match(body: MatchCreate, session: AsyncSession = Depends(get_session)):
-    mid = uuid.uuid4().hex
+    mid = str(ulid.new())
     match = Match(
         id=mid,
         sport_id=body.sport,
@@ -60,7 +60,7 @@ async def create_match(body: MatchCreate, session: AsyncSession = Depends(get_se
 
     for part in body.participants:
         mp = MatchParticipant(
-            id=uuid.uuid4().hex,
+            id=str(ulid.new()),
             match_id=mid,
             side=part.side,
             player_ids=part.playerIds,
@@ -169,7 +169,7 @@ async def append_event(mid: str, ev: EventIn, session: AsyncSession = Depends(ge
         raise HTTPException(400, str(exc))
 
     e = ScoreEvent(
-        id=uuid.uuid4().hex,
+        id=str(ulid.new()),
         match_id=mid,
         type=ev.type,
         payload=payload,
@@ -217,7 +217,7 @@ async def record_sets_endpoint(mid: str, body: SetsIn, session: AsyncSession = D
 
     for ev in new_events:
         e = ScoreEvent(
-            id=uuid.uuid4().hex,
+            id=str(ulid.new()),
             match_id=mid,
             type=ev["type"],
             payload=ev,

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,4 +1,4 @@
-import uuid
+import ulid
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,7 +16,7 @@ async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_
     exists = (await session.execute(select(Player).where(Player.name == body.name))).scalar_one_or_none()
     if exists:
         raise HTTPException(400, "player name already exists")
-    pid = uuid.uuid4().hex
+    pid = str(ulid.new())
     p = Player(id=pid, name=body.name, club_id=body.club_id)
     session.add(p)
     await session.commit()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,5 @@ python-multipart>=0.0.9,<1.0
 redis>=4.0,<5.0
 fakeredis>=2.0,<3.0
 httpx>=0.23,<1.0
+ulid-py>=1.1,<2.0
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -66,7 +66,11 @@ async def main():
             x.id for x in (await s.execute(select(Player))).scalars().all()
         }
         players = [
-            Player(id="demo-player", name="Demo Player", club_id="demo-club"),
+            Player(
+                id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                name="Demo Player",
+                club_id="demo-club",
+            ),
         ]
         for p in players:
             if p.id not in existing_players:

--- a/backend/tests/test_broadcast.py
+++ b/backend/tests/test_broadcast.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import redis.asyncio as redis
+import ulid
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -14,7 +15,9 @@ def test_broadcast_connection_error(monkeypatch):
         raise redis.ConnectionError("unavailable")
     monkeypatch.setattr(streams.redis_client, "publish", fake_publish)
 
+    mid = str(ulid.new())
+
     async def call():
-        await streams.broadcast("m1", {"foo": "bar"})
+        await streams.broadcast(mid, {"foo": "bar"})
 
     asyncio.run(call())

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pytest
 from fastapi import HTTPException
+import ulid
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -27,7 +28,7 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
         await conn.run_sync(Player.__table__.create)
 
     async with db.AsyncSessionLocal() as session:
-        session.add(Player(id="p1", name="Alice"))
+        session.add(Player(id=str(ulid.new()), name="Alice"))
         await session.commit()
         body = MatchCreateByName(
             sport="padel",

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+import ulid
 
 from app.db import Base, get_session
 from app.models import Match, Sport, ScoreEvent
@@ -67,7 +68,7 @@ def seed_match(session_maker, mid: str) -> None:
 
 def test_record_sets_success(client_and_session):
     client, session_maker = client_and_session
-    mid = "m1"
+    mid = str(ulid.new())
     seed_match(session_maker, mid)
 
     resp = client.post(f"/matches/{mid}/sets", json={"sets": [[6, 4], [6, 2]]})
@@ -87,7 +88,7 @@ def test_record_sets_success(client_and_session):
 
 def test_record_sets_invalid(client_and_session):
     client, session_maker = client_and_session
-    mid = "m2"
+    mid = str(ulid.new())
     seed_match(session_maker, mid)
 
     resp = client.post(f"/matches/{mid}/sets", json={"sets": [[6, 6]]})

--- a/backend/tests/test_streams.py
+++ b/backend/tests/test_streams.py
@@ -1,6 +1,7 @@
 import fakeredis.aioredis
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import ulid
 
 from app.routers import streams
 
@@ -11,10 +12,11 @@ app.include_router(streams.router)
 
 def test_broadcast_reaches_multiple_clients() -> None:
     streams.redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    mid = str(ulid.new())
     with TestClient(app) as client1, TestClient(app) as client2:
-        with client1.websocket_connect("/matches/m1/stream") as ws1, \
-             client2.websocket_connect("/matches/m1/stream") as ws2:
-            client1.portal.call(streams.broadcast, "m1", {"msg": 1})
+        with client1.websocket_connect(f"/matches/{mid}/stream") as ws1, \
+             client2.websocket_connect(f"/matches/{mid}/stream") as ws2:
+            client1.portal.call(streams.broadcast, mid, {"msg": 1})
             assert ws1.receive_json() == {"msg": 1}
             assert ws2.receive_json() == {"msg": 1}
 


### PR DESCRIPTION
## Summary
- add ulid-py dependency
- generate ULIDs in player and match routers instead of UUID4
- update tests and seed script for ULID-formatted IDs

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b309fe66c4832389a3c872f11a4a70