### PR TITLE
refactor: initialize form error as nullable

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -25,7 +25,7 @@ export default function RecordSportPage() {
   const [bestOf, setBestOf] = useState(3);
   const [playedAt, setPlayedAt] = useState("");
   const [location, setLocation] = useState("");
-  const [formError, setFormError] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -60,7 +60,7 @@ export default function RecordSportPage() {
   }
 
   async function submit() {
-    setFormError("");
+    setFormError(null);
     setSubmitting(true);
     try {
       const parsedSets = isPadel


### PR DESCRIPTION
## Summary
- init record form error state as nullable
- reset form error to null before submitting match

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5046a89cc83238537ec71e518edb0