### PR TITLE
feat(padel): add golden point scoring option

### DIFF
--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -10,7 +10,21 @@ def test_padel_game_win():
     state = padel.init_state({})
     for _ in range(4):
         state = padel.apply({"type": "POINT", "by": "A"}, state)
-    assert state["games"]["A"] == 1
+    summary = padel.summary(state)
+    assert summary["games"]["A"] == 1
+    assert summary["config"]["goldenPoint"] is False
+
+
+def test_padel_golden_point_game_win():
+    state = padel.init_state({"goldenPoint": True})
+    for _ in range(3):
+        state = padel.apply({"type": "POINT", "by": "A"}, state)
+        state = padel.apply({"type": "POINT", "by": "B"}, state)
+    state = padel.apply({"type": "POINT", "by": "A"}, state)
+    summary = padel.summary(state)
+    assert summary["games"]["A"] == 1
+    assert summary["points"] == {"A": 0, "B": 0}
+    assert summary["config"]["goldenPoint"] is True
 
 
 def test_bowling_simple_score():


### PR DESCRIPTION
## Summary
- allow padel scoreboard to track optional golden point rule
- report configuration in summary
- test golden point game win

## Testing
- `pytest backend/tests/test_scoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43fc9c8088323bc5e9ef59f3bef66