### PR TITLE
Add tournaments and stages API with tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from .routers import sports, rulesets, players, matches, leaderboards, streams
+from .routers import sports, rulesets, players, matches, leaderboards, streams, tournaments
 from .exceptions import DomainException, ProblemDetail
 import os
 
@@ -89,3 +89,4 @@ app.include_router(players.router,     prefix="/api/v0")
 app.include_router(matches.router,     prefix="/api/v0")
 app.include_router(leaderboards.router, prefix="/api/v0")
 app.include_router(streams.router,      prefix="/api/v0")
+app.include_router(tournaments.router, prefix="/api/v0")

--- a/backend/app/routers/tournaments.py
+++ b/backend/app/routers/tournaments.py
@@ -1,0 +1,83 @@
+# backend/app/routers/tournaments.py
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..models import Tournament, Stage
+from ..schemas import (
+    TournamentCreate,
+    TournamentOut,
+    StageCreate,
+    StageOut,
+)
+
+# Resource-only prefix; versioning is added in main.py
+router = APIRouter(prefix="/tournaments", tags=["tournaments"])
+
+
+@router.post("", response_model=TournamentOut)
+async def create_tournament(
+    body: TournamentCreate, session: AsyncSession = Depends(get_session)
+):
+    tid = uuid.uuid4().hex
+    t = Tournament(
+        id=tid,
+        sport_id=body.sport,
+        club_id=body.clubId,
+        name=body.name,
+    )
+    session.add(t)
+    await session.commit()
+    return TournamentOut(id=tid, sport=t.sport_id, name=t.name, clubId=t.club_id)
+
+
+@router.get("", response_model=list[TournamentOut])
+async def list_tournaments(session: AsyncSession = Depends(get_session)):
+    rows = (await session.execute(select(Tournament))).scalars().all()
+    return [
+        TournamentOut(id=t.id, sport=t.sport_id, name=t.name, clubId=t.club_id)
+        for t in rows
+    ]
+
+
+@router.get("/{tid}", response_model=TournamentOut)
+async def get_tournament(tid: str, session: AsyncSession = Depends(get_session)):
+    t = await session.get(Tournament, tid)
+    if not t:
+        raise HTTPException(404, "tournament not found")
+    return TournamentOut(id=t.id, sport=t.sport_id, name=t.name, clubId=t.club_id)
+
+
+@router.post("/{tid}/stages", response_model=StageOut)
+async def create_stage(
+    tid: str, body: StageCreate, session: AsyncSession = Depends(get_session)
+):
+    t = await session.get(Tournament, tid)
+    if not t:
+        raise HTTPException(404, "tournament not found")
+    sid = uuid.uuid4().hex
+    s = Stage(id=sid, tournament_id=tid, type=body.type)
+    session.add(s)
+    await session.commit()
+    return StageOut(id=sid, tournamentId=tid, type=s.type)
+
+
+@router.get("/{tid}/stages", response_model=list[StageOut])
+async def list_stages(tid: str, session: AsyncSession = Depends(get_session)):
+    t = await session.get(Tournament, tid)
+    if not t:
+        raise HTTPException(404, "tournament not found")
+    rows = (
+        await session.execute(select(Stage).where(Stage.tournament_id == tid))
+    ).scalars().all()
+    return [StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type) for s in rows]
+
+
+@router.get("/{tid}/stages/{sid}", response_model=StageOut)
+async def get_stage(tid: str, sid: str, session: AsyncSession = Depends(get_session)):
+    s = await session.get(Stage, sid)
+    if not s or s.tournament_id != tid:
+        raise HTTPException(404, "stage not found")
+    return StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -134,3 +134,26 @@ class PlayerStatsOut(BaseModel):
     worstAgainst: Optional[VersusRecord] = None
     bestWith: Optional[VersusRecord] = None
     worstWith: Optional[VersusRecord] = None
+
+
+class TournamentCreate(BaseModel):
+    sport: str
+    name: str
+    clubId: Optional[str] = None
+
+
+class TournamentOut(BaseModel):
+    id: str
+    sport: str
+    name: str
+    clubId: Optional[str] = None
+
+
+class StageCreate(BaseModel):
+    type: Literal["round_robin", "single_elim"]
+
+
+class StageOut(BaseModel):
+    id: str
+    tournamentId: str
+    type: str

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -1,0 +1,88 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure backend app modules can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+@pytest.mark.anyio
+async def test_tournament_crud(tmp_path):
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    from app import db
+    from app.models import Sport, Tournament, Stage
+    from app.routers import tournaments
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            db.Base.metadata.create_all,
+            tables=[Sport.__table__, Tournament.__table__, Stage.__table__],
+        )
+    async with db.AsyncSessionLocal() as session:
+        session.add(Sport(id="padel", name="Padel"))
+        await session.commit()
+
+    app = FastAPI()
+    app.include_router(tournaments.router)
+
+    with TestClient(app) as client:
+        resp = client.post("/tournaments", json={"sport": "padel", "name": "Winter Cup"})
+        assert resp.status_code == 200
+        tid = resp.json()["id"]
+
+        resp = client.get("/tournaments")
+        assert resp.status_code == 200
+        assert any(t["id"] == tid for t in resp.json())
+
+        resp = client.get(f"/tournaments/{tid}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Winter Cup"
+
+
+@pytest.mark.anyio
+async def test_stage_crud(tmp_path):
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    from app import db
+    from app.models import Sport, Tournament, Stage
+    from app.routers import tournaments
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            db.Base.metadata.create_all,
+            tables=[Sport.__table__, Tournament.__table__, Stage.__table__],
+        )
+    async with db.AsyncSessionLocal() as session:
+        session.add(Sport(id="padel", name="Padel"))
+        await session.commit()
+
+    app = FastAPI()
+    app.include_router(tournaments.router)
+
+    with TestClient(app) as client:
+        tid = client.post("/tournaments", json={"sport": "padel", "name": "Winter Cup"}).json()["id"]
+
+        resp = client.post(f"/tournaments/{tid}/stages", json={"type": "round_robin"})
+        assert resp.status_code == 200
+        sid = resp.json()["id"]
+
+        resp = client.get(f"/tournaments/{tid}/stages")
+        assert resp.status_code == 200
+        assert any(s["id"] == sid for s in resp.json())
+
+        resp = client.get(f"/tournaments/{tid}/stages/{sid}")
+        assert resp.status_code == 200
+        assert resp.json()["type"] == "round_robin"


### PR DESCRIPTION
## Summary
- add FastAPI router for tournaments and stages
- define Pydantic schemas for tournaments and stages
- register tournaments router and test CRUD operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b43fb2af1483238fc8f0ec4431b8b0