### PR TITLE
Sort matches by most recent

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -81,6 +81,11 @@ function formatSummary(s?: MatchDetail["summary"]): string {
 export default async function MatchesPage() {
   try {
     const rows = await getMatches();
+    rows.sort((a, b) => {
+      if (!a.playedAt) return 1;
+      if (!b.playedAt) return -1;
+      return new Date(b.playedAt).getTime() - new Date(a.playedAt).getTime();
+    });
     const matches = await enrichMatches(rows);
 
     return (


### PR DESCRIPTION
## Summary
- sort matches by `playedAt` timestamp descending to show most recent first

## Testing
- `npm test`
- `npm run lint` *(fails: uses @ts-ignore and no-explicit-any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b427942c6483239ae71375da490dcd