### PR TITLE
refactor: replace any with explicit types

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -145,13 +145,21 @@ function winnerFromSummary(
     // @ts-expect-error dynamic
     "score",
   ];
-  for (const key of checks) {
-    const val: any = (s as any)[key];
-    if (val && typeof val.A === "number" && typeof val.B === "number") {
-      if (val.A > val.B) return "A";
-      if (val.B > val.A) return "B";
+    for (const key of checks) {
+      const raw = (s as Record<string, unknown>)[key];
+      if (
+        raw &&
+        typeof raw === "object" &&
+        "A" in raw &&
+        "B" in raw &&
+        typeof (raw as { A: unknown }).A === "number" &&
+        typeof (raw as { B: unknown }).B === "number"
+      ) {
+        const val = raw as { A: number; B: number };
+        if (val.A > val.B) return "A";
+        if (val.B > val.A) return "B";
+      }
     }
-  }
   return null;
 }
 

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -24,9 +24,7 @@ export default function RecordSportPage() {
   const params = useParams();
   const sport = typeof params.sport === "string" ? params.sport : "";
   const isPadel = sport === "padel";
-  const isTennis = sport === "tennis";
   const isPickleball = sport === "pickleball";
-  const usesSets = isPadel || isTennis;
 
   const [players, setPlayers] = useState<Player[]>([]);
   const [ids, setIds] = useState<IdMap>({ a1: "", a2: "", b1: "", b2: "" });
@@ -91,7 +89,21 @@ export default function RecordSportPage() {
         ];
 
     try {
-      const payload: any = { sport, participants, score: [scoreA, scoreB] };
+      interface MatchParticipant {
+        side: "A" | "B";
+        playerIds: string[];
+      }
+      interface MatchPayload {
+        sport: string;
+        participants: MatchParticipant[];
+        score: [string, string];
+        playedAt?: string;
+      }
+      const payload: MatchPayload = {
+        sport,
+        participants,
+        score: [scoreA, scoreB],
+      };
       if (date) {
         payload.playedAt = new Date(
           `${date}T${time || "00:00"}`

--- a/apps/web/src/components/charts/MatchHeatmap.tsx
+++ b/apps/web/src/components/charts/MatchHeatmap.tsx
@@ -6,6 +6,8 @@ import {
   LinearScale,
   Tooltip,
   Legend,
+  type ScriptableContext,
+  type TooltipItem,
 } from 'chart.js';
 import { MatrixController, MatrixElement } from 'chartjs-chart-matrix';
 import { Chart } from 'react-chartjs-2';
@@ -34,13 +36,15 @@ export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
       {
         label: 'Matches',
         data,
-        backgroundColor: (ctx: any) => {
-          const value = ctx.raw.v || 0;
+        backgroundColor: (ctx: ScriptableContext<'matrix'>) => {
+          const value = (ctx.raw as HeatmapDatum | undefined)?.v ?? 0;
           const alpha = maxV ? value / maxV : 0;
           return `rgba(26, 115, 232, ${alpha})`;
         },
-        width: ({ chart }: any) => chart.chartArea.width / xLabels.length - 2,
-        height: ({ chart }: any) => chart.chartArea.height / yLabels.length - 2,
+        width: (ctx: ScriptableContext<'matrix'>) =>
+          ctx.chart.chartArea.width / xLabels.length - 2,
+        height: (ctx: ScriptableContext<'matrix'>) =>
+          ctx.chart.chartArea.height / yLabels.length - 2,
       },
     ],
   };
@@ -54,8 +58,10 @@ export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
     plugins: {
       tooltip: {
         callbacks: {
-          title: (items: any) => xLabels[items[0].parsed.x],
-          label: (item: any) => `${yLabels[item.parsed.y]}: ${item.raw.v}`,
+          title: (items: TooltipItem<'matrix'>[]) =>
+            xLabels[items[0].parsed.x],
+          label: (item: TooltipItem<'matrix'>) =>
+            `${yLabels[item.parsed.y]}: ${(item.raw as HeatmapDatum).v}`,
         },
       },
       legend: { display: false },


### PR DESCRIPTION
## Summary
- remove `any` in MatchHeatmap by using Chart.js types
- replace loosely typed payload with typed MatchPayload
- strengthen winner calculation with type guards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b66f84f0088323a2ae8eb72fe3db54