### PR TITLE
Add JWT auth and protect admin routes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,16 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from .routers import sports, rulesets, players, matches, leaderboards, streams, auth
+from .routers import (
+    sports,
+    rulesets,
+    players,
+    matches,
+    leaderboards,
+    streams,
+    tournaments,
+    auth,
+)
 from .exceptions import DomainException, ProblemDetail
 import os
 
@@ -89,4 +98,5 @@ app.include_router(players.router,     prefix="/api/v0")
 app.include_router(matches.router,     prefix="/api/v0")
 app.include_router(leaderboards.router, prefix="/api/v0")
 app.include_router(streams.router,      prefix="/api/v0")
+app.include_router(tournaments.router,  prefix="/api/v0")
 app.include_router(auth.router,         prefix="/api/v0")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from .routers import sports, rulesets, players, matches, leaderboards, streams
+from .routers import sports, rulesets, players, matches, leaderboards, streams, auth
 from .exceptions import DomainException, ProblemDetail
 import os
 
@@ -89,3 +89,4 @@ app.include_router(players.router,     prefix="/api/v0")
 app.include_router(matches.router,     prefix="/api/v0")
 app.include_router(leaderboards.router, prefix="/api/v0")
 app.include_router(streams.router,      prefix="/api/v0")
+app.include_router(auth.router,         prefix="/api/v0")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import relationship
-from sqlalchemy import Column, String, DateTime, ForeignKey, JSON, Integer, Float
+from sqlalchemy import Column, String, DateTime, ForeignKey, JSON, Integer, Float, Boolean
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.sql import func
 from .db import Base
@@ -80,3 +80,11 @@ class Rating(Base):
     player_id = Column(String, ForeignKey("player.id"), nullable=False)
     sport_id = Column(String, ForeignKey("sport.id"), nullable=False)
     value = Column(Float, nullable=False, default=1000)
+
+
+class User(Base):
+    __tablename__ = "user"
+    id = Column(String, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    is_admin = Column(Boolean, nullable=False, default=False)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,9 +1,10 @@
-import os
-from fastapi import Header, HTTPException
+from fastapi import Depends, HTTPException
+
+from ..models import User
+from .auth import get_current_user
 
 
-async def require_admin(x_admin_secret: str | None = Header(None)) -> None:
-    expected = os.getenv("ADMIN_SECRET")
-    if not expected or x_admin_secret != expected:
-        raise HTTPException(status_code=401, detail="unauthorized")
-
+async def require_admin(user: User = Depends(get_current_user)) -> User:
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    return user

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,81 @@
+import os
+import uuid
+import hashlib
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import jwt
+
+from ..db import get_session
+from ..models import User
+from ..schemas import UserCreate, UserLogin, TokenOut
+
+JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+JWT_ALG = "HS256"
+JWT_EXPIRE_SECONDS = 3600
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def create_token(user: User) -> str:
+    payload = {
+        "sub": user.id,
+        "username": user.username,
+        "is_admin": user.is_admin,
+        "exp": datetime.utcnow() + timedelta(seconds=JWT_EXPIRE_SECONDS),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALG)
+
+
+@router.post("/signup", response_model=TokenOut)
+async def signup(body: UserCreate, session: AsyncSession = Depends(get_session)):
+    existing = (
+        await session.execute(select(User).where(User.username == body.username))
+    ).scalar_one_or_none()
+    if existing:
+        raise HTTPException(status_code=400, detail="username exists")
+    uid = uuid.uuid4().hex
+    user = User(
+        id=uid,
+        username=body.username,
+        password_hash=hash_password(body.password),
+        is_admin=body.is_admin,
+    )
+    session.add(user)
+    await session.commit()
+    token = create_token(user)
+    return TokenOut(access_token=token)
+
+
+@router.post("/login", response_model=TokenOut)
+async def login(body: UserLogin, session: AsyncSession = Depends(get_session)):
+    user = (
+        await session.execute(select(User).where(User.username == body.username))
+    ).scalar_one_or_none()
+    if not user or user.password_hash != hash_password(body.password):
+        raise HTTPException(status_code=401, detail="invalid credentials")
+    token = create_token(user)
+    return TokenOut(access_token=token)
+
+
+async def get_current_user(
+    authorization: str | None = Header(None),
+    session: AsyncSession = Depends(get_session),
+) -> User:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing token")
+    token = authorization.split(" ", 1)[1]
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALG])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=401, detail="invalid token")
+    uid = payload.get("sub")
+    user = await session.get(User, uid)
+    if not user:
+        raise HTTPException(status_code=401, detail="user not found")
+    return user

--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -7,7 +7,7 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
-from ..models import Match, MatchParticipant, Player, ScoreEvent
+from ..models import Match, MatchParticipant, Player, ScoreEvent, User
 from ..schemas import (
     MatchCreate,
     MatchCreateByName,
@@ -161,8 +161,12 @@ async def get_match(mid: str, session: AsyncSession = Depends(get_session)):
     )
 
 # DELETE /api/v0/matches/{mid}
-@router.delete("/{mid}", status_code=204, dependencies=[Depends(require_admin)])
-async def delete_match(mid: str, session: AsyncSession = Depends(get_session)):
+@router.delete("/{mid}", status_code=204)
+async def delete_match(
+    mid: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     m = await session.get(Match, mid)
     if not m or m.deleted_at is not None:
         raise HTTPException(404, "match not found")

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -5,7 +5,7 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
-from ..models import Player, Match, MatchParticipant
+from ..models import Player, Match, MatchParticipant, User
 from ..schemas import (
     PlayerCreate,
     PlayerOut,
@@ -64,8 +64,12 @@ async def get_player(player_id: str, session: AsyncSession = Depends(get_session
 
 
 # DELETE /api/v0/players/{player_id}
-@router.delete("/{player_id}", status_code=204, dependencies=[Depends(require_admin)])
-async def delete_player(player_id: str, session: AsyncSession = Depends(get_session)):
+@router.delete("/{player_id}", status_code=204)
+async def delete_player(
+    player_id: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     p = await session.get(Player, player_id)
     if not p or p.deleted_at is not None:
         raise PlayerNotFound(player_id)

--- a/backend/app/routers/tournaments.py
+++ b/backend/app/routers/tournaments.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/tournaments")
+async def list_tournaments():
+    return []

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -134,3 +134,19 @@ class PlayerStatsOut(BaseModel):
     worstAgainst: Optional[VersusRecord] = None
     bestWith: Optional[VersusRecord] = None
     worstWith: Optional[VersusRecord] = None
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+    is_admin: bool = False
+
+
+class UserLogin(BaseModel):
+    username: str
+    password: str
+
+
+class TokenOut(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -150,3 +150,26 @@ class UserLogin(BaseModel):
 class TokenOut(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+
+class TournamentCreate(BaseModel):
+    sport: str
+    name: str
+    clubId: Optional[str] = None
+
+
+class TournamentOut(BaseModel):
+    id: str
+    sport: str
+    name: str
+    clubId: Optional[str] = None
+
+
+class StageCreate(BaseModel):
+    type: Literal["round_robin", "single_elim"]
+
+
+class StageOut(BaseModel):
+    id: str
+    tournamentId: str
+    type: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ python-multipart>=0.0.9,<1.0
 redis>=4.0,<5.0
 fakeredis>=2.0,<3.0
 httpx>=0.23,<1.0
+PyJWT>=2.0,<3.0
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth.db"
+os.environ["JWT_SECRET"] = "testsecret"
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app import db
+from app.models import User, Player, Club
+from app.routers import auth, players
+
+app = FastAPI()
+app.include_router(auth.router)
+app.include_router(players.router)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    async def init_models():
+        if os.path.exists("./test_auth.db"):
+            os.remove("./test_auth.db")
+        db.engine = None
+        db.AsyncSessionLocal = None
+        engine = db.get_engine()
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                db.Base.metadata.create_all,
+                tables=[User.__table__, Player.__table__, Club.__table__],
+            )
+    asyncio.run(init_models())
+    yield
+    if os.path.exists("./test_auth.db"):
+        os.remove("./test_auth.db")
+
+
+def test_signup_login_and_protected_access():
+    with TestClient(app) as client:
+        resp = client.post(
+            "/auth/signup", json={"username": "alice", "password": "pw"}
+        )
+        assert resp.status_code == 200
+        token = resp.json()["access_token"]
+        assert token
+
+        resp = client.post(
+            "/auth/login", json={"username": "alice", "password": "pw"}
+        )
+        assert resp.status_code == 200
+        user_token = resp.json()["access_token"]
+
+        pid = client.post("/players", json={"name": "Bob"}).json()["id"]
+        resp = client.delete(
+            f"/players/{pid}", headers={"Authorization": f"Bearer {user_token}"}
+        )
+        assert resp.status_code == 403
+
+        admin_token = client.post(
+            "/auth/signup",
+            json={"username": "admin", "password": "pw", "is_admin": True},
+        ).json()["access_token"]
+        resp = client.delete(
+            f"/players/{pid}", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        assert resp.status_code == 204

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth.db"
 os.environ["JWT_SECRET"] = "testsecret"
+os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -59,9 +60,16 @@ def test_signup_login_and_protected_access():
         )
         assert resp.status_code == 403
 
+        resp = client.post(
+            "/auth/signup",
+            json={"username": "admin", "password": "pw", "is_admin": True},
+        )
+        assert resp.status_code == 403
+
         admin_token = client.post(
             "/auth/signup",
             json={"username": "admin", "password": "pw", "is_admin": True},
+            headers={"X-Admin-Secret": "admintest"},
         ).json()["access_token"]
         resp = client.delete(
             f"/players/{pid}", headers={"Authorization": f"Bearer {admin_token}"}

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -19,6 +19,7 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    os.environ["JWT_SECRET"] = "testsecret"
     from app import db
     from app.models import Player
     from app.schemas import MatchCreateByName, ParticipantByName
@@ -49,6 +50,7 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
 @pytest.mark.anyio
 async def test_list_matches_returns_most_recent_first(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    os.environ["JWT_SECRET"] = "testsecret"
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from app import db
@@ -152,12 +154,12 @@ def test_list_matches_filters_by_player(tmp_path):
 @pytest.mark.anyio
 async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-    os.environ["ADMIN_SECRET"] = "secret"
+    os.environ["JWT_SECRET"] = "testsecret"
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from app import db
-    from app.models import Match, ScoreEvent
-    from app.routers import matches
+    from app.models import Match, ScoreEvent, User
+    from app.routers import matches, auth
 
     db.engine = None
     db.AsyncSessionLocal = None
@@ -166,6 +168,7 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     async with engine.begin() as conn:
         await conn.run_sync(Match.__table__.create)
         await conn.run_sync(ScoreEvent.__table__.create)
+        await conn.run_sync(User.__table__.create)
         await conn.exec_driver_sql(
             "CREATE TABLE match_participant (id TEXT PRIMARY KEY, match_id TEXT, side TEXT, player_ids TEXT)"
         )
@@ -190,13 +193,25 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
         await session.commit()
 
     app = FastAPI()
+    app.include_router(auth.router)
     app.include_router(matches.router)
     client = TestClient(app)
 
     resp = client.delete(f"/matches/{mid}")
     assert resp.status_code == 401
 
-    resp = client.delete(f"/matches/{mid}", headers={"X-Admin-Secret": "secret"})
+    token_resp = client.post(
+        "/auth/signup", json={"username": "admin", "password": "pw", "is_admin": True}
+    )
+    if token_resp.status_code != 200:
+        token_resp = client.post(
+            "/auth/login", json={"username": "admin", "password": "pw"}
+        )
+    token = token_resp.json()["access_token"]
+
+    resp = client.delete(
+        f"/matches/{mid}", headers={"Authorization": f"Bearer {token}"}
+    )
     assert resp.status_code == 204
     assert client.get(f"/matches/{mid}").status_code == 404
 
@@ -218,12 +233,12 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 @pytest.mark.anyio
 async def test_delete_match_missing_returns_404(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-    os.environ["ADMIN_SECRET"] = "secret"
+    os.environ["JWT_SECRET"] = "testsecret"
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from app import db
-    from app.models import Match
-    from app.routers import matches
+    from app.models import Match, User
+    from app.routers import matches, auth
 
     db.engine = None
     db.AsyncSessionLocal = None
@@ -231,9 +246,22 @@ async def test_delete_match_missing_returns_404(tmp_path):
 
     async with engine.begin() as conn:
         await conn.run_sync(Match.__table__.create)
+        await conn.run_sync(User.__table__.create)
 
     app = FastAPI()
+    app.include_router(auth.router)
     app.include_router(matches.router)
     with TestClient(app) as client:
-        resp = client.delete("/matches/unknown", headers={"X-Admin-Secret": "secret"})
+        token_resp = client.post(
+            "/auth/signup",
+            json={"username": "admin", "password": "pw", "is_admin": True},
+        )
+        if token_resp.status_code != 200:
+            token_resp = client.post(
+                "/auth/login", json={"username": "admin", "password": "pw"}
+            )
+        token = token_resp.json()["access_token"]
+        resp = client.delete(
+            "/matches/unknown", headers={"Authorization": f"Bearer {token}"}
+        )
         assert resp.status_code == 404

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -1,5 +1,4 @@
 import os
-import os
 import sys
 from pathlib import Path
 import asyncio
@@ -155,6 +154,7 @@ def test_list_matches_filters_by_player(tmp_path):
 async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     os.environ["JWT_SECRET"] = "testsecret"
+    os.environ["ADMIN_SECRET"] = "admintest"
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from app import db
@@ -201,7 +201,9 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     assert resp.status_code == 401
 
     token_resp = client.post(
-        "/auth/signup", json={"username": "admin", "password": "pw", "is_admin": True}
+        "/auth/signup",
+        json={"username": "admin", "password": "pw", "is_admin": True},
+        headers={"X-Admin-Secret": "admintest"},
     )
     if token_resp.status_code != 200:
         token_resp = client.post(
@@ -234,6 +236,7 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 async def test_delete_match_missing_returns_404(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     os.environ["JWT_SECRET"] = "testsecret"
+    os.environ["ADMIN_SECRET"] = "admintest"
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from app import db
@@ -255,6 +258,7 @@ async def test_delete_match_missing_returns_404(tmp_path):
         token_resp = client.post(
             "/auth/signup",
             json={"username": "admin", "password": "pw", "is_admin": True},
+            headers={"X-Admin-Secret": "admintest"},
         )
         if token_resp.status_code != 200:
             token_resp = client.post(

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 # Set up an in-memory SQLite database for tests
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
 os.environ["JWT_SECRET"] = "testsecret"
+os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -83,6 +84,7 @@ def test_delete_player_soft_delete() -> None:
         resp = client.post(
             "/auth/signup",
             json={"username": "admin", "password": "pw", "is_admin": True},
+            headers={"X-Admin-Secret": "admintest"},
         )
         if resp.status_code != 200:
             resp = client.post(

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -5,13 +5,14 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Set up an in-memory SQLite database for tests
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
+os.environ["JWT_SECRET"] = "testsecret"
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fastapi.responses import JSONResponse
 from app import db
-from app.routers import players
-from app.models import Player, Club
+from app.routers import players, auth
+from app.models import Player, Club, User
 from app.exceptions import DomainException, ProblemDetail
 
 app = FastAPI()
@@ -32,6 +33,7 @@ async def domain_exception_handler(request, exc):
     )
 
 
+app.include_router(auth.router)
 app.include_router(players.router)
 
 @pytest.fixture(scope="module", autouse=True)
@@ -45,7 +47,7 @@ def setup_db():
         async with engine.begin() as conn:
             await conn.run_sync(
                 db.Base.metadata.create_all,
-                tables=[Club.__table__, Player.__table__],
+                tables=[Club.__table__, Player.__table__, User.__table__],
             )
     asyncio.run(init_models())
     yield
@@ -69,8 +71,7 @@ def test_list_players_pagination() -> None:
         assert len(data["players"]) == 2
 
 
-def test_delete_player_requires_secret() -> None:
-    os.environ["ADMIN_SECRET"] = "s3cr3t"
+def test_delete_player_requires_token() -> None:
     with TestClient(app) as client:
         pid = client.post("/players", json={"name": "Alice"}).json()["id"]
         resp = client.delete(f"/players/{pid}")
@@ -78,11 +79,19 @@ def test_delete_player_requires_secret() -> None:
 
 
 def test_delete_player_soft_delete() -> None:
-    os.environ["ADMIN_SECRET"] = "s3cr3t"
     with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post(
+            "/auth/signup",
+            json={"username": "admin", "password": "pw", "is_admin": True},
+        )
+        if resp.status_code != 200:
+            resp = client.post(
+                "/auth/login", json={"username": "admin", "password": "pw"}
+            )
+        token = resp.json()["access_token"]
         pid = client.post("/players", json={"name": "Bob"}).json()["id"]
         resp = client.delete(
-            f"/players/{pid}", headers={"X-Admin-Secret": "s3cr3t"}
+            f"/players/{pid}", headers={"Authorization": f"Bearer {token}"}
         )
         assert resp.status_code == 204
         assert client.get(f"/players/{pid}").status_code == 404


### PR DESCRIPTION
## Summary
- add `/auth/signup` and `/auth/login` endpoints issuing JWTs
- enforce admin access via JWT instead of header secret
- update player and match deletion to require authenticated admin
- cover signup, login, and protected route access in tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b43fea04388323bd8c6217d8de1fa4