### PR TITLE
Handle unreachable API with retry banner

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import Link from "next/link";
-
-const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+import { apiFetch } from "../../lib/api";
 
 interface Player {
   id: string;
@@ -16,12 +15,19 @@ export default function PlayersPage() {
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
-    const res = await fetch(`${base}/v0/players?limit=100&offset=0`, {
-      cache: "no-store",
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setPlayers(data.players);
+    setError(null);
+    try {
+      const res = await apiFetch("/v0/players?limit=100&offset=0", {
+        cache: "no-store",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setPlayers(data.players);
+      } else {
+        setError("Failed to load players.");
+      }
+    } catch (err) {
+      setError("Unable to reach the server.");
     }
   }
   useEffect(() => {
@@ -31,7 +37,7 @@ export default function PlayersPage() {
   async function create() {
     setError(null);
     try {
-      const res = await fetch(`${base}/v0/players`, {
+      const res = await apiFetch("/v0/players", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name }),
@@ -75,7 +81,14 @@ export default function PlayersPage() {
       <button className="button" onClick={create}>
         Add
       </button>
-      {error && <p className="text-red-500 mt-2">{error}</p>}
+      {error && (
+        <div className="text-red-500 mt-2">
+          {error}
+          <button className="ml-2 underline" onClick={load}>
+            Retry
+          </button>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -23,7 +23,6 @@ describe("RecordSportPage", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) });
-    // @ts-expect-error override global fetch for test
     global.fetch = fetchMock;
 
     const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -86,7 +86,7 @@ export default function RecordSportPage() {
       return;
     }
 
-    const body: any = {
+    const body: Record<string, unknown> = {
       sport,
       participants: [
         { side: "A", playerIds: [ids.a1, ids.a2].filter(Boolean) },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -14,5 +14,10 @@ export function apiUrl(path: string): string {
 }
 
 export async function apiFetch(path: string, init?: RequestInit) {
-  return fetch(apiUrl(path), init);
+  try {
+    return await fetch(apiUrl(path), init);
+  } catch (err) {
+    console.error('API request failed', err);
+    throw err;
+  }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,7 +22,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "types": ["vitest/globals"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- log network failures in apiFetch wrapper
- surface unreachable API errors with retry option on players page
- add vitest type definitions and tighten record page typings

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30a0cf3188323b9284e62f0770965