### PR TITLE
Fix player names display on matches page

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -31,8 +31,8 @@ describe("MatchesPage", () => {
       summary: { points: { A: 11, B: 7 } },
     };
     const players = [
-      { id: "1", name: "Alice" },
-      { id: "2", name: "Bob" },
+      { playerId: "1", playerName: "Alice" },
+      { playerId: "2", playerName: "Bob" },
     ];
 
     const fetchMock = vi

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -59,8 +59,17 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
       { cache: "no-store" }
     );
     if (r.ok) {
-      const players = (await r.json()) as { id: string; name: string }[];
-      players.forEach((p) => idToName.set(p.id, p.name));
+      const players = (await r.json()) as {
+        id?: string;
+        name?: string;
+        playerId?: string;
+        playerName?: string;
+      }[];
+      players.forEach((p) => {
+        const pid = p.id ?? p.playerId;
+        const pname = p.name ?? p.playerName;
+        if (pid && pname) idToName.set(pid, pname);
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve player names correctly on matches page by accepting `playerId`/`playerName` fields
- update tests for new player name shape

## Testing
- `npm test`
- `pytest` *(fails: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68b44cf394408323bbe0a7b92a30a8d7