### PR TITLE
Use native dict payloads for score events

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -1,6 +1,5 @@
 # backend/app/routers/matches.py
 import uuid
-import json
 import importlib
 from collections import Counter
 from fastapi import APIRouter, Depends, HTTPException
@@ -162,7 +161,7 @@ async def append_event(mid: str, ev: EventIn, session: AsyncSession = Depends(ge
     for old in existing:
         state = engine.apply(old.payload, state)
 
-    payload = json.loads(ev.model_dump_json())
+    payload = ev.model_dump()
     try:
         state = engine.apply(payload, state)
     except ValueError as exc:

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 # Ensure the app package is importable and the DB URL is set for module import
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
@@ -11,11 +12,12 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
 
-from app.db import Base, get_session
-from app.models import Match, Sport, ScoreEvent
-from app.routers import matches
-from app.scoring import padel
+from backend.app.db import Base, get_session
+from backend.app.models import Match, Sport, ScoreEvent
+from backend.app.routers import matches
+from backend.app.scoring import padel
 
 
 @pytest.fixture()
@@ -46,6 +48,7 @@ def client_and_session():
         return None
 
     matches.broadcast = dummy_broadcast
+    matches.importlib.import_module = lambda *args, **kwargs: padel
 
     app = FastAPI()
     app.include_router(matches.router)
@@ -92,4 +95,28 @@ def test_record_sets_invalid(client_and_session):
 
     resp = client.post(f"/matches/{mid}/sets", json={"sets": [[6, 6]]})
     assert resp.status_code == 422
+
+
+def test_append_event_point(client_and_session):
+    client, session_maker = client_and_session
+    mid = "m3"
+    seed_match(session_maker, mid)
+
+    resp = client.post(f"/matches/{mid}/events", json={"type": "POINT", "by": "A"})
+    assert resp.status_code == 200
+
+    async def fetch():
+        async with session_maker() as session:
+            events = (
+                await session.execute(
+                    select(ScoreEvent).where(ScoreEvent.match_id == mid)
+                )
+            ).scalars().all()
+            match = await session.get(Match, mid)
+            return events, match.details
+
+    events, summary = asyncio.run(fetch())
+    assert len(events) == 1
+    assert events[0].payload == {"type": "POINT", "by": "A", "pins": None}
+    assert summary["points"] == {"A": 1, "B": 0}
 


### PR DESCRIPTION
## Summary
- Replace JSON round-trip with `ev.model_dump()` for event payloads
- Patch test harness to use padel engine directly and add coverage for event appending

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30a017b10832398e17e66bc18259e