### PR TITLE
Default local API base URL and document dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,24 +162,41 @@ Prereqs: Node 20, Python 3.12, Docker
 # Postgres (local)
 docker compose up -d postgres
 
-# Backend
+### Backend
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 alembic upgrade head
 python seed.py  # adds default sports, rulesets, demo club/player
-uvicorn app.main:app --reload  # http://localhost:8000, docs at /docs
+
+### Web
+cd ../apps/web
+npm install
+
+### Run backend & frontend together
+Start the API and UI in separate terminals:
+
+**Terminal 1 - Backend**
+
+```
+cd backend
+source .venv/bin/activate
+uvicorn app.main:app --reload  # http://localhost:8000/api, docs at /api/docs
+```
+
+**Terminal 2 - Frontend**
+
+```
+cd apps/web
+# INTERNAL_API_BASE_URL defaults to http://localhost:8000/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api npm run dev  # http://localhost:3000
+```
 
 Seed inserts:
 - Sports: Padel, Bowling
 - RuleSets: padel-default, padel-golden, bowling-standard
 - Club: Demo Club (id: demo-club)
 - Player: Demo Player (id: demo-player, club: Demo Club)
-
-# Web
-cd ../../apps/web
-npm install
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api npm run dev  # http://localhost:3000
 
 Self-hosting (single VPS, low cost)
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,7 +2,7 @@
 export function apiBase(): string {
   const server = typeof window === 'undefined';
   const base = server
-    ? process.env.INTERNAL_API_BASE_URL || 'http://backend:8000/api'
+    ? process.env.INTERNAL_API_BASE_URL || 'http://localhost:8000/api'
     : process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
   return base.endsWith('/') ? base.slice(0, -1) : base;
 }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,6 +22,10 @@ class PlayerOut(BaseModel):
     name: str
     club_id: Optional[str] = None
 
+class PlayerNameOut(BaseModel):
+    id: str
+    name: str
+
 class PlayerListOut(BaseModel):
     players: List[PlayerOut]
     total: int


### PR DESCRIPTION
## Summary
- Default INTERNAL_API_BASE_URL to `http://localhost:8000/api` for local development
- Add missing `PlayerNameOut` schema so backend can start
- Document running backend and frontend together in README

## Testing
- `npm test`
- `pytest` *(fails: KeyError and assertion errors)*
- `curl -s http://localhost:8000/api`

------
https://chatgpt.com/codex/tasks/task_e_68b51225bf508323a4f3fbf5ce9aab01