### PR TITLE
Implement padel golden point and tournament CRUD endpoints

### DIFF
--- a/backend/app/routers/tournaments.py
+++ b/backend/app/routers/tournaments.py
@@ -1,7 +1,72 @@
-from fastapi import APIRouter
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..models import Tournament, Stage
+from ..schemas import TournamentCreate, TournamentOut, StageCreate, StageOut
 
 router = APIRouter()
 
-@router.get("/tournaments")
-async def list_tournaments():
-    return []
+
+@router.post("/tournaments", response_model=TournamentOut)
+async def create_tournament(
+    body: TournamentCreate, session: AsyncSession = Depends(get_session)
+):
+    tid = uuid.uuid4().hex
+    t = Tournament(id=tid, sport_id=body.sport, name=body.name, club_id=body.clubId)
+    session.add(t)
+    await session.commit()
+    return TournamentOut(id=tid, sport=body.sport, name=body.name, clubId=body.clubId)
+
+
+@router.get("/tournaments", response_model=list[TournamentOut])
+async def list_tournaments(session: AsyncSession = Depends(get_session)):
+    rows = (await session.execute(select(Tournament))).scalars().all()
+    return [
+        TournamentOut(id=t.id, sport=t.sport_id, name=t.name, clubId=t.club_id)
+        for t in rows
+    ]
+
+
+@router.get("/tournaments/{tournament_id}", response_model=TournamentOut)
+async def get_tournament(
+    tournament_id: str, session: AsyncSession = Depends(get_session)
+):
+    t = await session.get(Tournament, tournament_id)
+    if not t:
+        raise HTTPException(status_code=404, detail="tournament not found")
+    return TournamentOut(id=t.id, sport=t.sport_id, name=t.name, clubId=t.club_id)
+
+
+@router.post("/tournaments/{tournament_id}/stages", response_model=StageOut)
+async def create_stage(
+    tournament_id: str, body: StageCreate, session: AsyncSession = Depends(get_session)
+):
+    sid = uuid.uuid4().hex
+    s = Stage(id=sid, tournament_id=tournament_id, type=body.type)
+    session.add(s)
+    await session.commit()
+    return StageOut(id=sid, tournamentId=tournament_id, type=body.type)
+
+
+@router.get("/tournaments/{tournament_id}/stages", response_model=list[StageOut])
+async def list_stages(tournament_id: str, session: AsyncSession = Depends(get_session)):
+    rows = (
+        await session.execute(select(Stage).where(Stage.tournament_id == tournament_id))
+    ).scalars().all()
+    return [StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type) for s in rows]
+
+
+@router.get(
+    "/tournaments/{tournament_id}/stages/{stage_id}", response_model=StageOut
+)
+async def get_stage(
+    tournament_id: str, stage_id: str, session: AsyncSession = Depends(get_session)
+):
+    s = await session.get(Stage, stage_id)
+    if not s or s.tournament_id != tournament_id:
+        raise HTTPException(status_code=404, detail="stage not found")
+    return StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type)
+

--- a/backend/app/scoring/padel.py
+++ b/backend/app/scoring/padel.py
@@ -17,6 +17,7 @@ def init_state(config: Dict) -> Dict:
         "config": {
             "tiebreakTo": config.get("tiebreakTo", 7),
             "sets": config.get("sets"),
+            "goldenPoint": config.get("goldenPoint", False),
         },
         "points": {"A": 0, "B": 0},
         "games": {"A": 0, "B": 0},
@@ -38,6 +39,7 @@ def apply(event: Dict, state: Dict) -> Dict:
     cfg = state["config"]
     tiebreak_to = cfg.get("tiebreakTo", 7)
     best_of = cfg.get("sets")
+    golden_point = cfg.get("goldenPoint", False)
     sets_needed = best_of // 2 + 1 if best_of else None
 
     # Stop processing if the match is already decided.
@@ -57,7 +59,7 @@ def apply(event: Dict, state: Dict) -> Dict:
             state["tiebreak"] = False
         return state
 
-    if ps >= 4 and ps - po >= 2:
+    if ps >= 4 and (ps - po >= 2 or (golden_point and po >= 3)):
         state["games"][side] += 1
         state["points"]["A"] = state["points"]["B"] = 0
         gs, go = state["games"][side], state["games"][opp]
@@ -78,6 +80,7 @@ def summary(state: Dict) -> Dict:
         "points": state["points"],
         "games": state["games"],
         "sets": state["sets"],
+        "config": state["config"],
     }
 
 


### PR DESCRIPTION
## Summary
- support golden point rule in padel scoring and expose config in summary
- add basic tournament and stage CRUD API endpoints

## Testing
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68b517cc89e483239ec650250da010da