### PR TITLE
feat(web): add responsive nav with hamburger

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -81,13 +81,44 @@ a {
 .nav a:hover {
   text-decoration: underline;
 }
-.nav ul {
+.nav-links ul {
   display: flex;
   justify-content: center;
   gap: 1rem;
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--color-nav-text);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .nav {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .nav-links {
+    display: none;
+    width: 100%;
+  }
+  .nav-links.open {
+    display: block;
+  }
+  .nav-links ul {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .hamburger {
+    display: block;
+  }
 }
 
 /* Sport list */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 // apps/web/src/app/layout.tsx
 import './globals.css';
 import Link from 'next/link';
+import { useState } from 'react';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -12,11 +15,19 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const [open, setOpen] = useState(false);
   return (
     <html lang="en">
       <body>
         <header className="nav">
-          <nav>
+          <button
+            className="hamburger"
+            aria-label="Toggle navigation"
+            onClick={() => setOpen((prev) => !prev)}
+          >
+            ☰
+          </button>
+          <nav className={`nav-links ${open ? 'open' : ''}`}>
             <ul>
               <li>
                 <Link href="/">Home</Link>


### PR DESCRIPTION
## Summary
- add client-side layout with a toggleable navigation container
- introduce hamburger menu for small viewports
- style nav with responsive media queries and flex adjustments

## Testing
- `npm test`
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in apps/web/src/app/players/[id]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b465c0d1dc8323822b931f4f4dee1c