### PR TITLE
Add MMR rating system and rankings page

### DIFF
--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+const sports = ["padel", "bowling"];
+
+interface Leader {
+  playerId: string;
+  playerName: string;
+  rating: number;
+}
+
+export default function RankingsPage() {
+  const [sport, setSport] = useState<string>("padel");
+  const [leaders, setLeaders] = useState<Leader[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await fetch(`${base}/v0/leaderboards?sport=${sport}`, { cache: "no-store" });
+      if (res.ok) {
+        const data = await res.json();
+        setLeaders((data.leaders || []) as Leader[]);
+      } else {
+        setLeaders([]);
+      }
+    } catch (e) {
+      console.error(e);
+      setLeaders([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sport]);
+
+  return (
+    <main className="container">
+      <h1 className="heading">Rankings</h1>
+      <label>
+        Sport:
+        <select
+          className="input"
+          value={sport}
+          onChange={(e) => setSport(e.target.value)}
+          style={{ marginLeft: "0.5rem" }}
+        >
+          {sports.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </label>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table
+          style={{
+            marginTop: "1rem",
+            borderCollapse: "collapse",
+            width: "100%",
+          }}
+        >
+          <thead>
+            <tr>
+              <th
+                style={{
+                  border: "1px solid #ccc",
+                  padding: "0.5rem",
+                  textAlign: "left",
+                }}
+              >
+                #
+              </th>
+              <th
+                style={{
+                  border: "1px solid #ccc",
+                  padding: "0.5rem",
+                  textAlign: "left",
+                }}
+              >
+                Player
+              </th>
+              <th
+                style={{
+                  border: "1px solid #ccc",
+                  padding: "0.5rem",
+                  textAlign: "left",
+                }}
+              >
+                Rating
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {leaders.map((l, i) => (
+              <tr key={l.playerId}>
+                <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{i + 1}</td>
+                <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{l.playerName}</td>
+                <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{l.rating}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,6 +1,7 @@
 """Internal application services (pure helpers, no I/O)."""
 
 from .validation import ValidationError, validate_set_scores
+from .rating import update_ratings
 
-__all__ = ["validate_set_scores", "ValidationError"]
+__all__ = ["validate_set_scores", "ValidationError", "update_ratings"]
 

--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -1,0 +1,50 @@
+import uuid
+from typing import Sequence
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import Rating
+
+K_FACTOR = 32.0
+
+async def update_ratings(
+    session: AsyncSession,
+    sport_id: str,
+    winners: Sequence[str],
+    losers: Sequence[str],
+    k: float = K_FACTOR,
+) -> None:
+    """Update player ratings using a basic MMR/Elo system.
+
+    The winner gains more points for beating a higher-rated opponent and
+    loses fewer for losing against a stronger player. Ratings are created
+    on the fly for new players with a default value of 1000.
+    """
+    if not winners or not losers:
+        return
+
+    ids = set(winners) | set(losers)
+    rows = (
+        await session.execute(
+            select(Rating).where(Rating.player_id.in_(ids), Rating.sport_id == sport_id)
+        )
+    ).scalars().all()
+    rating_map = {r.player_id: r for r in rows}
+
+    for pid in ids:
+        if pid not in rating_map:
+            r = Rating(id=uuid.uuid4().hex, player_id=pid, sport_id=sport_id, value=1000.0)
+            session.add(r)
+            rating_map[pid] = r
+
+    avg_win = sum(rating_map[pid].value for pid in winners) / len(winners)
+    avg_lose = sum(rating_map[pid].value for pid in losers) / len(losers)
+
+    expected_win = 1 / (1 + 10 ** ((avg_lose - avg_win) / 400))
+    win_delta = k * (1 - expected_win)
+    lose_delta = -k * (1 - expected_win)
+
+    for pid in winners:
+        rating_map[pid].value += win_delta
+    for pid in losers:
+        rating_map[pid].value += lose_delta

--- a/backend/tests/test_rating_service.py
+++ b/backend/tests/test_rating_service.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
+
+from backend.app.models import Player, Rating
+from backend.app.services import update_ratings
+
+
+def test_update_ratings():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def run_test():
+        async with engine.begin() as conn:
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Rating.__table__.create)
+
+        async with async_session_maker() as session:
+            session.add_all([
+                Player(id="p1", name="A"),
+                Player(id="p2", name="B"),
+                Rating(id="r1", player_id="p1", sport_id="padel", value=1000),
+                Rating(id="r2", player_id="p2", sport_id="padel", value=1000),
+            ])
+            await session.commit()
+            await update_ratings(session, "padel", ["p1"], ["p2"])
+            await session.commit()
+            rows = (
+                await session.execute(select(Rating).order_by(Rating.player_id))
+            ).scalars().all()
+            return [r.value for r in rows]
+
+    r1, r2 = asyncio.run(run_test())
+    assert r1 > 1000
+    assert r2 < 1000


### PR DESCRIPTION
## Summary
- implement Elo-style MMR rating updates and expose helper
- update match set recording to adjust player ratings
- add Rankings page to surface leaderboards

## Testing
- `pytest backend/tests/test_record_sets.py::test_record_sets_success backend/tests/test_rating_service.py::test_update_ratings`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b31dded5ac8323aec538f94cfc13a9