### PR TITLE
Validate CORS origin configuration when using credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ POSTGRES_DB=crosssport
 POSTGRES_PASSWORD=
 DATABASE_URL=
 SECRET_KEY=
+# When cookies/credentials are enabled, list each trusted origin explicitly
+ALLOW_CREDENTIALS=true
 ALLOWED_ORIGINS=https://www.YourDomain.com
 NEXT_PUBLIC_API_BASE_URL=/api
 NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -202,11 +202,16 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/crosssport
 
 # Backend
 SECRET_KEY=change-me
+# When cookies/credentials are enabled, list each trusted origin explicitly
+ALLOW_CREDENTIALS=true
 ALLOWED_ORIGINS=https://yourdomain.com
 
 # Web
 NEXT_PUBLIC_API_BASE_URL=https://yourdomain.com/api
 NODE_ENV=production
+
+# If ALLOW_CREDENTIALS=true, the backend will error on startup if
+# ALLOWED_ORIGINS contains '*' to prevent insecure CORS configuration.
 
 
 docker-compose.prod.yml (place in repo root):
@@ -241,6 +246,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - SECRET_KEY=${SECRET_KEY}
+      - ALLOW_CREDENTIALS=${ALLOW_CREDENTIALS}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
     command: >
       sh -c "alembic upgrade head &&

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,21 @@ from fastapi.middleware.cors import CORSMiddleware
 from .routers import sports, rulesets, players, matches, leaderboards, streams
 import os
 
-ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+
+ALLOWED_ORIGINS = [
+    o.strip()
+    for o in os.getenv("ALLOWED_ORIGINS", "*").split(",")
+    if o.strip()
+]
+ALLOW_CREDENTIALS = os.getenv("ALLOW_CREDENTIALS", "true").lower() == "true"
+
+# CORS safety check
+if ALLOW_CREDENTIALS and (not ALLOWED_ORIGINS or "*" in ALLOWED_ORIGINS):
+    raise ValueError(
+        "ALLOWED_ORIGINS cannot be '*' when credentials are allowed. "
+        "Set ALLOWED_ORIGINS to a comma-separated list of origins or set "
+        "ALLOW_CREDENTIALS=false."
+    )
 
 app = FastAPI(
     title="Cross Sport Tracker API",
@@ -16,8 +30,8 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[o.strip() for o in ALLOWED_ORIGINS if o.strip()],
-    allow_credentials=True,
+    allow_origins=ALLOWED_ORIGINS or ["*"],
+    allow_credentials=ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,13 @@
+import os, sys, importlib, pytest
+
+# Ensure the app package is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_rejects_wildcard_with_credentials(monkeypatch):
+    monkeypatch.setenv("ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("ALLOW_CREDENTIALS", "true")
+    sys.modules.pop("app.main", None)
+    with pytest.raises(ValueError):
+        importlib.import_module("app.main")
+


### PR DESCRIPTION
## Summary
- enforce explicit CORS origin list when credentials are allowed
- expose `ALLOW_CREDENTIALS` env var and validate startup configuration
- document safe CORS settings and add regression test

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68b30a05cdcc8323ae17bdf99b7e3cd0