### PR TITLE
feat: add player timeline and season summary

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -31,6 +31,7 @@ type MatchDetail = {
 type EnrichedMatch = MatchRow & {
   names: Record<"A" | "B", string[]>;
   summary?: MatchDetail["summary"];
+  playerSide?: "A" | "B" | null;
 };
 
 async function getPlayer(id: string): Promise<Player> {
@@ -84,10 +85,12 @@ async function getMatches(playerId: string): Promise<EnrichedMatch[]> {
 
   return details.map(({ row, detail }) => {
     const names: Record<"A" | "B", string[]> = { A: [], B: [] };
+    let playerSide: "A" | "B" | null = null;
     for (const p of detail.participants ?? []) {
       names[p.side] = (p.playerIds ?? []).map((id) => idToName.get(id) ?? id);
+      if (p.playerIds?.includes(playerId)) playerSide = p.side;
     }
-    return { ...row, names, summary: detail.summary };
+    return { ...row, names, summary: detail.summary, playerSide };
   });
 }
 
@@ -99,10 +102,43 @@ function formatSummary(s?: MatchDetail["summary"]): string {
   return "";
 }
 
+function winnerFromSummary(s?: MatchDetail["summary"]): "A" | "B" | null {
+  if (!s) return null;
+  for (const key of ["sets", "games", "points"] as const) {
+    const val = (s as any)[key] as { A?: number; B?: number } | undefined;
+    if (val && typeof val.A === "number" && typeof val.B === "number") {
+      if (val.A > val.B) return "A";
+      if (val.B > val.A) return "B";
+    }
+  }
+  return null;
+}
+
+type SeasonSummary = { season: string; wins: number; losses: number };
+
+function summariseSeasons(matches: EnrichedMatch[]): SeasonSummary[] {
+  const byYear: Record<string, { wins: number; losses: number }> = {};
+  for (const m of matches) {
+    if (!m.playedAt) continue;
+    const year = new Date(m.playedAt).getFullYear().toString();
+    if (!byYear[year]) byYear[year] = { wins: 0, losses: 0 };
+    const winner = winnerFromSummary(m.summary);
+    if (winner && m.playerSide) {
+      if (winner === m.playerSide) byYear[year].wins += 1;
+      else byYear[year].losses += 1;
+    }
+  }
+  return Object.keys(byYear)
+    .sort()
+    .map((season) => ({ season, ...byYear[season] }));
+}
+
 export default async function PlayerPage({
   params,
+  searchParams,
 }: {
   params: { id: string };
+  searchParams: { view?: string };
 }) {
   try {
     const [player, matches] = await Promise.all([
@@ -110,34 +146,91 @@ export default async function PlayerPage({
       getMatches(params.id),
     ]);
 
+    const view = searchParams?.view === "summary" ? "summary" : "timeline";
+    const seasons = summariseSeasons(matches);
+    const sortedMatches = [...matches].sort((a, b) => {
+      const da = a.playedAt ? new Date(a.playedAt).getTime() : 0;
+      const db = b.playedAt ? new Date(b.playedAt).getTime() : 0;
+      return da - db;
+    });
+
     return (
       <main className="container">
         <h1 className="heading">{player.name}</h1>
         {player.club_id && <p>Club: {player.club_id}</p>}
 
-        <h2 className="heading mt-4">Recent Matches</h2>
-        {matches.length ? (
-          <ul>
-            {matches.map((m) => (
-              <li key={m.id} className="mb-2">
-                <div>
-                  <Link href={`/matches/${m.id}`}>
-                    {m.names.A.join(" & ")} vs {m.names.B.join(" & ")}
-                  </Link>
-                </div>
-                <div className="text-sm text-gray-700">
-                  {formatSummary(m.summary)}
-                  {m.summary ? " · " : ""}
-                  {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-                  {m.playedAt ? new Date(m.playedAt).toLocaleDateString() : "—"}
-                  {" · "}
-                  {m.location ?? "—"}
-                </div>
-              </li>
-            ))}
-          </ul>
+        <nav className="mt-4 mb-4 space-x-4">
+          <Link
+            href={`/players/${params.id}?view=timeline`}
+            className={view === "timeline" ? "font-bold" : ""}
+          >
+            Timeline
+          </Link>
+          <Link
+            href={`/players/${params.id}?view=summary`}
+            className={view === "summary" ? "font-bold" : ""}
+          >
+            Season Summary
+          </Link>
+        </nav>
+
+        {view === "timeline" ? (
+          <section>
+            <h2 className="heading">Matches</h2>
+            {sortedMatches.length ? (
+              <ul>
+                {sortedMatches.map((m) => {
+                  const winner = winnerFromSummary(m.summary);
+                  const result =
+                    winner && m.playerSide
+                      ? winner === m.playerSide
+                        ? "Win"
+                        : "Loss"
+                      : "";
+                  return (
+                    <li key={m.id} className="mb-2">
+                      <div>
+                        <Link href={`/matches/${m.id}`}>
+                          {m.names.A.join(" & ")} vs {m.names.B.join(" & ")}
+                        </Link>
+                      </div>
+                      <div className="text-sm text-gray-700">
+                        {formatSummary(m.summary)}
+                        {result ? ` · ${result}` : ""}
+                        {m.summary || result ? " · " : ""}
+                        {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
+                        {m.playedAt
+                          ? new Date(m.playedAt).toLocaleDateString()
+                          : "—"}
+                        {" · "}
+                        {m.location ?? "—"}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p>No matches found.</p>
+            )}
+          </section>
         ) : (
-          <p>No matches found.</p>
+          <section>
+            <h2 className="heading">Season Summary</h2>
+            {seasons.length ? (
+              <ul>
+                {seasons.map((s) => (
+                  <li key={s.season} className="mb-2">
+                    <div className="font-semibold">{s.season}</div>
+                    <div className="text-sm text-gray-700">
+                      Wins: {s.wins} · Losses: {s.losses}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No matches found.</p>
+            )}
+          </section>
         )}
 
         <Link href="/players" className="block mt-4">


### PR DESCRIPTION
## Summary
- show match timeline with results on player page
- add per-season win/loss aggregation
- allow switching between timeline and season summary

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a147fae08323bc345c1baac7dcbb