### PR TITLE
Handle empty heatmap datasets

### DIFF
--- a/apps/web/src/components/charts/MatchHeatmap.test.ts
+++ b/apps/web/src/components/charts/MatchHeatmap.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { calculateMaxValue, HeatmapDatum } from './heatmapUtils';
+
+describe('calculateMaxValue', () => {
+  it('returns 0 for an empty dataset', () => {
+    expect(calculateMaxValue([])).toBe(0);
+  });
+
+  it('finds the highest value in the dataset', () => {
+    const data: HeatmapDatum[] = [
+      { x: 0, y: 0, v: 1 },
+      { x: 1, y: 1, v: 3 },
+    ];
+    expect(calculateMaxValue(data)).toBe(3);
+  });
+});

--- a/apps/web/src/components/charts/MatchHeatmap.tsx
+++ b/apps/web/src/components/charts/MatchHeatmap.tsx
@@ -9,6 +9,8 @@ import {
 } from 'chart.js';
 import { MatrixController, MatrixElement } from 'chartjs-chart-matrix';
 import { Chart } from 'react-chartjs-2';
+import { HeatmapDatum, calculateMaxValue } from './heatmapUtils';
+export type { HeatmapDatum } from './heatmapUtils';
 
 ChartJS.register(
   CategoryScale,
@@ -19,12 +21,6 @@ ChartJS.register(
   MatrixElement
 );
 
-export interface HeatmapDatum {
-  x: number;
-  y: number;
-  v: number;
-}
-
 export interface MatchHeatmapProps {
   data: HeatmapDatum[];
   xLabels: string[];
@@ -32,7 +28,7 @@ export interface MatchHeatmapProps {
 }
 
 export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
-  const maxV = data.reduce((m, d) => Math.max(m, d.v), 0);
+  const maxV = calculateMaxValue(data);
   const chartData = {
     datasets: [
       {

--- a/apps/web/src/components/charts/heatmapUtils.ts
+++ b/apps/web/src/components/charts/heatmapUtils.ts
@@ -1,0 +1,10 @@
+export interface HeatmapDatum {
+  x: number;
+  y: number;
+  v: number;
+}
+
+// Guard against empty datasets to avoid reduce throwing on an empty array
+export function calculateMaxValue(data: HeatmapDatum[]): number {
+  return data.length > 0 ? data.reduce((m, d) => Math.max(m, d.v), 0) : 0;
+}


### PR DESCRIPTION
## Summary
- guard heatmap max value calculation against empty data
- extract heatmap utilities and re-export type
- add tests for heatmap utility

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68b66d3c99908323b83bfbc9ceb4d318