### PR TITLE
Add migration for Player profile fields

### DIFF
--- a/backend/alembic/versions/0005_add_player_columns.py
+++ b/backend/alembic/versions/0005_add_player_columns.py
@@ -1,0 +1,17 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005_add_player_columns'
+down_revision = '0004_soft_delete_columns'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('player', sa.Column('photo_url', sa.String(), nullable=True))
+    op.add_column('player', sa.Column('location', sa.String(), nullable=True))
+    op.add_column('player', sa.Column('ranking', sa.Integer(), nullable=True))
+
+def downgrade():
+    op.drop_column('player', 'ranking')
+    op.drop_column('player', 'location')
+    op.drop_column('player', 'photo_url')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,9 @@ class Player(Base):
     user_id = Column(String, nullable=True)
     name = Column(String, nullable=False, unique=True)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
+    photo_url = Column(String, nullable=True)
+    location = Column(String, nullable=True)
+    ranking = Column(Integer, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 
 class Team(Base):

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -38,10 +38,24 @@ async def create_player(body: PlayerCreate, session: AsyncSession = Depends(get_
     if exists:
         raise PlayerAlreadyExists(body.name)
     pid = uuid.uuid4().hex
-    p = Player(id=pid, name=body.name, club_id=body.club_id)
+    p = Player(
+        id=pid,
+        name=body.name,
+        club_id=body.club_id,
+        photo_url=body.photo_url,
+        location=body.location,
+        ranking=body.ranking,
+    )
     session.add(p)
     await session.commit()
-    return PlayerOut(id=pid, name=p.name, club_id=p.club_id)
+    return PlayerOut(
+        id=pid,
+        name=p.name,
+        club_id=p.club_id,
+        photo_url=p.photo_url,
+        location=p.location,
+        ranking=p.ranking,
+    )
 
 # GET /api/v0/players
 @router.get("", response_model=PlayerListOut)
@@ -59,7 +73,17 @@ async def list_players(
     total = (await session.execute(count_stmt)).scalar()
     stmt = stmt.limit(limit).offset(offset)
     rows = (await session.execute(stmt)).scalars().all()
-    players = [PlayerOut(id=p.id, name=p.name, club_id=p.club_id) for p in rows]
+    players = [
+        PlayerOut(
+            id=p.id,
+            name=p.name,
+            club_id=p.club_id,
+            photo_url=p.photo_url,
+            location=p.location,
+            ranking=p.ranking,
+        )
+        for p in rows
+    ]
     return PlayerListOut(players=players, total=total, limit=limit, offset=offset)
 
 
@@ -80,7 +104,14 @@ async def get_player(player_id: str, session: AsyncSession = Depends(get_session
     p = await session.get(Player, player_id)
     if not p or p.deleted_at is not None:
         raise PlayerNotFound(player_id)
-    return PlayerOut(id=p.id, name=p.name, club_id=p.club_id)
+    return PlayerOut(
+        id=p.id,
+        name=p.name,
+        club_id=p.club_id,
+        photo_url=p.photo_url,
+        location=p.location,
+        ranking=p.ranking,
+    )
 
 
 # DELETE /api/v0/players/{player_id}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,11 +18,17 @@ class PlayerCreate(BaseModel):
         ..., min_length=1, max_length=50, pattern=r"^[A-Za-z0-9 '-]+$"
     )
     club_id: Optional[str] = None
+    photo_url: Optional[str] = None
+    location: Optional[str] = None
+    ranking: Optional[int] = None
 
 class PlayerOut(BaseModel):
     id: str
     name: str
     club_id: Optional[str] = None
+    photo_url: Optional[str] = None
+    location: Optional[str] = None
+    ranking: Optional[int] = None
 
 class PlayerNameOut(BaseModel):
     id: str


### PR DESCRIPTION
## Summary
- support optional Player fields (photo_url, location, ranking) in model, schemas, and API
- add Alembic migration for new Player columns

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3b3ef008323aed22f49cef822a3