### PR TITLE
fix: handle missing search params in matches page

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -93,11 +93,12 @@ function formatSummary(s?: MatchDetail["summary"]): string {
   return "";
 }
 
-export default async function MatchesPage({
-  searchParams = {},
-}: {
-  searchParams?: Record<string, string | string[] | undefined>;
-}) {
+export default async function MatchesPage(
+  props: {
+    searchParams?: Record<string, string | string[] | undefined>;
+  }
+) {
+  const searchParams = props.searchParams ?? {};
   const limit = Number(searchParams.limit) || 25;
   const offset = Number(searchParams.offset) || 0;
 


### PR DESCRIPTION
## Summary
- avoid TypeScript constraint error by handling optional search params in matches page

## Testing
- `npm test -- --run`
- `npm run build` *(fails: ECONNREFUSED when fetching backend during static page generation)*

------
https://chatgpt.com/codex/tasks/task_e_68b522219c5c83239a57a0b5eebdef6a