### PR TITLE
refactor(web): allow metadata in layout

### DIFF
--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+  return (
+    <header className="nav">
+      <button
+        className="hamburger"
+        aria-label="Toggle navigation"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        ☰
+      </button>
+      <nav className={`nav-links ${open ? 'open' : ''}`}>
+        <ul>
+          <li>
+            <Link href="/">Home</Link>
+          </li>
+          <li>
+            <Link href="/players">Players</Link>
+          </li>
+          <li>
+            <Link href="/matches">Matches</Link>
+          </li>
+          <li>
+            <Link href="/record">Record</Link>
+          </li>
+          <li>
+            <Link href="/leaderboard">Leaderboard</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,6 @@
-'use client';
-
 // apps/web/src/app/layout.tsx
 import './globals.css';
-import Link from 'next/link';
-import { useState } from 'react';
+import Header from './header';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -15,38 +12,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
   return (
     <html lang="en">
       <body>
-        <header className="nav">
-          <button
-            className="hamburger"
-            aria-label="Toggle navigation"
-            onClick={() => setOpen((prev) => !prev)}
-          >
-            ☰
-          </button>
-          <nav className={`nav-links ${open ? 'open' : ''}`}>
-            <ul>
-              <li>
-                <Link href="/">Home</Link>
-              </li>
-              <li>
-                <Link href="/players">Players</Link>
-              </li>
-              <li>
-                <Link href="/matches">Matches</Link>
-              </li>
-              <li>
-                <Link href="/record">Record</Link>
-              </li>
-              <li>
-                <Link href="/leaderboard">Leaderboard</Link>
-              </li>
-            </ul>
-          </nav>
-        </header>
+        <Header />
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- move navigation UI into new `Header` client component
- expose metadata from server `RootLayout`

## Testing
- `npm test` *(fails: ReferenceError: the is not defined)*
- `npm run lint`
- `npm run build` *(fails: Type error in src/app/matches/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b51c39add08323a22e598473aa658f