### PR TITLE
Add head-to-head records to player page

### DIFF
--- a/apps/web/src/app/players/[id]/head-to-head.test.ts
+++ b/apps/web/src/app/players/[id]/head-to-head.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { computeHeadToHead } from "./head-to-head";
+import type { EnrichedMatch } from "./types";
+
+const baseMatch = {
+  sport: "Tennis",
+  bestOf: null,
+  playedAt: null,
+  location: null,
+};
+
+describe("computeHeadToHead", () => {
+  it("aggregates wins and losses per opponent and sorts by encounters", () => {
+    const matches: EnrichedMatch[] = [
+      {
+        ...baseMatch,
+        id: "m1",
+        names: { A: ["Alice"], B: ["Bob"] },
+        playerIds: { A: ["1"], B: ["2"] },
+        summary: { sets: { A: 2, B: 0 } },
+      },
+      {
+        ...baseMatch,
+        id: "m2",
+        names: { A: ["Alice"], B: ["Bob"] },
+        playerIds: { A: ["1"], B: ["2"] },
+        summary: { sets: { A: 0, B: 2 } },
+      },
+      {
+        ...baseMatch,
+        id: "m3",
+        names: { A: ["Alice"], B: ["Carol"] },
+        playerIds: { A: ["1"], B: ["3"] },
+        summary: { sets: { A: 2, B: 1 } },
+      },
+    ];
+
+    const records = computeHeadToHead("1", matches);
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      opponentId: "2",
+      wins: 1,
+      losses: 1,
+      encounters: 2,
+      winRate: 0.5,
+    });
+    expect(records[1]).toMatchObject({
+      opponentId: "3",
+      wins: 1,
+      losses: 0,
+      encounters: 1,
+      winRate: 1,
+    });
+  });
+});

--- a/apps/web/src/app/players/[id]/head-to-head.tsx
+++ b/apps/web/src/app/players/[id]/head-to-head.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { EnrichedMatch, MatchSummary } from "./types";
+
+function winner(summary?: MatchSummary): "A" | "B" | null {
+  if (!summary) return null;
+  if (summary.sets) {
+    if (summary.sets.A > summary.sets.B) return "A";
+    if (summary.sets.B > summary.sets.A) return "B";
+  }
+  if (summary.games) {
+    if (summary.games.A > summary.games.B) return "A";
+    if (summary.games.B > summary.games.A) return "B";
+  }
+  if (summary.points) {
+    if (summary.points.A > summary.points.B) return "A";
+    if (summary.points.B > summary.points.A) return "B";
+  }
+  return null;
+}
+
+export type HeadToHeadRecord = {
+  opponentId: string;
+  opponentName: string;
+  wins: number;
+  losses: number;
+  encounters: number;
+  winRate: number;
+};
+
+export function computeHeadToHead(
+  playerId: string,
+  matches: EnrichedMatch[],
+): HeadToHeadRecord[] {
+  const map = new Map<string, { name: string; wins: number; losses: number }>();
+
+  for (const m of matches) {
+    const side = m.playerIds.A.includes(playerId)
+      ? "A"
+      : m.playerIds.B.includes(playerId)
+        ? "B"
+        : null;
+    if (!side) continue;
+    const oppSide = side === "A" ? "B" : "A";
+    const winSide = winner(m.summary);
+    if (!winSide) continue;
+    const playerWon = winSide === side;
+    m.playerIds[oppSide].forEach((oppId, idx) => {
+      const oppName = m.names[oppSide][idx] ?? oppId;
+      const rec = map.get(oppId) || { name: oppName, wins: 0, losses: 0 };
+      if (playerWon) rec.wins += 1; else rec.losses += 1;
+      rec.name = oppName;
+      map.set(oppId, rec);
+    });
+  }
+
+  return Array.from(map.entries())
+    .map(([opponentId, { name, wins, losses }]) => {
+      const encounters = wins + losses;
+      const winRate = encounters ? wins / encounters : 0;
+      return { opponentId, opponentName: name, wins, losses, encounters, winRate };
+    })
+    .sort((a, b) => b.encounters - a.encounters);
+}
+
+export default function HeadToHead({
+  playerId,
+  matches,
+}: {
+  playerId: string;
+  matches: EnrichedMatch[];
+}) {
+  const records = computeHeadToHead(playerId, matches);
+  if (!records.length) return null;
+  return (
+    <div className="mt-4">
+      <h2 className="heading">Head-to-Head Records</h2>
+      <table className="mt-2">
+        <thead>
+          <tr>
+            <th className="text-left">Opponent</th>
+            <th className="text-left">Record</th>
+            <th className="text-left">Win Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((r) => (
+            <tr key={r.opponentId}>
+              <td>{r.opponentName}</td>
+              <td>
+                {r.wins}-{r.losses}
+              </td>
+              <td>{Math.round(r.winRate * 100)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/players/[id]/types.ts
+++ b/apps/web/src/app/players/[id]/types.ts
@@ -1,0 +1,16 @@
+export type MatchSummary = {
+  sets?: { A: number; B: number };
+  games?: { A: number; B: number };
+  points?: { A: number; B: number };
+} | null;
+
+export type EnrichedMatch = {
+  id: string;
+  sport: string;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+  names: Record<"A" | "B", string[]>;
+  playerIds: Record<"A" | "B", string[]>;
+  summary?: MatchSummary;
+};


### PR DESCRIPTION
## Summary
- compute wins, losses and win rate vs each opponent
- show head-to-head records table on player page
- add unit test for head-to-head aggregation

## Testing
- `npm test --prefix apps/web`
- `npm run lint --prefix apps/web` *(fails: 'usesSets' is assigned a value but never used, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a145347c832388486e6bb1ca5174