### PR TITLE
Show recent matches on player page

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 import { apiFetch } from "../../../lib/api";
 
@@ -7,40 +8,106 @@ interface Player {
   club_id?: string | null;
 }
 
-interface Match {
+type MatchRow = {
   id: string;
   sport: string;
-  bestOf?: number | null;
-  playedAt?: string | null;
-  location?: string | null;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+};
+
+type Participant = { side: "A" | "B"; playerIds: string[] };
+type MatchDetail = {
+  participants: Participant[];
+  summary?: { sets?: { A: number; B: number }; games?: { A: number; B: number }; points?: { A: number; B: number } } | null;
+};
+
+type EnrichedMatch = MatchRow & {
+  names: Record<"A" | "B", string[]>;
+  summary?: MatchDetail["summary"];
+};
+
+async function getPlayer(id: string): Promise<Player> {
+  const res = await apiFetch(`/v0/players/${id}`, { cache: "no-store" });
+  if (!res.ok) throw new Error("player");
+  return (await res.json()) as Player;
 }
 
-export default async function PlayerPage({
-  params,
-}: {
-  params: { id: string };
-}) {
-  try {
-    const res = await apiFetch(`/v0/players/${params.id}`, { cache: "no-store" });
-    if (!res.ok) throw new Error();
-    const p: Player = await res.json();
+async function getMatches(playerId: string): Promise<EnrichedMatch[]> {
+  const r = await apiFetch(`/v0/matches?playerId=${playerId}`, { cache: "no-store" });
+  if (!r.ok) return [];
+  const rows = (await r.json()) as MatchRow[];
 
-    const matchesRes = await apiFetch(
-      `/v0/matches?playerId=${params.id}`,
-      { cache: "no-store" }
-    );
-    const matches: Match[] = matchesRes.ok ? await matchesRes.json() : [];
+  // Load details for participants and summaries
+  const details = await Promise.all(
+    rows.map(async (m) => {
+      const resp = await apiFetch(`/v0/matches/${m.id}`, { cache: "no-store" });
+      if (!resp.ok) throw new Error(`match ${m.id}`);
+      return { row: m, detail: (await resp.json()) as MatchDetail };
+    })
+  );
+
+  // Fetch player names for all participants
+  const ids = new Set<string>();
+  for (const { detail } of details) {
+    for (const p of detail.detail.participants) p.playerIds.forEach((id) => ids.add(id));
+  }
+  const idToName = new Map<string, string>();
+  await Promise.all(
+    Array.from(ids).map(async (pid) => {
+      const resp = await apiFetch(`/v0/players/${pid}`, { cache: "no-store" });
+      if (resp.ok) {
+        const j = (await resp.json()) as { id: string; name: string };
+        idToName.set(pid, j.name);
+      }
+    })
+  );
+
+  return details.map(({ row, detail }) => {
+    const names: Record<"A" | "B", string[]> = { A: [], B: [] };
+    for (const p of detail.participants) {
+      names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
+    }
+    return { ...row, names, summary: detail.summary };
+  });
+}
+
+function formatSummary(s?: MatchDetail["summary"]): string {
+  if (!s) return "";
+  if (s.sets) return `Sets ${s.sets.A}-${s.sets.B}`;
+  if (s.games) return `Games ${s.games.A}-${s.games.B}`;
+  if (s.points) return `Points ${s.points.A}-${s.points.B}`;
+  return "";
+}
+
+export default async function PlayerPage({ params }: { params: { id: string } }) {
+  try {
+    const [player, matches] = await Promise.all([
+      getPlayer(params.id),
+      getMatches(params.id),
+    ]);
 
     return (
       <main className="container">
-        <h1 className="heading">{p.name}</h1>
-        {p.club_id && <p>Club: {p.club_id}</p>}
+        <h1 className="heading">{player.name}</h1>
+        {player.club_id && <p>Club: {player.club_id}</p>}
         <h2 className="heading mt-4">Recent Matches</h2>
         {matches.length ? (
           <ul>
             {matches.map((m) => (
-              <li key={m.id}>
-                <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+              <li key={m.id} className="mb-2">
+                <div>
+                  <Link href={`/matches/${m.id}`}>
+                    {m.names.A.join(" & ")} vs {m.names.B.join(" & ")}
+                  </Link>
+                </div>
+                <div className="text-sm text-gray-700">
+                  {formatSummary(m.summary)}
+                  {m.summary ? " · " : ""}
+                  {m.sport} · Best of {m.bestOf ?? "—"} · {m.playedAt ? new Date(m.playedAt).toLocaleString() : "—"}
+                  {" · "}
+                  {m.location ?? "—"}
+                </div>
               </li>
             ))}
           </ul>
@@ -61,4 +128,5 @@ export default async function PlayerPage({
     );
   }
 }
+
 


### PR DESCRIPTION
## Summary
- expand player page to fetch and display recent matches with opponent names, summaries, and metadata

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31d61a3e48323b47b8f0b96b39ea2