### PR TITLE
Show participant names on home page

### DIFF
--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -31,4 +31,30 @@ describe('HomePageClient error messages', () => {
       screen.getByText(/Unable to load matches\. Check connection\./i)
     ).toBeInTheDocument();
   });
+
+  it('renders player names and match details link', () => {
+    render(
+      <HomePageClient
+        sports={[]}
+        matches={[
+          {
+            id: 'm1',
+            sport: 'padel',
+            bestOf: 3,
+            playedAt: null,
+            location: null,
+            names: { A: ['A1', 'A2'], B: ['B1', 'B2'] },
+          },
+        ]}
+        sportError={false}
+        matchError={false}
+      />
+    );
+    expect(
+      screen.getByText('A1 & A2 vs B1 & B2')
+    ).toBeInTheDocument();
+    const link = screen.getByText('Match details');
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/matches/m1');
+  });
 });

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -1,0 +1,68 @@
+export type MatchRow = {
+  id: string;
+  sport: string;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+};
+
+export type Participant = {
+  side: 'A' | 'B';
+  playerIds: string[];
+};
+
+export type MatchDetail = {
+  participants: Participant[];
+};
+
+export type EnrichedMatch = MatchRow & {
+  names: Record<'A' | 'B', string[]>;
+};
+
+import { apiFetch } from './api';
+
+export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
+  const details = await Promise.all(
+    rows.map(async (m) => {
+      const r = await apiFetch(`/v0/matches/${m.id}`, { cache: 'no-store' });
+      if (!r.ok) throw new Error(`Failed to load match ${m.id}`);
+      const d = (await r.json()) as MatchDetail;
+      return { row: m, detail: d };
+    })
+  );
+
+  const ids = new Set<string>();
+  for (const { detail } of details) {
+    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+  }
+
+  const idToName = new Map<string, string>();
+  const idList = Array.from(ids);
+  if (idList.length) {
+    const r = await apiFetch(
+      `/v0/players/by-ids?ids=${idList.join(',')}`,
+      { cache: 'no-store' }
+    );
+    if (r.ok) {
+      const players = (await r.json()) as {
+        id?: string;
+        name?: string;
+        playerId?: string;
+        playerName?: string;
+      }[];
+      players.forEach((p) => {
+        const pid = p.id ?? p.playerId;
+        const pname = p.name ?? p.playerName;
+        if (pid && pname) idToName.set(pid, pname);
+      });
+    }
+  }
+
+  return details.map(({ row, detail }) => {
+    const names: Record<'A' | 'B', string[]> = { A: [], B: [] };
+    for (const p of detail.participants) {
+      names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
+    }
+    return { ...row, names };
+  });
+}


### PR DESCRIPTION
## Summary
- Display match participants instead of IDs with a “Match details” link
- Fetch player names for recent matches using a shared enrichment helper
- Test rendering of player names and link

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b59c44fd4483239d5cae00b5eb2db0