### PR TITLE
feat(web): handle fetch errors with retry

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, type MouseEvent } from 'react';
+import Link from 'next/link';
+import { apiFetch } from '../lib/api';
+
+interface Sport { id: string; name: string }
+interface MatchRow {
+  id: string;
+  sport: string;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+}
+
+const sportIcons: Record<string, string> = {
+  padel: '\uD83C\uDFBE', // tennis ball
+  bowling: '🎳',
+};
+
+interface Props {
+  sports: Sport[];
+  matches: MatchRow[];
+  sportError: boolean;
+  matchError: boolean;
+}
+
+export default function HomePageClient({
+  sports: initialSports,
+  matches: initialMatches,
+  sportError: initialSportError,
+  matchError: initialMatchError,
+}: Props) {
+  const [sports, setSports] = useState(initialSports);
+  const [matches, setMatches] = useState(initialMatches);
+  const [sportError, setSportError] = useState(initialSportError);
+  const [matchError, setMatchError] = useState(initialMatchError);
+
+  const retrySports = async (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    try {
+      const r = await apiFetch('/v0/sports', { cache: 'no-store' });
+      if (r.ok) {
+        setSports((await r.json()) as Sport[]);
+        setSportError(false);
+      } else {
+        setSportError(true);
+      }
+    } catch {
+      setSportError(true);
+    }
+  };
+
+  const retryMatches = async (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    try {
+      const r = await apiFetch('/v0/matches', { cache: 'no-store' });
+      if (r.ok) {
+        setMatches((await r.json()) as MatchRow[]);
+        setMatchError(false);
+      } else {
+        setMatchError(true);
+      }
+    } catch {
+      setMatchError(true);
+    }
+  };
+
+  return (
+    <main className="container">
+      <section className="card">
+        <h1 className="heading">cross-sport-tracker</h1>
+        <p>Ongoing self-hosted project</p>
+      </section>
+
+      <section className="section">
+        <h2 className="heading">Sports</h2>
+        {sports.length === 0 ? (
+          sportError ? (
+            <p>
+              Could not load sports.{' '}
+              <a href="#" onClick={retrySports}>
+                Retry
+              </a>
+            </p>
+          ) : (
+            <p>No sports found.</p>
+          )
+        ) : (
+          <ul className="sport-list">
+            {sports.map((s) => {
+              const icon = sportIcons[s.id];
+              return (
+                <li key={s.id} className="sport-item">
+                  {icon ? (
+                    <span role="img" aria-label={s.name} title={s.name}>
+                      {icon}
+                    </span>
+                  ) : (
+                    s.name
+                  )}
+                  <span className="sport-id">{s.id}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section className="section">
+        <h2 className="heading">Recent Matches</h2>
+        {matches.length === 0 ? (
+          matchError ? (
+            <p>
+              Could not load matches.{' '}
+              <a href="#" onClick={retryMatches}>
+                Retry
+              </a>
+            </p>
+          ) : (
+            <p>No matches recorded yet.</p>
+          )
+        ) : (
+          <ul className="match-list">
+            {matches.slice(0, 5).map((m) => (
+              <li key={m.id} className="card match-item">
+                <div>
+                  <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
+                </div>
+                <div className="match-meta">
+                  {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}
+                  {m.playedAt ? new Date(m.playedAt).toLocaleDateString() : '—'}
+                  {m.location ? ` · ${m.location}` : ''}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic'; // fetch per request on the server
 
-import Link from 'next/link';
 import { apiFetch } from '../lib/api';
+import HomePageClient from './home-page-client';
 
 type Sport = { id: string; name: string };
 type MatchRow = {
@@ -12,84 +12,40 @@ type MatchRow = {
   location: string | null;
 };
 
-const sportIcons: Record<string, string> = {
-  padel: '\uD83C\uDFBE', // tennis ball
-  bowling: '🎳',
-};
-
 export default async function HomePage() {
   let sports: Sport[] = [];
   let matches: MatchRow[] = [];
+  let sportError = false;
+  let matchError = false;
+
   try {
     const r = await apiFetch('/v0/sports', { cache: 'no-store' });
     if (r.ok) {
       sports = (await r.json()) as Sport[];
+    } else {
+      sportError = true;
     }
   } catch {
-    // ignore; render with empty list
+    sportError = true;
   }
+
   try {
     const r = await apiFetch('/v0/matches', { cache: 'no-store' });
     if (r.ok) {
       matches = (await r.json()) as MatchRow[];
+    } else {
+      matchError = true;
     }
   } catch {
-    // ignore; render with empty list
+    matchError = true;
   }
 
   return (
-    <main className="container">
-      <section className="card">
-        <h1 className="heading">cross-sport-tracker</h1>
-        <p>Ongoing self-hosted project</p>
-      </section>
-
-      <section className="section">
-        <h2 className="heading">Sports</h2>
-        {sports.length === 0 ? (
-          <p>No sports found.</p>
-        ) : (
-          <ul className="sport-list">
-            {sports.map((s) => {
-              const icon = sportIcons[s.id];
-              return (
-                <li key={s.id} className="sport-item">
-                  {icon ? (
-                    <span role="img" aria-label={s.name} title={s.name}>
-                      {icon}
-                    </span>
-                  ) : (
-                    s.name
-                  )}
-                  <span className="sport-id">{s.id}</span>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </section>
-
-      <section className="section">
-        <h2 className="heading">Recent Matches</h2>
-        {matches.length === 0 ? (
-          <p>No matches recorded yet.</p>
-        ) : (
-          <ul className="match-list">
-            {matches.slice(0, 5).map((m) => (
-              <li key={m.id} className="card match-item">
-                <div>
-                  <Link href={`/matches/${m.id}`}>Match {m.id}</Link>
-                </div>
-                <div className="match-meta">
-                  {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}
-                  {m.playedAt ? new Date(m.playedAt).toLocaleDateString() : '—'}
-                  {m.location ? ` · ${m.location}` : ''}
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+    <HomePageClient
+      sports={sports}
+      matches={matches}
+      sportError={sportError}
+      matchError={matchError}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- track sports and matches fetch errors on the server
- show loading errors with retry links that refetch on the client

## Testing
- `npm test`
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in src/app/players/[id]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b465d00ad48323a74e21072f616980