### PR TITLE
Fix tennis tiebreak handling in record_sets

### DIFF
--- a/backend/app/scoring/tennis.py
+++ b/backend/app/scoring/tennis.py
@@ -87,22 +87,30 @@ def record_sets(set_scores, state=None):
         loser = _other(winner)
         win_games = ga if winner == "A" else gb
         lose_games = gb if winner == "A" else ga
+        min_games = min(win_games, lose_games)
 
-        for _ in range(win_games - 1):
+        # Alternate games between winner and loser to avoid premature set wins
+        for _ in range(min_games):
             for _ in range(4):
                 ev = {"type": "POINT", "by": winner}
                 events.append(ev)
                 state = apply(ev, state)
-
-        for _ in range(lose_games):
             for _ in range(4):
                 ev = {"type": "POINT", "by": loser}
                 events.append(ev)
                 state = apply(ev, state)
 
-        for _ in range(4):
-            ev = {"type": "POINT", "by": winner}
-            events.append(ev)
-            state = apply(ev, state)
+        if win_games == 7 and lose_games == 6:
+            tiebreak_to = state["config"].get("tiebreakTo", 7)
+            for _ in range(tiebreak_to):
+                ev = {"type": "POINT", "by": winner}
+                events.append(ev)
+                state = apply(ev, state)
+        else:
+            for _ in range(win_games - min_games):
+                for _ in range(4):
+                    ev = {"type": "POINT", "by": winner}
+                    events.append(ev)
+                    state = apply(ev, state)
 
     return events, state

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -2,7 +2,7 @@ import os, sys
 import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from app.scoring import padel, bowling
+from app.scoring import padel, bowling, tennis
 from app.services import validate_set_scores, ValidationError
 
 
@@ -86,6 +86,12 @@ def test_record_sets():
     events, state = padel.record_sets([(6, 4), (6, 2)])
     assert state["sets"]["A"] == 2
     assert len(events) == (6 + 4 + 6 + 2) * 4
+
+
+def test_tennis_record_sets_tiebreak():
+    events, state = tennis.record_sets([(7, 6)])
+    assert state["sets"] == {"A": 1, "B": 0}
+    assert len(events) == (12 * 4) + state["config"].get("tiebreakTo", 7)
 
 
 def test_validate_set_scores_negative():


### PR DESCRIPTION
## Summary
- interleave games and simulate tiebreak points in tennis `record_sets`
- add regression test for 7-6 tennis set

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b594a55f208323bfad2b69971ae8fb