### PR TITLE
feat(web): paginate matches list

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -52,7 +52,45 @@ describe("MatchesPage", () => {
 
     await screen.findByText("Alice vs Bob");
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    const listUrl = fetchMock.mock.calls[0][0] as string;
+    expect(listUrl).toContain("/v0/matches?limit=25&offset=0");
     const url = fetchMock.mock.calls[2][0] as string;
     expect(url).toContain("/players/by-ids?ids=1,2");
+  });
+
+  it("disables pagination buttons when at bounds", async () => {
+    const matches = [
+      {
+        id: "m1",
+        sport: "padel",
+        bestOf: 3,
+        playedAt: null,
+        location: null,
+      },
+    ];
+    const detail = {
+      participants: [
+        { side: "A" as const, playerIds: ["1"] },
+        { side: "B" as const, playerIds: ["2"] },
+      ],
+    };
+    const fetchMock = vi
+      .fn()
+      // list matches
+      .mockResolvedValueOnce({ ok: true, json: async () => matches })
+      // match detail
+      .mockResolvedValueOnce({ ok: true, json: async () => detail })
+      // players by ids
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+    // @ts-expect-error override for test
+    global.fetch = fetchMock;
+
+    const page = await MatchesPage();
+    render(page);
+
+    const prev = screen.getByText("Previous");
+    const next = screen.getByText("Next");
+    expect(prev.getAttribute("aria-disabled")).toBe("true");
+    expect(next.getAttribute("aria-disabled")).toBe("true");
   });
 });


### PR DESCRIPTION
## Summary
- add limit/offset query params to matches fetch
- add previous/next navigation with disabled states
- test pagination behaviour

## Testing
- `npm test --prefix apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68b465d315908323b73b8e1d3888eecc