### PR TITLE
feat: support rating draws and adaptive K factor

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -264,11 +264,20 @@ async def record_sets_endpoint(mid: str, body: SetsIn, session: AsyncSession = D
         players_a = [pid for p in parts if p.side == "A" for pid in p.player_ids]
         players_b = [pid for p in parts if p.side == "B" for pid in p.player_ids]
         sets = m.details.get("sets") if m.details else None
-        if sets and players_a and players_b and sets.get("A") != sets.get("B"):
-            winner_side = "A" if sets["A"] > sets["B"] else "B"
-            winners = players_a if winner_side == "A" else players_b
-            losers = players_b if winner_side == "A" else players_a
-            await update_ratings(session, m.sport_id, winners, losers)
+        if sets and players_a and players_b:
+            if sets.get("A") == sets.get("B"):
+                await update_ratings(
+                    session,
+                    m.sport_id,
+                    players_a,
+                    players_b,
+                    draws=players_a + players_b,
+                )
+            else:
+                winner_side = "A" if sets["A"] > sets["B"] else "B"
+                winners = players_a if winner_side == "A" else players_b
+                losers = players_b if winner_side == "A" else players_a
+                await update_ratings(session, m.sport_id, winners, losers)
     except Exception:
         # The rating tables may not exist (e.g., in tests); ignore errors
         pass

--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -3,7 +3,7 @@ from typing import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..models import Rating
+from ..models import Rating, MatchParticipant, Match
 
 K_FACTOR = 32.0
 
@@ -12,6 +12,7 @@ async def update_ratings(
     sport_id: str,
     winners: Sequence[str],
     losers: Sequence[str],
+    draws: Sequence[str] | None = None,
     k: float = K_FACTOR,
 ) -> None:
     """Update player ratings using a basic MMR/Elo system.
@@ -20,10 +21,11 @@ async def update_ratings(
     loses fewer for losing against a stronger player. Ratings are created
     on the fly for new players with a default value of 1000.
     """
-    if not winners or not losers:
+    if not winners and not losers:
         return
 
-    ids = set(winners) | set(losers)
+    draws = list(draws or [])
+    ids = set(winners) | set(losers) | set(draws)
     rows = (
         await session.execute(
             select(Rating).where(Rating.player_id.in_(ids), Rating.sport_id == sport_id)
@@ -41,10 +43,30 @@ async def update_ratings(
     avg_lose = sum(rating_map[pid].value for pid in losers) / len(losers)
 
     expected_win = 1 / (1 + 10 ** ((avg_lose - avg_win) / 400))
-    win_delta = k * (1 - expected_win)
-    lose_delta = -k * (1 - expected_win)
+
+    win_score = 0.5 if draws else 1.0
+    lose_score = 0.5 if draws else 0.0
+
+    # Determine K for each player based on number of matches played
+    rows = (
+        await session.execute(
+            select(MatchParticipant.player_ids)
+            .join(Match, MatchParticipant.match_id == Match.id)
+            .where(Match.sport_id == sport_id, Match.deleted_at.is_(None))
+        )
+    ).scalars().all()
+
+    match_counts = {pid: 0 for pid in ids}
+    for player_ids in rows:
+        for pid in ids:
+            if pid in player_ids:
+                match_counts[pid] += 1
+
+    k_map: dict[str, float] = {}
+    for pid in ids:
+        k_map[pid] = k / 2 if match_counts[pid] > 30 else k
 
     for pid in winners:
-        rating_map[pid].value += win_delta
+        rating_map[pid].value += k_map[pid] * (win_score - expected_win)
     for pid in losers:
-        rating_map[pid].value += lose_delta
+        rating_map[pid].value += k_map[pid] * (lose_score - (1 - expected_win))

--- a/backend/tests/test_rating_service.py
+++ b/backend/tests/test_rating_service.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from sqlalchemy import select
 
-from backend.app.models import Player, Rating
+from backend.app.models import Player, Rating, Match, MatchParticipant
 from backend.app.services import update_ratings
 
 
@@ -21,6 +21,8 @@ def test_update_ratings():
         async with engine.begin() as conn:
             await conn.run_sync(Player.__table__.create)
             await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(Match.__table__.create)
+            await conn.run_sync(MatchParticipant.__table__.create)
 
         async with async_session_maker() as session:
             session.add_all([
@@ -40,3 +42,100 @@ def test_update_ratings():
     r1, r2 = asyncio.run(run_test())
     assert r1 > 1000
     assert r2 < 1000
+
+
+def test_update_ratings_draw():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def run_test():
+        async with engine.begin() as conn:
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(Match.__table__.create)
+            await conn.run_sync(MatchParticipant.__table__.create)
+
+        async with async_session_maker() as session:
+            session.add_all([
+                Player(id="p1", name="A"),
+                Player(id="p2", name="B"),
+                Rating(id="r1", player_id="p1", sport_id="padel", value=1200),
+                Rating(id="r2", player_id="p2", sport_id="padel", value=1000),
+            ])
+            await session.commit()
+
+            await update_ratings(
+                session,
+                "padel",
+                ["p1"],
+                ["p2"],
+                draws=["p1", "p2"],
+            )
+            await session.commit()
+            rows = (
+                await session.execute(select(Rating).order_by(Rating.player_id))
+            ).scalars().all()
+            return [r.value for r in rows]
+
+    r1, r2 = asyncio.run(run_test())
+    assert r1 < 1200  # higher-rated player loses points on draw
+    assert r2 > 1000  # lower-rated player gains points on draw
+
+
+def test_update_ratings_variable_k():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def run_test():
+        async with engine.begin() as conn:
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(Match.__table__.create)
+            await conn.run_sync(MatchParticipant.__table__.create)
+
+        async with async_session_maker() as session:
+            # Create players and ratings
+            session.add_all([
+                Player(id="p1", name="A"),
+                Player(id="p2", name="B"),
+                Rating(id="r1", player_id="p1", sport_id="padel", value=1000),
+                Rating(id="r2", player_id="p2", sport_id="padel", value=1000),
+            ])
+            await session.commit()
+
+            # Insert 31 past matches for p1 to reduce K
+            for i in range(31):
+                mid = f"m{i}"
+                session.add(
+                    Match(id=mid, sport_id="padel", stage_id=None, ruleset_id=None)
+                )
+                session.add(
+                    MatchParticipant(
+                        id=f"mp{i}",
+                        match_id=mid,
+                        side="A",
+                        player_ids=["p1"],
+                    )
+                )
+            await session.commit()
+
+            await update_ratings(session, "padel", ["p1"], ["p2"])
+            await session.commit()
+            rows = (
+                await session.execute(select(Rating).order_by(Rating.player_id))
+            ).scalars().all()
+            return [r.value for r in rows]
+
+    r1, r2 = asyncio.run(run_test())
+    # p1 K-factor should be halved; expected change = 8 points
+    assert abs(r1 - 1008) < 1e-6
+    # p2 still uses default K-factor 32; expected change = -16 points
+    assert abs(r2 - 984) < 1e-6


### PR DESCRIPTION
## Summary
- allow rating updates to handle draws and compute K-factor per player based on match count
- update match router to pass draw information
- cover draw and variable K scenarios with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b43faca4b48323ae705f1acc893420