### PR TITLE
Validate duplicate players in match creation

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -68,6 +68,13 @@ async def create_match(body: MatchCreate, session: AsyncSession = Depends(get_se
         details=None,
     )
     session.add(match)
+    # Validate that no player appears on more than one side
+    player_sides: dict[str, str] = {}
+    for part in body.participants:
+        for pid in part.playerIds:
+            if pid in player_sides and player_sides[pid] != part.side:
+                raise HTTPException(400, "duplicate players")
+            player_sides[pid] = part.side
 
     for part in body.participants:
         mp = MatchParticipant(

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -47,6 +47,31 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_create_match_rejects_duplicate_players(tmp_path):
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    from app import db
+    from app.schemas import MatchCreate, Participant
+    from app.routers.matches import create_match
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    db.get_engine()
+
+    async with db.AsyncSessionLocal() as session:
+        body = MatchCreate(
+            sport="padel",
+            participants=[
+                Participant(side="A", playerIds=["p1"]),
+                Participant(side="B", playerIds=["p1"]),
+            ],
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_match(body, session)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "duplicate players"
+
+
+@pytest.mark.anyio
 async def test_list_matches_returns_most_recent_first(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- prevent players from being added to multiple sides when creating matches
- add regression test for duplicate player validation

## Testing
- `pytest backend/tests/test_matches.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43fbe13cc83239098474fb14aa683