### PR TITLE
fix(web): memoize load callbacks

### DIFF
--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "../../../lib/api";
 
 interface Comment {
@@ -18,16 +18,16 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
   const token =
     typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
-  async function load() {
+  const load = useCallback(async () => {
     const resp = await apiFetch(`/v0/players/${playerId}/comments`);
     if (resp.ok) {
       setComments((await resp.json()) as Comment[]);
     }
-  }
+  }, [playerId]);
 
   useEffect(() => {
     load();
-  }, [playerId]);
+  }, [load]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 const sports = ["padel", "bowling"];
@@ -15,7 +15,7 @@ export default function RankingsPage() {
   const [leaders, setLeaders] = useState<Leader[]>([]);
   const [loading, setLoading] = useState(false);
 
-  async function load() {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const res = await fetch(`${base}/v0/leaderboards?sport=${sport}`, { cache: "no-store" });
@@ -31,12 +31,11 @@ export default function RankingsPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [sport]);
 
   useEffect(() => {
     load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sport]);
+  }, [load]);
 
   return (
     <main className="container">


### PR DESCRIPTION
## Summary
- use useCallback for rankings page load function
- fix comments-client hook dependencies

## Testing
- `cd apps/web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b682f3fb58832385fe875d9b9a899d