### PR TITLE
feat: configurable tenth-frame bowling bonuses

### DIFF
--- a/backend/app/scoring/bowling.py
+++ b/backend/app/scoring/bowling.py
@@ -3,7 +3,11 @@ from typing import Dict, List
 
 
 def init_state(config: Dict) -> Dict:
-    return {"config": config, "frames": [[] for _ in range(10)]}
+    return {
+        "config": config,
+        "frames": [[] for _ in range(10)],
+        "tenth_bonus": bool(config.get("tenthFrameBonus", True)),
+    }
 
 
 def apply(event: Dict, state: Dict) -> Dict:
@@ -21,15 +25,25 @@ def apply(event: Dict, state: Dict) -> Dict:
             f.append(pins)
             break
         else:
-            if len(f) < 2 or f[0] == 10 or sum(f[:2]) == 10:
-                f.append(pins)
+            bonus = state.get("tenth_bonus", True)
+            if bonus:
+                if len(f) < 2:
+                    f.append(pins)
+                elif f and f[0] == 10 and len(f) < 3:
+                    f.append(pins)
+                elif len(f) >= 2 and sum(f[:2]) == 10 and len(f) < 3:
+                    f.append(pins)
+                else:
+                    raise ValueError("no rolls left in final frame")
             else:
-                raise ValueError("no rolls left in final frame")
+                if f and (f[0] == 10 or len(f) == 2):
+                    raise ValueError("no rolls left in final frame")
+                f.append(pins)
             break
     return state
 
 
-def _frame_score(frames: List[List[int]], i: int) -> int:
+def _frame_score(frames: List[List[int]], i: int, tenth_bonus: bool) -> int:
     f = frames[i]
     if i < 9:
         if f and f[0] == 10:  # strike
@@ -38,15 +52,22 @@ def _frame_score(frames: List[List[int]], i: int) -> int:
         if sum(f) == 10:  # spare
             return 10 + (frames[i + 1][0] if len(frames) > i + 1 and frames[i + 1] else 0)
         return sum(f)
-    return sum(f)
+    if not tenth_bonus:
+        return sum(f[:2])
+    if f and f[0] == 10:
+        return 10 + sum(f[1:3])
+    if len(f) >= 2 and sum(f[:2]) == 10:
+        return 10 + (f[2] if len(f) > 2 else 0)
+    return sum(f[:2])
 
 
 def summary(state: Dict) -> Dict:
     frames = state["frames"]
     scores = []
     total = 0
+    bonus = state.get("tenth_bonus", True)
     for i in range(10):
-        s = _frame_score(frames, i)
+        s = _frame_score(frames, i, bonus)
         scores.append(s)
         total += s
     return {"frames": frames, "scores": scores, "total": total}

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -21,6 +21,53 @@ def test_bowling_simple_score():
     assert summary["total"] == 20
 
 
+def test_bowling_tenth_frame_strike_bonus_allowed():
+    state = bowling.init_state({"tenthFrameBonus": True})
+    for _ in range(9 * 2):
+        state = bowling.apply({"type": "ROLL", "pins": 0}, state)
+    for pins in [10, 3, 4]:
+        state = bowling.apply({"type": "ROLL", "pins": pins}, state)
+    summary = bowling.summary(state)
+    assert summary["frames"][9] == [10, 3, 4]
+    assert summary["total"] == 17
+
+
+def test_bowling_tenth_frame_spare_bonus_allowed():
+    state = bowling.init_state({"tenthFrameBonus": True})
+    for _ in range(9 * 2):
+        state = bowling.apply({"type": "ROLL", "pins": 0}, state)
+    for pins in [7, 3, 5]:
+        state = bowling.apply({"type": "ROLL", "pins": pins}, state)
+    summary = bowling.summary(state)
+    assert summary["frames"][9] == [7, 3, 5]
+    assert summary["total"] == 15
+
+
+def test_bowling_tenth_frame_strike_no_bonus():
+    state = bowling.init_state({"tenthFrameBonus": False})
+    for _ in range(9 * 2):
+        state = bowling.apply({"type": "ROLL", "pins": 0}, state)
+    state = bowling.apply({"type": "ROLL", "pins": 10}, state)
+    with pytest.raises(ValueError, match="no rolls left"):
+        bowling.apply({"type": "ROLL", "pins": 0}, state)
+    summary = bowling.summary(state)
+    assert summary["frames"][9] == [10]
+    assert summary["total"] == 10
+
+
+def test_bowling_tenth_frame_spare_no_bonus():
+    state = bowling.init_state({"tenthFrameBonus": False})
+    for _ in range(9 * 2):
+        state = bowling.apply({"type": "ROLL", "pins": 0}, state)
+    for pins in [7, 3]:
+        state = bowling.apply({"type": "ROLL", "pins": pins}, state)
+    with pytest.raises(ValueError, match="no rolls left"):
+        bowling.apply({"type": "ROLL", "pins": 5}, state)
+    summary = bowling.summary(state)
+    assert summary["frames"][9] == [7, 3]
+    assert summary["total"] == 10
+
+
 def test_record_sets():
     events, state = padel.record_sets([(6, 4), (6, 2)])
     assert state["sets"]["A"] == 2


### PR DESCRIPTION
## Summary
- add `tenthFrameBonus` option to bowling state
- enforce optional bonus rolls in the 10th frame and score accordingly
- test strike and spare edge cases in the final frame

## Testing
- `pytest backend/tests/test_scoring.py`

------
https://chatgpt.com/codex/tasks/task_e_68b43fc54d988323a5dff105c823fb5c