### PR TITLE
Use router-driven buttons for matches pagination

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -56,6 +56,11 @@ a {
   background: var(--color-accent-red-hover);
 }
 
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .section {
   margin-bottom: 16px;
 }

--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import MatchesPage from "./page";
+import "@testing-library/jest-dom";
 
 vi.mock("next/link", () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
 }));
 
 describe("MatchesPage", () => {
@@ -88,9 +92,9 @@ describe("MatchesPage", () => {
     const page = await MatchesPage({ searchParams: {} });
     render(page);
 
-    const prev = screen.getByText("Previous");
-    const next = screen.getByText("Next");
-    expect(prev.getAttribute("aria-disabled")).toBe("true");
-    expect(next.getAttribute("aria-disabled")).toBe("true");
+    const prev = screen.getByText("Previous") as HTMLButtonElement;
+    const next = screen.getByText("Next") as HTMLButtonElement;
+    expect(prev).toBeDisabled();
+    expect(next).toBeDisabled();
   });
 });

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
+import Pager from "./pager";
 
 type MatchRow = {
   id: string;
@@ -137,22 +138,13 @@ export default async function MatchesPage(
             </li>
           ))}
         </ul>
-        <div className="pager">
-          {disablePrev ? (
-            <span aria-disabled="true">Previous</span>
-          ) : (
-            <Link href={`/matches?limit=${limit}&offset=${prevOffset}`}>
-              Previous
-            </Link>
-          )}
-          {disableNext ? (
-            <span aria-disabled="true">Next</span>
-          ) : (
-            <Link href={`/matches?limit=${limit}&offset=${nextOffset}`}>
-              Next
-            </Link>
-          )}
-        </div>
+        <Pager
+          limit={limit}
+          prevOffset={prevOffset}
+          nextOffset={nextOffset}
+          disablePrev={disablePrev}
+          disableNext={disableNext}
+        />
       </main>
     );
   } catch {

--- a/apps/web/src/app/matches/pager.tsx
+++ b/apps/web/src/app/matches/pager.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+
+interface PagerProps {
+  limit: number;
+  prevOffset: number;
+  nextOffset: number;
+  disablePrev: boolean;
+  disableNext: boolean;
+}
+
+export default function Pager({
+  limit,
+  prevOffset,
+  nextOffset,
+  disablePrev,
+  disableNext,
+}: PagerProps) {
+  const router = useRouter();
+  return (
+    <div className="pager">
+      <button
+        type="button"
+        className="button"
+        disabled={disablePrev}
+        onClick={() => router.push(`/matches?limit=${limit}&offset=${prevOffset}`)}
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        className="button"
+        disabled={disableNext}
+        onClick={() => router.push(`/matches?limit=${limit}&offset=${nextOffset}`)}
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace pager links with buttons powered by `router.push`
- style disabled state for buttons
- adjust tests for new pager behavior

## Testing
- `npm test --prefix apps/web`
- `npm run lint --prefix apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68b681586c2c8323bab8e168ee733a2d