### PR TITLE
Add optional match time

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -69,6 +69,13 @@ export default async function MatchDetailPage({
     sideNames[p.side] = names;
   }
 
+  const playedAtDate = match.playedAt ? new Date(match.playedAt) : null;
+  const playedAtStr = playedAtDate
+    ? playedAtDate.getHours() || playedAtDate.getMinutes() || playedAtDate.getSeconds() || playedAtDate.getMilliseconds()
+      ? playedAtDate.toLocaleString()
+      : playedAtDate.toLocaleDateString()
+    : "";
+
   return (
     <main className="container">
       <div className="text-sm">
@@ -85,7 +92,7 @@ export default async function MatchDetailPage({
         <p className="match-meta">
           {match.sport || "sport"} · {match.ruleset || "rules"} · {" "}
           {match.status || "status"}
-          {match.playedAt ? ` · ${new Date(match.playedAt).toLocaleString()}` : ""}
+          {playedAtStr ? ` · ${playedAtStr}` : ""}
           {match.location ? ` · ${match.location}` : ""}
         </p>
       </header>

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -33,6 +33,8 @@ export default function RecordSportPage() {
   const [scoreA, setScoreA] = useState("0");
   const [scoreB, setScoreB] = useState("0");
   const [error, setError] = useState<string | null>(null);
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
 
   // Padal is always doubles. Other sports default to singles unless specified.
   const [doubles, setDoubles] = useState(isPadel);
@@ -89,10 +91,16 @@ export default function RecordSportPage() {
         ];
 
     try {
+      const payload: any = { sport, participants, score: [scoreA, scoreB] };
+      if (date) {
+        payload.playedAt = new Date(
+          `${date}T${time || "00:00"}`
+        ).toISOString();
+      }
       const res = await fetch(`${base}/v0/matches`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sport, participants, score: [scoreA, scoreB] }),
+        body: JSON.stringify(payload),
       });
       if (res.ok) {
         router.push(`/matches`);
@@ -115,6 +123,21 @@ export default function RecordSportPage() {
             Doubles
           </label>
         )}
+
+        <div className="datetime">
+          <input
+            type="date"
+            aria-label="Date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+          <input
+            type="time"
+            aria-label="Time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </div>
 
         <div className="players">
           <select


### PR DESCRIPTION
## Summary
- allow entering date and time when recording a match
- include match time only if provided on match detail page

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59d00c18483238296fff46748e5a2