### PR TITLE
Add migration for Player extra fields

### DIFF
--- a/backend/alembic/versions/0005_player_extra_fields.py
+++ b/backend/alembic/versions/0005_player_extra_fields.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005_player_extra_fields'
+down_revision = '0004_soft_delete_columns'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('player', sa.Column('photo_url', sa.String(), nullable=True))
+    op.add_column('player', sa.Column('location', sa.String(), nullable=True))
+    op.add_column('player', sa.Column('ranking', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('player', 'ranking')
+    op.drop_column('player', 'location')
+    op.drop_column('player', 'photo_url')


### PR DESCRIPTION
## Summary
- add Alembic migration to create photo_url, location, and ranking columns on player table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b663d925c08323aa5adf0ec33c9f56