### PR TITLE
Reorder imports in auth router

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,6 @@
 import os
-import uuid
 import hashlib
+import uuid
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Header
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- reorder standard library imports in auth router

## Testing
- `ruff check backend/app/routers/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50906c848832383e78389c2a4c2f0