### PR TITLE
feat: add skeleton loading to leaderboard

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -135,3 +135,28 @@ a {
 .error {
   color: var(--color-accent-red);
 }
+
+/* Skeleton loading placeholders */
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: #e0e0e0;
+  border-radius: 4px;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: skeleton-shimmer 1.5s infinite;
+}

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -74,6 +74,21 @@ export default function Leaderboard({ sport }: Props) {
     };
   }, [sport]);
 
+  const TableHeader = () => (
+    <thead>
+      <tr>
+        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>#</th>
+        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Player</th>
+        {sport === "all" && (
+          <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Sport</th>
+        )}
+        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Rating</th>
+        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>W</th>
+        <th style={{ textAlign: "left", padding: "4px 0" }}>L</th>
+      </tr>
+    </thead>
+  );
+
   return (
     <main className="container">
       <div style={{ marginBottom: "1rem", fontSize: "0.9rem" }}>
@@ -108,7 +123,42 @@ export default function Leaderboard({ sport }: Props) {
       </header>
 
       {loading ? (
-        <p>Loading...</p>
+        <table
+          style={{
+            width: "100%",
+            borderCollapse: "collapse",
+            marginTop: "1rem",
+            fontSize: "0.9rem",
+          }}
+        >
+          <TableHeader />
+          <tbody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={`skeleton-${i}`} style={{ borderTop: "1px solid #ccc" }}>
+                <td style={{ padding: "4px 16px 4px 0" }}>
+                  <div className="skeleton" style={{ width: "12px", height: "1em" }} />
+                </td>
+                <td style={{ padding: "4px 16px 4px 0" }}>
+                  <div className="skeleton" style={{ width: "120px", height: "1em" }} />
+                </td>
+                {sport === "all" && (
+                  <td style={{ padding: "4px 16px 4px 0" }}>
+                    <div className="skeleton" style={{ width: "80px", height: "1em" }} />
+                  </td>
+                )}
+                <td style={{ padding: "4px 16px 4px 0" }}>
+                  <div className="skeleton" style={{ width: "40px", height: "1em" }} />
+                </td>
+                <td style={{ padding: "4px 16px 4px 0" }}>
+                  <div className="skeleton" style={{ width: "20px", height: "1em" }} />
+                </td>
+                <td style={{ padding: "4px 0" }}>
+                  <div className="skeleton" style={{ width: "20px", height: "1em" }} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       ) : leaders.length === 0 ? (
         <p>{error ?? "No data."}</p>
       ) : (
@@ -120,24 +170,7 @@ export default function Leaderboard({ sport }: Props) {
             fontSize: "0.9rem",
           }}
         >
-          <thead>
-            <tr>
-              <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>#</th>
-              <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>
-                Player
-              </th>
-              {sport === "all" && (
-                <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>
-                  Sport
-                </th>
-              )}
-              <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>
-                Rating
-              </th>
-              <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>W</th>
-              <th style={{ textAlign: "left", padding: "4px 0" }}>L</th>
-            </tr>
-          </thead>
+          <TableHeader />
           <tbody>
             {leaders.map((row) => (
               <tr


### PR DESCRIPTION
## Summary
- render skeleton table with placeholders while leaderboard data loads
- add shimmering skeleton animation styles

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b465bcf0b88323a25944dbb22f8257