### PR TITLE
Highlight higher set score

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -114,8 +114,8 @@ export default async function MatchDetailPage({
                 return (
                   <tr key={i} className="border-t">
                     <td className="py-1 pr-4">{i + 1}</td>
-                    <td className="py-1 pr-4">{a}</td>
-                    <td className="py-1">{b}</td>
+                    <td className={`py-1 pr-4${a > b ? " font-bold" : ""}`}>{a}</td>
+                    <td className={`py-1${b > a ? " font-bold" : ""}`}>{b}</td>
                   </tr>
                 );
               })}


### PR DESCRIPTION
## Summary
- bold sets leading score in match detail page

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b68158aa848323b191ede41db25ccc