### PR TITLE
Add admin-only soft delete for players and matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ GET  /api/v0/sports
 GET  /api/v0/rulesets?sport=padel
 POST /api/v0/players
 GET  /api/v0/players?q=name
+DELETE /api/v0/players/{id}  # admin, soft delete
 POST /api/v0/matches
 POST /api/v0/matches/by-name
 GET  /api/v0/matches/{id}
+DELETE /api/v0/matches/{id}  # admin, soft delete
 POST /api/v0/matches/{id}/events
 POST /api/v0/matches/{id}/sets
 GET  /api/v0/leaderboards?sport=padel

--- a/backend/alembic/versions/0004_soft_delete_columns.py
+++ b/backend/alembic/versions/0004_soft_delete_columns.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0004_soft_delete_columns'
+down_revision = '0003_match_meta_unique_names'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('player', sa.Column('deleted_at', sa.DateTime(), nullable=True))
+    op.add_column('match', sa.Column('deleted_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('match', 'deleted_at')
+    op.drop_column('player', 'deleted_at')
+

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -26,6 +26,7 @@ class Player(Base):
     user_id = Column(String, nullable=True)
     name = Column(String, nullable=False, unique=True)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
+    deleted_at = Column(DateTime, nullable=True)
 
 class Team(Base):
     __tablename__ = "team"
@@ -55,6 +56,7 @@ class Match(Base):
     played_at = Column(DateTime, nullable=True)
     location = Column(String, nullable=True)
     details = Column(JSON, nullable=True)
+    deleted_at = Column(DateTime, nullable=True)
 
 class MatchParticipant(Base):
     __tablename__ = "match_participant"

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,9 @@
+import os
+from fastapi import Header, HTTPException
+
+
+async def require_admin(x_admin_secret: str | None = Header(None)) -> None:
+    expected = os.getenv("ADMIN_SECRET")
+    if not expected or x_admin_secret != expected:
+        raise HTTPException(status_code=401, detail="unauthorized")
+

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -21,7 +21,7 @@ async def leaderboard(
     stmt = (
         select(Rating, Player)
         .join(Player, Player.id == Rating.player_id)
-        .where(Rating.sport_id == sport)
+        .where(Rating.sport_id == sport, Player.deleted_at.is_(None))
         .order_by(Rating.value.desc())
     )
     count_stmt = select(func.count()).select_from(Rating).where(Rating.sport_id == sport)
@@ -37,7 +37,7 @@ async def leaderboard(
             await session.execute(
                 select(MatchParticipant, Match)
                 .join(Match, Match.id == MatchParticipant.match_id)
-                .where(Match.sport_id == sport)
+                .where(Match.sport_id == sport, Match.deleted_at.is_(None))
             )
         ).all()
         for mp, m in mp_rows:

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -149,13 +149,15 @@ def test_list_matches_filters_by_player(tmp_path):
         assert len(data) == 1
         assert data[0]["id"] == m1
 
-
 @pytest.mark.anyio
-async def test_delete_match_removes_related_rows(tmp_path):
+async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    os.environ["ADMIN_SECRET"] = "secret"
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
     from app import db
     from app.models import Match, ScoreEvent
-    from app.routers.matches import delete_match
+    from app.routers import matches
 
     db.engine = None
     db.AsyncSessionLocal = None
@@ -187,27 +189,41 @@ async def test_delete_match_removes_related_rows(tmp_path):
         )
         await session.commit()
 
-        resp = await delete_match(mid, session)
-        assert resp.status_code == 204
-        assert await session.get(Match, mid) is None
+    app = FastAPI()
+    app.include_router(matches.router)
+    client = TestClient(app)
+
+    resp = client.delete(f"/matches/{mid}")
+    assert resp.status_code == 401
+
+    resp = client.delete(f"/matches/{mid}", headers={"X-Admin-Secret": "secret"})
+    assert resp.status_code == 204
+    assert client.get(f"/matches/{mid}").status_code == 404
+
+    async with db.AsyncSessionLocal() as session:
+        m = await session.get(Match, mid)
+        assert m is not None and m.deleted_at is not None
         mp_rows = await session.execute(
             text("SELECT * FROM match_participant WHERE match_id=:mid"), {"mid": mid}
         )
-        assert mp_rows.fetchall() == []
+        assert mp_rows.fetchall() != []
         se_rows = (
             await session.execute(
                 select(ScoreEvent).where(ScoreEvent.match_id == mid)
             )
         ).scalars().all()
-        assert se_rows == []
+        assert se_rows != []
 
 
 @pytest.mark.anyio
-async def test_delete_match_missing_raises_404(tmp_path):
+async def test_delete_match_missing_returns_404(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    os.environ["ADMIN_SECRET"] = "secret"
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
     from app import db
-    from app.models import Match, ScoreEvent
-    from app.routers.matches import delete_match
+    from app.models import Match
+    from app.routers import matches
 
     db.engine = None
     db.AsyncSessionLocal = None
@@ -215,12 +231,9 @@ async def test_delete_match_missing_raises_404(tmp_path):
 
     async with engine.begin() as conn:
         await conn.run_sync(Match.__table__.create)
-        await conn.run_sync(ScoreEvent.__table__.create)
-        await conn.exec_driver_sql(
-            "CREATE TABLE match_participant (id TEXT PRIMARY KEY, match_id TEXT, side TEXT, player_ids TEXT)"
-        )
 
-    async with db.AsyncSessionLocal() as session:
-        with pytest.raises(HTTPException) as exc:
-            await delete_match("unknown", session)
-        assert exc.value.status_code == 404
+    app = FastAPI()
+    app.include_router(matches.router)
+    with TestClient(app) as client:
+        resp = client.delete("/matches/unknown", headers={"X-Admin-Secret": "secret"})
+        assert resp.status_code == 404

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -8,11 +8,30 @@ os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
 from app import db
 from app.routers import players
 from app.models import Player, Club
+from app.exceptions import DomainException, ProblemDetail
 
 app = FastAPI()
+
+
+@app.exception_handler(DomainException)
+async def domain_exception_handler(request, exc):
+    problem = ProblemDetail(
+        type=exc.type,
+        title=exc.title,
+        detail=exc.detail,
+        status=exc.status_code,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
 app.include_router(players.router)
 
 @pytest.fixture(scope="module", autouse=True)
@@ -48,3 +67,29 @@ def test_list_players_pagination() -> None:
         assert data["offset"] == 1
         assert data["total"] == base_total + 5
         assert len(data["players"]) == 2
+
+
+def test_delete_player_requires_secret() -> None:
+    os.environ["ADMIN_SECRET"] = "s3cr3t"
+    with TestClient(app) as client:
+        pid = client.post("/players", json={"name": "Alice"}).json()["id"]
+        resp = client.delete(f"/players/{pid}")
+        assert resp.status_code == 401
+
+
+def test_delete_player_soft_delete() -> None:
+    os.environ["ADMIN_SECRET"] = "s3cr3t"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        pid = client.post("/players", json={"name": "Bob"}).json()["id"]
+        resp = client.delete(
+            f"/players/{pid}", headers={"X-Admin-Secret": "s3cr3t"}
+        )
+        assert resp.status_code == 204
+        assert client.get(f"/players/{pid}").status_code == 404
+
+    async def check_deleted():
+        async with db.AsyncSessionLocal() as session:
+            p = await session.get(Player, pid)
+            assert p is not None and p.deleted_at is not None
+
+    asyncio.run(check_deleted())


### PR DESCRIPTION
## Summary
- support soft deletions by adding `deleted_at` to players and matches
- restrict DELETE `/players/{id}` and `/matches/{id}` with `X-Admin-Secret`
- filter leaderboards and listings to hide soft-deleted records

## Testing
- `pytest tests/test_players.py tests/test_matches.py`


------
https://chatgpt.com/codex/tasks/task_e_68b40f84e1f0832382adf6552f0d02a5