### PR TITLE
Fix Next.js matches page types and remove stray tokens

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -47,7 +47,7 @@ describe("MatchesPage", () => {
     // @ts-expect-error override for test
     global.fetch = fetchMock;
 
-    const page = await MatchesPage();
+    const page = await MatchesPage({ searchParams: {} });
     render(page);
 
     await screen.findByText("Alice vs Bob");
@@ -85,7 +85,7 @@ describe("MatchesPage", () => {
     // @ts-expect-error override for test
     global.fetch = fetchMock;
 
-    const page = await MatchesPage();
+    const page = await MatchesPage({ searchParams: {} });
     render(page);
 
     const prev = screen.getByText("Previous");

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -97,7 +97,7 @@ export default async function MatchesPage({
   searchParams = {},
 }: {
   searchParams?: Record<string, string | string[] | undefined>;
-} = {}) {
+}) {
   const limit = Number(searchParams.limit) || 25;
   const offset = Number(searchParams.offset) || 0;
 

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -38,9 +38,7 @@ async function getPlayer(id: string): Promise<Player> {
     cache: "no-store",
   } as RequestInit);
   // apiFetch returns a Response in this app
-  // @ts-expect-error next line can throw when non-OK
   if (!res.ok) throw new Error("player");
-  // @ts-expect-error Response.json type mismatch handled
   return (await res.json()) as Player;
 }
 
@@ -48,9 +46,7 @@ async function getMatches(playerId: string): Promise<EnrichedMatch[]> {
   const r = await apiFetch(`/v0/matches?playerId=${encodeURIComponent(playerId)}`, {
     cache: "no-store",
   } as RequestInit);
-  // @ts-expect-error allow non-OK responses to return empty list
   if (!r.ok) return [];
-  // @ts-expect-error Response.json typing
   const rows = (await r.json()) as MatchRow[];
 
   // Load details for participants and summaries
@@ -59,9 +55,7 @@ async function getMatches(playerId: string): Promise<EnrichedMatch[]> {
       const resp = await apiFetch(`/v0/matches/${encodeURIComponent(m.id)}`, {
         cache: "no-store",
       } as RequestInit);
-      // @ts-expect-error non-OK responses throw
       if (!resp.ok) throw new Error(`match ${m.id}`);
-      // @ts-expect-error Response.json typing
       return { row: m, detail: (await resp.json()) as MatchDetail };
     })
   );
@@ -81,9 +75,7 @@ async function getMatches(playerId: string): Promise<EnrichedMatch[]> {
       const resp = await apiFetch(`/v0/players/${encodeURIComponent(pid)}`, {
         cache: "no-store",
       } as RequestInit);
-      // @ts-expect-error Response.ok type narrowing
       if (resp.ok) {
-        // @ts-expect-error Response.json typing
         const j = (await resp.json()) as { id: string; name: string };
         idToName.set(pid, j.name);
       }

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -15,7 +15,7 @@ export default function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [recentMatches, setRecentMatches] =
     useState<Record<string, string | null>>({});
-  the [name, setName] = useState("");
+  const [name, setName] = useState("");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/lib/useMatchStream.ts
+++ b/apps/web/src/lib/useMatchStream.ts
@@ -24,7 +24,7 @@ function buildWsUrl(path: string): string {
 
 export function useMatchStream(id: string) {
   const [event, setEvent] = useState<MatchEvent | null>(null);
-  the [connected, setConnected] = useState(false);
+  const [connected, setConnected] = useState(false);
   const [fallback, setFallback] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Remove optional page props default to satisfy Next.js type constraints
- Update match page tests and clean up leftover tokens
- Drop unnecessary `@ts-expect-error` directives and fix typos in player-related code

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b51e19e6e883238d01e368007fca36