### PR TITLE
feat: add tennis scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Status & Scope
 
 Monorepo: apps/web (Next.js) + backend (FastAPI) + packages/* (shared)
 
-Implement now: Padel, Bowling (DB → API → UI)
+Implement now: Padel, Bowling, Tennis (DB → API → UI)
 
-Later: Tennis, Disc Golf, cross-sport normalization, PWA, OAuth, notifications
+Later: Disc Golf, cross-sport normalization, PWA, OAuth, notifications
 
 Project Decisions (locked for MVP)
 
@@ -34,6 +34,8 @@ Scoring contract: init_state(config) → dict, apply(event, state) → dict, sum
 Padel default config: { goldenPoint: false, tiebreakTo: 7, sets: 3 }
 
 Bowling default config: { frames: 10, tenthFrameBonus: true }
+
+Tennis default config: { tiebreakTo: 7, sets: 3 }
 
 Tournaments (MVP): Round-robin + Single-elimination; seeding=random; RR tiebreakers = H2H → differential → wins
 
@@ -77,7 +79,7 @@ Bowling (included)
 
 Data Model (abridged)
 
-Sport(id, name) → "padel" | "bowling"
+Sport(id, name) → "padel" | "bowling" | "tennis"
 
 RuleSet(id, sport_id, name, config JSON)
 
@@ -193,8 +195,8 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api npm run dev  # http://localho
 ```
 
 Seed inserts:
-- Sports: Padel, Bowling
-- RuleSets: padel-default, padel-golden, bowling-standard
+  - Sports: Padel, Bowling, Tennis
+  - RuleSets: padel-default, padel-golden, bowling-standard, tennis-standard
 - Club: Demo Club (id: demo-club)
 - Player: Demo Player (id: demo-player, club: Demo Club)
 

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -17,11 +17,14 @@ export default function RecordSportPage() {
   const params = useParams();
   const sport = typeof params.sport === "string" ? params.sport : "";
   const isPadel = sport === "padel";
+  const isTennis = sport === "tennis";
+  const usesSets = isPadel || isTennis;
 
   const [players, setPlayers] = useState<Player[]>([]);
   const [ids, setIds] = useState({ a1: "", a2: "", b1: "", b2: "" });
+  const [doubles, setDoubles] = useState(isPadel);
   const [sets, setSets] = useState<Array<{ A: string; B: string }>>(
-    isPadel ? [{ A: "", B: "" }] : []
+    usesSets ? [{ A: "", B: "" }] : []
   );
   const [bestOf, setBestOf] = useState(3);
   const [playedAt, setPlayedAt] = useState("");
@@ -64,7 +67,7 @@ export default function RecordSportPage() {
     setFormError(null);
     setSubmitting(true);
     try {
-      const parsedSets = isPadel
+      const parsedSets = usesSets
         ? sets
             .map(
               (s) => [parseInt(s.A, 10), parseInt(s.B, 10)] as [number, number]
@@ -72,17 +75,17 @@ export default function RecordSportPage() {
             .filter(([a, b]) => Number.isFinite(a) && Number.isFinite(b))
         : [];
 
-      if (isPadel && parsedSets.length === 0) {
+      if (usesSets && parsedSets.length === 0) {
         setFormError("Please enter at least one completed set score.");
         return;
       }
 
-      const requiredIds = isPadel
+      const requiredIds = doubles
         ? [ids.a1, ids.a2, ids.b1, ids.b2]
         : [ids.a1, ids.b1];
       if (!requiredIds.every(Boolean)) {
         setFormError(
-          isPadel
+          doubles
             ? "Please select all four players."
             : "Please select at least one player per side."
         );
@@ -106,7 +109,7 @@ export default function RecordSportPage() {
         playedAt: playedAt ? `${playedAt}T00:00:00` : undefined,
         location: location || undefined,
       };
-      if (isPadel) {
+      if (usesSets) {
         body.bestOf = bestOf;
       }
 
@@ -119,19 +122,19 @@ export default function RecordSportPage() {
         setFormError("Failed to create match.");
         return;
       }
-      const { id } = (await createRes.json()) as { id: string };
+        const { id } = (await createRes.json()) as { id: string };
 
-      if (isPadel && parsedSets.length > 0) {
-        const setsRes = await fetch(`${base}/v0/matches/${id}/sets`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sets: parsedSets }),
-        });
-        if (!setsRes.ok) {
-          setFormError("Failed to submit set scores.");
-          return;
+        if (usesSets && parsedSets.length > 0) {
+          const setsRes = await fetch(`${base}/v0/matches/${id}/sets`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sets: parsedSets }),
+          });
+          if (!setsRes.ok) {
+            setFormError("Failed to submit set scores.");
+            return;
+          }
         }
-      }
 
       router.push(`/matches/${id}`);
     } finally {
@@ -149,113 +152,129 @@ export default function RecordSportPage() {
       
       {formError && <p className="error">{formError}</p>}
 
-      <section className="section">
-        <h2 className="heading">Players</h2>
-        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
-          <div>
+        <section className="section">
+          <h2 className="heading">Players</h2>
+          {isTennis && (
             <label
-              htmlFor="player-a1"
-              style={{ display: "flex", flexDirection: "column" }}
+              style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 8 }}
             >
-              Player A1
-              <select
-                id="player-a1"
-                className="input"
-                value={ids.a1}
-                onChange={(e) => onIdChange("a1", e.target.value)}
-              >
-                <option value="">Player A1</option>
-                {players.map((p) => (
-                  <option
-                    key={p.id}
-                    value={p.id}
-                    disabled={isUsedElsewhere(p.id, "a1")}
-                  >
-                    {p.name}
-                  </option>
-                ))}
-              </select>
+              <input
+                type="checkbox"
+                checked={doubles}
+                onChange={(e) => setDoubles(e.target.checked)}
+              />
+              Doubles
             </label>
-          </div>
-          <div>
-            <label
-              htmlFor="player-a2"
-              style={{ display: "flex", flexDirection: "column" }}
-            >
-              Player A2
-              <select
-                id="player-a2"
-                className="input"
-                value={ids.a2}
-                onChange={(e) => onIdChange("a2", e.target.value)}
+          )}
+          <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
+            <div>
+              <label
+                htmlFor="player-a1"
+                style={{ display: "flex", flexDirection: "column" }}
               >
-                <option value="">Player A2</option>
-                {players.map((p) => (
-                  <option
-                    key={p.id}
-                    value={p.id}
-                    disabled={isUsedElsewhere(p.id, "a2")}
-                  >
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-          <div>
-            <label
-              htmlFor="player-b1"
-              style={{ display: "flex", flexDirection: "column" }}
-            >
-              Player B1
-              <select
-                id="player-b1"
-                className="input"
-                value={ids.b1}
-                onChange={(e) => onIdChange("b1", e.target.value)}
+                {doubles ? "Player A1" : "Player A"}
+                <select
+                  id="player-a1"
+                  className="input"
+                  value={ids.a1}
+                  onChange={(e) => onIdChange("a1", e.target.value)}
+                >
+                  <option value="">{doubles ? "Player A1" : "Player A"}</option>
+                  {players.map((p) => (
+                    <option
+                      key={p.id}
+                      value={p.id}
+                      disabled={isUsedElsewhere(p.id, "a1")}
+                    >
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div>
+              <label
+                htmlFor="player-b1"
+                style={{ display: "flex", flexDirection: "column" }}
               >
-                <option value="">Player B1</option>
-                {players.map((p) => (
-                  <option
-                    key={p.id}
-                    value={p.id}
-                    disabled={isUsedElsewhere(p.id, "b1")}
+                {doubles ? "Player B1" : "Player B"}
+                <select
+                  id="player-b1"
+                  className="input"
+                  value={ids.b1}
+                  onChange={(e) => onIdChange("b1", e.target.value)}
+                >
+                  <option value="">{doubles ? "Player B1" : "Player B"}</option>
+                  {players.map((p) => (
+                    <option
+                      key={p.id}
+                      value={p.id}
+                      disabled={isUsedElsewhere(p.id, "b1")}
+                    >
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {doubles && (
+              <>
+                <div>
+                  <label
+                    htmlFor="player-a2"
+                    style={{ display: "flex", flexDirection: "column" }}
                   >
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-          <div>
-            <label
-              htmlFor="player-b2"
-              style={{ display: "flex", flexDirection: "column" }}
-            >
-              Player B2
-              <select
-                id="player-b2"
-                className="input"
-                value={ids.b2}
-                onChange={(e) => onIdChange("b2", e.target.value)}
-              >
-                <option value="">Player B2</option>
-                {players.map((p) => (
-                  <option
-                    key={p.id}
-                    value={p.id}
-                    disabled={isUsedElsewhere(p.id, "b2")}
+                    Player A2
+                    <select
+                      id="player-a2"
+                      className="input"
+                      value={ids.a2}
+                      onChange={(e) => onIdChange("a2", e.target.value)}
+                    >
+                      <option value="">Player A2</option>
+                      {players.map((p) => (
+                        <option
+                          key={p.id}
+                          value={p.id}
+                          disabled={isUsedElsewhere(p.id, "a2")}
+                        >
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <div>
+                  <label
+                    htmlFor="player-b2"
+                    style={{ display: "flex", flexDirection: "column" }}
                   >
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            </label>
+                    Player B2
+                    <select
+                      id="player-b2"
+                      className="input"
+                      value={ids.b2}
+                      onChange={(e) => onIdChange("b2", e.target.value)}
+                    >
+                      <option value="">Player B2</option>
+                      {players.map((p) => (
+                        <option
+                          key={p.id}
+                          value={p.id}
+                          disabled={isUsedElsewhere(p.id, "b2")}
+                        >
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              </>
+            )}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {isPadel && (
+        {usesSets && (
         <section className="section">
           <h2 className="heading">Sets</h2>
           <div style={{ display: "grid", gap: 8 }}>
@@ -303,7 +322,7 @@ export default function RecordSportPage() {
       <section className="section">
         <h2 className="heading">Details</h2>
         <div style={{ display: "flex", gap: 8 }}>
-          {isPadel && (
+            {usesSets && (
             <label
               htmlFor="best-of"
               style={{ display: "flex", flexDirection: "column" }}

--- a/backend/app/scoring/tennis.py
+++ b/backend/app/scoring/tennis.py
@@ -1,0 +1,108 @@
+"""Tennis scoring engine.
+Tracks points → games → sets with optional tiebreaks."""
+
+from typing import Dict
+
+
+def init_state(config: Dict) -> Dict:
+    """Initialise the scoreboard state."""
+    return {
+        "config": {
+            "tiebreakTo": config.get("tiebreakTo", 7),
+            "sets": config.get("sets"),
+        },
+        "points": {"A": 0, "B": 0},
+        "games": {"A": 0, "B": 0},
+        "sets": {"A": 0, "B": 0},
+        "tiebreak": False,
+    }
+
+
+def _other(side: str) -> str:
+    return "B" if side == "A" else "A"
+
+
+def apply(event: Dict, state: Dict) -> Dict:
+    if event.get("type") != "POINT" or event.get("by") not in ("A", "B"):
+        raise ValueError("invalid tennis event")
+    side = event["by"]
+    opp = _other(side)
+
+    cfg = state["config"]
+    tiebreak_to = cfg.get("tiebreakTo", 7)
+    best_of = cfg.get("sets")
+    sets_needed = best_of // 2 + 1 if best_of else None
+
+    # Stop processing if the match is already decided.
+    if sets_needed and (
+        state["sets"]["A"] >= sets_needed or state["sets"]["B"] >= sets_needed
+    ):
+        return state
+
+    state["points"][side] += 1
+    ps, po = state["points"][side], state["points"][opp]
+
+    if state.get("tiebreak"):
+        if ps >= tiebreak_to and ps - po >= 2:
+            state["sets"][side] += 1
+            state["points"]["A"] = state["points"]["B"] = 0
+            state["games"]["A"] = state["games"]["B"] = 0
+            state["tiebreak"] = False
+        return state
+
+    if ps >= 4 and ps - po >= 2:
+        state["games"][side] += 1
+        state["points"]["A"] = state["points"]["B"] = 0
+        gs, go = state["games"][side], state["games"][opp]
+        if (
+            tiebreak_to
+            and state["games"]["A"] == 6
+            and state["games"]["B"] == 6
+        ):
+            state["tiebreak"] = True
+        elif gs >= 6 and gs - go >= 2:
+            state["sets"][side] += 1
+            state["games"]["A"] = state["games"]["B"] = 0
+    return state
+
+
+def summary(state: Dict) -> Dict:
+    return {
+        "points": state["points"],
+        "games": state["games"],
+        "sets": state["sets"],
+        "config": state["config"],
+    }
+
+
+def record_sets(set_scores, state=None):
+    """Generate point events to reach the provided set scores."""
+    state = state or init_state({})
+    events = []
+
+    for ga, gb in set_scores:
+        if ga == gb:
+            raise ValueError("sets cannot be tied")
+        winner = "A" if ga > gb else "B"
+        loser = _other(winner)
+        win_games = ga if winner == "A" else gb
+        lose_games = gb if winner == "A" else ga
+
+        for _ in range(win_games - 1):
+            for _ in range(4):
+                ev = {"type": "POINT", "by": winner}
+                events.append(ev)
+                state = apply(ev, state)
+
+        for _ in range(lose_games):
+            for _ in range(4):
+                ev = {"type": "POINT", "by": loser}
+                events.append(ev)
+                state = apply(ev, state)
+
+        for _ in range(4):
+            ev = {"type": "POINT", "by": winner}
+            events.append(ev)
+            state = apply(ev, state)
+
+    return events, state

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -18,7 +18,7 @@ async def main():
     async with Session() as s:
         existing = (await s.execute(select(Sport))).scalars().all()
         have = {x.id for x in existing}
-        for sid, name in [("padel", "Padel"), ("bowling", "Bowling")]:
+        for sid, name in [("padel", "Padel"), ("bowling", "Bowling"), ("tennis", "Tennis")]:
             if sid not in have:
                 s.add(Sport(id=sid, name=name))
         await s.commit()
@@ -45,6 +45,12 @@ async def main():
                 sport_id="bowling",
                 name="Bowling standard",
                 config={"frames": 10, "tenthFrameBonus": True},
+            ),
+            RuleSet(
+                id="tennis-standard",
+                sport_id="tennis",
+                name="Tennis standard",
+                config={"tiebreakTo": 7, "sets": 3},
             ),
         ]
         for rs in rulesets:

--- a/backend/tests/scoring/test_tennis.py
+++ b/backend/tests/scoring/test_tennis.py
@@ -1,0 +1,60 @@
+import os, sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from app.scoring import tennis
+
+
+def _score_game(side, state):
+    for _ in range(4):
+        state = tennis.apply({"type": "POINT", "by": side}, state)
+    return state
+
+
+def test_tennis_basic_game_win():
+    state = tennis.init_state({})
+    state = _score_game("A", state)
+    assert state["games"] == {"A": 1, "B": 0}
+    assert state["points"] == {"A": 0, "B": 0}
+
+
+def test_tennis_tiebreak():
+    state = tennis.init_state({"tiebreakTo": 7})
+    for _ in range(6):
+        state = _score_game("A", state)
+        state = _score_game("B", state)
+    assert state["games"] == {"A": 6, "B": 6}
+    assert state["tiebreak"] is True
+
+    for _ in range(6):
+        state = tennis.apply({"type": "POINT", "by": "A"}, state)
+    for _ in range(5):
+        state = tennis.apply({"type": "POINT", "by": "B"}, state)
+    state = tennis.apply({"type": "POINT", "by": "A"}, state)
+    assert state["sets"] == {"A": 1, "B": 0}
+    assert state["games"] == {"A": 0, "B": 0}
+
+
+def test_tennis_match_stops_after_set_limit():
+    state = tennis.init_state({"sets": 3})
+    for _ in range(2):
+        for _ in range(6):
+            state = _score_game("A", state)
+    assert state["sets"]["A"] == 2
+    before = {
+        "points": dict(state["points"]),
+        "games": dict(state["games"]),
+        "sets": dict(state["sets"]),
+    }
+    state = tennis.apply({"type": "POINT", "by": "A"}, state)
+    assert state["points"] == before["points"]
+    assert state["games"] == before["games"]
+    assert state["sets"] == before["sets"]
+
+
+def test_tennis_no_set_limit_by_default():
+    state = tennis.init_state({})
+    for _ in range(3):
+        for _ in range(6):
+            state = _score_game("A", state)
+    assert state["sets"]["A"] == 3


### PR DESCRIPTION
## Summary
- implement tennis scoring engine with tiebreaks and set/game logic
- seed tennis sport and default ruleset
- enable tennis match recording in UI and API

## Testing
- `pytest backend/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b542ffd19c8323bdc8b013a5957e93