### PR TITLE
Round leaderboard ratings for display

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -184,7 +184,7 @@ export default function Leaderboard({ sport }: Props) {
                   <td style={{ padding: "4px 16px 4px 0" }}>{row.sport}</td>
                 )}
                 <td style={{ padding: "4px 16px 4px 0" }}>
-                  {row.rating ?? "—"}
+                  {row.rating != null ? Math.round(row.rating) : "—"}
                 </td>
                 <td style={{ padding: "4px 16px 4px 0" }}>{row.setsWon ?? "—"}</td>
                 <td style={{ padding: "4px 0" }}>{row.setsLost ?? "—"}</td>

--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -102,7 +102,7 @@ export default function RankingsPage() {
               <tr key={l.playerId}>
                 <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{i + 1}</td>
                 <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{l.playerName}</td>
-                <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{l.rating}</td>
+                <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{Math.round(l.rating)}</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- Round rating values on leaderboard and rankings pages to display whole numbers

## Testing
- `cd backend && pytest`
- `cd apps/web && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b547ca80508323839e93cdd8f4c240