### PR TITLE
feat: batch fetch player names

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MatchesPage from "./page";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("MatchesPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches player names in a single request", async () => {
+    const matches = [
+      {
+        id: "m1",
+        sport: "padel",
+        bestOf: 3,
+        playedAt: null,
+        location: null,
+      },
+    ];
+    const detail = {
+      participants: [
+        { side: "A" as const, playerIds: ["1"] },
+        { side: "B" as const, playerIds: ["2"] },
+      ],
+      summary: { points: { A: 11, B: 7 } },
+    };
+    const players = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ];
+
+    const fetchMock = vi
+      .fn()
+      // list matches
+      .mockResolvedValueOnce({ ok: true, json: async () => matches })
+      // match detail
+      .mockResolvedValueOnce({ ok: true, json: async () => detail })
+      // players by ids
+      .mockResolvedValueOnce({ ok: true, json: async () => players });
+
+    // @ts-expect-error override for test
+    global.fetch = fetchMock;
+
+    const page = await MatchesPage();
+    render(page);
+
+    await screen.findByText("Alice vs Bob");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const url = fetchMock.mock.calls[2][0] as string;
+    expect(url).toContain("/players/by-ids?ids=1,2");
+  });
+});

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -10,6 +10,7 @@ from ..schemas import (
     PlayerCreate,
     PlayerOut,
     PlayerListOut,
+    PlayerNameOut,
     PlayerStatsOut,
     VersusRecord,
 )
@@ -53,6 +54,18 @@ async def list_players(
     rows = (await session.execute(stmt)).scalars().all()
     players = [PlayerOut(id=p.id, name=p.name, club_id=p.club_id) for p in rows]
     return PlayerListOut(players=players, total=total, limit=limit, offset=offset)
+
+
+# GET /api/v0/players/by-ids?ids=...
+@router.get("/by-ids", response_model=list[PlayerNameOut])
+async def players_by_ids(ids: str = "", session: AsyncSession = Depends(get_session)):
+    id_list = [i for i in ids.split(",") if i]
+    if not id_list:
+        return []
+    rows = (
+        await session.execute(select(Player).where(Player.id.in_(id_list)))
+    ).scalars().all()
+    return [PlayerNameOut(id=p.id, name=p.name) for p in rows]
 
 # GET /api/v0/players/{player_id}
 @router.get("/{player_id}", response_model=PlayerOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -23,6 +23,11 @@ class PlayerOut(BaseModel):
     club_id: Optional[str] = None
 
 
+class PlayerNameOut(BaseModel):
+    id: str
+    name: str
+
+
 class PlayerListOut(BaseModel):
     players: List[PlayerOut]
     total: int


### PR DESCRIPTION
## Summary
- add GET /players/by-ids endpoint returning player id and name
- use new endpoint in matches page to batch load player names
- add component test ensuring single player lookup

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b43fb79b748323bf622e81c130c20c