### PR TITLE
feat(web): show no players found message

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -67,5 +67,30 @@ describe("PlayersPage", () => {
     expect(screen.getByText("Bob")).toBeTruthy();
     vi.useRealTimers();
   });
+
+  it("shows a message when no players match the search", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        players: [
+          { id: "1", name: "Alice" },
+          { id: "2", name: "Bob" },
+        ],
+      }),
+    });
+    // @ts-expect-error override global fetch for test
+    global.fetch = fetchMock;
+
+    render(<PlayersPage />);
+    await screen.findByText("Alice");
+    vi.useFakeTimers();
+    const search = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(search, { target: { value: "zo" } });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByText(/no players found/i)).toBeTruthy();
+    vi.useRealTimers();
+  });
 });
 

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -133,21 +133,25 @@ export default function PlayersPage() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="search"
           />
-          <ul>
-            {filteredPlayers.map((p) => (
-              <li key={p.id}>
-                <Link
-                  href={
-                    recentMatches[p.id]
-                      ? `/matches/${recentMatches[p.id]}`
-                      : `/players/${p.id}`
-                  }
-                >
-                  {p.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
+          {filteredPlayers.length === 0 && debouncedSearch.trim() !== "" ? (
+            <p>No players found.</p>
+          ) : (
+            <ul>
+              {filteredPlayers.map((p) => (
+                <li key={p.id}>
+                  <Link
+                    href={
+                      recentMatches[p.id]
+                        ? `/matches/${recentMatches[p.id]}`
+                        : `/players/${p.id}`
+                    }
+                  >
+                    {p.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
         </>
       )}
       <input


### PR DESCRIPTION
## Summary
- display a "No players found." message when a search yields no results
- test that empty searches show the message

## Testing
- `cd apps/web && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b68156e1508323ad41215e666c4fa9