### PR TITLE
Validate player name characters

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 
+const NAME_REGEX = /^[A-Za-z0-9 '-]{1,50}$/;
+
 interface Player {
   id: string;
   name: string;
@@ -18,6 +20,9 @@ export default function PlayersPage() {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const trimmedName = name.trim();
+  const nameIsValid = NAME_REGEX.test(trimmedName);
 
   async function load() {
     setError(null);
@@ -79,9 +84,7 @@ export default function PlayersPage() {
   }, [players]);
 
   async function create() {
-    const trimmed = name.trim();
-    if (!trimmed) {
-      setError("Name cannot be empty");
+    if (!nameIsValid) {
       return;
     }
     setError(null);
@@ -89,7 +92,7 @@ export default function PlayersPage() {
       const res = await apiFetch("/v0/players", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: trimmed }),
+        body: JSON.stringify({ name: trimmedName }),
       });
       if (!res.ok) {
         const data = (await res.json().catch(() => null)) as
@@ -148,10 +151,16 @@ export default function PlayersPage() {
         onChange={(e) => setName(e.target.value)}
         placeholder="name"
       />
+      {!nameIsValid && trimmedName !== "" && (
+        <div className="text-red-500 mt-2">
+          Name must be 1-50 characters and contain only letters,
+          numbers, spaces, hyphens, or apostrophes.
+        </div>
+      )}
       <button
-      className="button"
-      onClick={create}
-      disabled={name.trim() === ""}
+        className="button"
+        onClick={create}
+        disabled={!nameIsValid}
       >
         Add
       </button>

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from typing import List, Literal, Optional, Tuple
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # Basic DTOs
 class SportOut(BaseModel):
@@ -14,7 +14,9 @@ class RuleSetOut(BaseModel):
     config: dict
 
 class PlayerCreate(BaseModel):
-    name: str
+    name: str = Field(
+        ..., min_length=1, max_length=50, pattern=r"^[A-Za-z0-9 '-]+$"
+    )
     club_id: Optional[str] = None
 
 class PlayerOut(BaseModel):
@@ -27,6 +29,10 @@ class PlayerListOut(BaseModel):
     total: int
     limit: int
     offset: int
+
+class PlayerNameOut(BaseModel):
+    id: str
+    name: str
 
 class LeaderboardEntryOut(BaseModel):
     rank: int

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -104,3 +104,9 @@ def test_delete_player_soft_delete() -> None:
             assert p is not None and p.deleted_at is not None
 
     asyncio.run(check_deleted())
+
+
+def test_create_player_invalid_name() -> None:
+    with TestClient(app) as client:
+        resp = client.post("/players", json={"name": "Bad!"})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- enforce allowed characters and length on server-side PlayerCreate schema
- add matching client-side validation with helpful error message
- test that invalid player names are rejected

## Testing
- `pytest` *(fails: KeyError: 'config', etc.)*
- `npx vitest run src/app/players/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b508fee5d4832394d5472c61fe85db