### PR TITLE
Improve home page error handling

### DIFF
--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HomePageClient from '../home-page-client';
+
+describe('HomePageClient error messages', () => {
+  it('shows sports error message', () => {
+    render(
+      <HomePageClient
+        sports={[]}
+        matches={[]}
+        sportError={true}
+        matchError={false}
+      />
+    );
+    expect(
+      screen.getByText(/Unable to load sports\. Check connection\./i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows matches error message', () => {
+    render(
+      <HomePageClient
+        sports={[]}
+        matches={[]}
+        sportError={false}
+        matchError={true}
+      />
+    );
+    expect(
+      screen.getByText(/Unable to load matches\. Check connection\./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type MouseEvent } from 'react';
+import React, { useState, type MouseEvent } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 
@@ -31,6 +31,7 @@ export default function HomePageClient({
   sportError: initialSportError,
   matchError: initialMatchError,
 }: Props) {
+  React;
   const [sports, setSports] = useState(initialSports);
   const [matches, setMatches] = useState(initialMatches);
   const [sportError, setSportError] = useState(initialSportError);
@@ -78,7 +79,7 @@ export default function HomePageClient({
         {sports.length === 0 ? (
           sportError ? (
             <p>
-              Could not load sports.{' '}
+              Unable to load sports. Check connection.{" "}
               <a href="#" onClick={retrySports}>
                 Retry
               </a>
@@ -112,7 +113,7 @@ export default function HomePageClient({
         {matches.length === 0 ? (
           matchError ? (
             <p>
-              Could not load matches.{' '}
+              Unable to load matches. Check connection.{" "}
               <a href="#" onClick={retryMatches}>
                 Retry
               </a>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -18,25 +18,20 @@ export default async function HomePage() {
   let sportError = false;
   let matchError = false;
 
-  try {
-    const r = await apiFetch('/v0/sports', { cache: 'no-store' });
-    if (r.ok) {
-      sports = (await r.json()) as Sport[];
-    } else {
-      sportError = true;
-    }
-  } catch {
+  const [sportsResult, matchesResult] = await Promise.allSettled([
+    apiFetch('/v0/sports', { cache: 'no-store' }),
+    apiFetch('/v0/matches', { cache: 'no-store' }),
+  ]);
+
+  if (sportsResult.status === 'fulfilled' && sportsResult.value.ok) {
+    sports = (await sportsResult.value.json()) as Sport[];
+  } else {
     sportError = true;
   }
 
-  try {
-    const r = await apiFetch('/v0/matches', { cache: 'no-store' });
-    if (r.ok) {
-      matches = (await r.json()) as MatchRow[];
-    } else {
-      matchError = true;
-    }
-  } catch {
+  if (matchesResult.status === 'fulfilled' && matchesResult.value.ok) {
+    matches = (await matchesResult.value.json()) as MatchRow[];
+  } else {
     matchError = true;
   }
 


### PR DESCRIPTION
## Summary
- handle sports and matches fetches separately on the home page
- show friendly error messages when sports or match loading fails
- add tests for the home page error messaging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5090009708323a6524050952a8905