### PR TITLE
feat(web): label record form inputs

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -142,76 +142,92 @@ export default function RecordSportPage() {
         <h2 className="heading">Players</h2>
         <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
           <div>
-            <select
-              className="input"
-              value={ids.a1}
-              onChange={(e) => onIdChange("a1", e.target.value)}
-            >
-              <option value="">Player A1</option>
-              {players.map((p) => (
-                <option
-                  key={p.id}
-                  value={p.id}
-                  disabled={isUsedElsewhere(p.id, "a1")}
-                >
-                  {p.name}
-                </option>
-              ))}
-            </select>
+            <label htmlFor="player-a1" style={{ display: "flex", flexDirection: "column" }}>
+              Player A1
+              <select
+                id="player-a1"
+                className="input"
+                value={ids.a1}
+                onChange={(e) => onIdChange("a1", e.target.value)}
+              >
+                <option value="">Player A1</option>
+                {players.map((p) => (
+                  <option
+                    key={p.id}
+                    value={p.id}
+                    disabled={isUsedElsewhere(p.id, "a1")}
+                  >
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
           <div>
-            <select
-              className="input"
-              value={ids.a2}
-              onChange={(e) => onIdChange("a2", e.target.value)}
-            >
-              <option value="">Player A2</option>
-              {players.map((p) => (
-                <option
-                  key={p.id}
-                  value={p.id}
-                  disabled={isUsedElsewhere(p.id, "a2")}
-                >
-                  {p.name}
-                </option>
-              ))}
-            </select>
+            <label htmlFor="player-a2" style={{ display: "flex", flexDirection: "column" }}>
+              Player A2
+              <select
+                id="player-a2"
+                className="input"
+                value={ids.a2}
+                onChange={(e) => onIdChange("a2", e.target.value)}
+              >
+                <option value="">Player A2</option>
+                {players.map((p) => (
+                  <option
+                    key={p.id}
+                    value={p.id}
+                    disabled={isUsedElsewhere(p.id, "a2")}
+                  >
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
           <div>
-            <select
-              className="input"
-              value={ids.b1}
-              onChange={(e) => onIdChange("b1", e.target.value)}
-            >
-              <option value="">Player B1</option>
-              {players.map((p) => (
-                <option
-                  key={p.id}
-                  value={p.id}
-                  disabled={isUsedElsewhere(p.id, "b1")}
-                >
-                  {p.name}
-                </option>
-              ))}
-            </select>
+            <label htmlFor="player-b1" style={{ display: "flex", flexDirection: "column" }}>
+              Player B1
+              <select
+                id="player-b1"
+                className="input"
+                value={ids.b1}
+                onChange={(e) => onIdChange("b1", e.target.value)}
+              >
+                <option value="">Player B1</option>
+                {players.map((p) => (
+                  <option
+                    key={p.id}
+                    value={p.id}
+                    disabled={isUsedElsewhere(p.id, "b1")}
+                  >
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
           <div>
-            <select
-              className="input"
-              value={ids.b2}
-              onChange={(e) => onIdChange("b2", e.target.value)}
-            >
-              <option value="">Player B2</option>
-              {players.map((p) => (
-                <option
-                  key={p.id}
-                  value={p.id}
-                  disabled={isUsedElsewhere(p.id, "b2")}
-                >
-                  {p.name}
-                </option>
-              ))}
-            </select>
+            <label htmlFor="player-b2" style={{ display: "flex", flexDirection: "column" }}>
+              Player B2
+              <select
+                id="player-b2"
+                className="input"
+                value={ids.b2}
+                onChange={(e) => onIdChange("b2", e.target.value)}
+              >
+                <option value="">Player B2</option>
+                {players.map((p) => (
+                  <option
+                    key={p.id}
+                    value={p.id}
+                    disabled={isUsedElsewhere(p.id, "b2")}
+                  >
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
         </div>
       </section>
@@ -222,19 +238,33 @@ export default function RecordSportPage() {
           <div style={{ display: "grid", gap: 8 }}>
             {sets.map((s, idx) => (
               <div key={idx} style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                <input
-                  className="input"
-                  value={s.A}
-                  onChange={(e) => onSetChange(idx, "A", e.target.value)}
-                  placeholder="A"
-                />
-                <span>–</span>
-                <input
-                  className="input"
-                  value={s.B}
-                  onChange={(e) => onSetChange(idx, "B", e.target.value)}
-                  placeholder="B"
-                />
+                <label
+                  htmlFor={`set-${idx}-a`}
+                  style={{ display: "flex", flexDirection: "column" }}
+                >
+                  Team A
+                  <input
+                    id={`set-${idx}-a`}
+                    className="input"
+                    value={s.A}
+                    onChange={(e) => onSetChange(idx, "A", e.target.value)}
+                    placeholder="A"
+                  />
+                </label>
+                <span aria-label="to">–</span>
+                <label
+                  htmlFor={`set-${idx}-b`}
+                  style={{ display: "flex", flexDirection: "column" }}
+                >
+                  Team B
+                  <input
+                    id={`set-${idx}-b`}
+                    className="input"
+                    value={s.B}
+                    onChange={(e) => onSetChange(idx, "B", e.target.value)}
+                    placeholder="B"
+                  />
+                </label>
               </div>
             ))}
           </div>
@@ -248,30 +278,42 @@ export default function RecordSportPage() {
         <h2 className="heading">Details</h2>
         <div style={{ display: "flex", gap: 8 }}>
           {isPadel && (
-            <select
-              className="input"
-              value={bestOf}
-              onChange={(e) => setBestOf(parseInt(e.target.value, 10))}
-            >
-              {[1, 3, 5].map((n) => (
-                <option key={n} value={n}>
-                  Best of {n}
-                </option>
-              ))}
-            </select>
+            <label htmlFor="best-of" style={{ display: "flex", flexDirection: "column" }}>
+              Best of
+              <select
+                id="best-of"
+                className="input"
+                value={bestOf}
+                onChange={(e) => setBestOf(parseInt(e.target.value, 10))}
+              >
+                {[1, 3, 5].map((n) => (
+                  <option key={n} value={n}>
+                    Best of {n}
+                  </option>
+                ))}
+              </select>
+            </label>
           )}
-          <input
-            className="input"
-            type="date"
-            value={playedAt}
-            onChange={(e) => setPlayedAt(e.target.value)}
-          />
-          <input
-            className="input"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="Location"
-          />
+          <label htmlFor="played-at" style={{ display: "flex", flexDirection: "column" }}>
+            Date
+            <input
+              id="played-at"
+              className="input"
+              type="date"
+              value={playedAt}
+              onChange={(e) => setPlayedAt(e.target.value)}
+            />
+          </label>
+          <label htmlFor="location" style={{ display: "flex", flexDirection: "column" }}>
+            Location
+            <input
+              id="location"
+              className="input"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="Location"
+            />
+          </label>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add descriptive labels and ids for player, set, and detail inputs
- mark score separator with an aria-label for screen readers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b465c8fc5483239fa903117ca12a9e