### PR TITLE
fix: add missing aiosqlite dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27,<1.0
 sqlalchemy[asyncio]>=2.0,<3.0
 asyncpg>=0.29,<1.0
+aiosqlite>=0.21,<1.0
 alembic>=1.12,<2.0
 pydantic>=2.4,<3.0
 pydantic-settings>=2.2,<3.0


### PR DESCRIPTION
## Summary
- include aiosqlite in backend requirements for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b313b804fc8323acf8b216112915ff