### PR TITLE
Fix chart imports and TypeScript chart options

### DIFF
--- a/apps/web/src/app/players/[id]/PlayerCharts.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import WinRateChart, { WinRatePoint } from '../../components/charts/WinRateChart';
-import RankingHistoryChart, { RankingPoint } from '../../components/charts/RankingHistoryChart';
-import MatchHeatmap, { HeatmapDatum } from '../../components/charts/MatchHeatmap';
+import WinRateChart, { WinRatePoint } from '../../../components/charts/WinRateChart';
+import RankingHistoryChart, { RankingPoint } from '../../../components/charts/RankingHistoryChart';
+import MatchHeatmap, { HeatmapDatum } from '../../../components/charts/MatchHeatmap';
 
 interface EnrichedMatch {
   playedAt: string | null;

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -68,6 +68,11 @@ export default function RecordSportPage() {
     e.preventDefault();
     setError(null);
 
+    interface MatchParticipant {
+      side: "A" | "B";
+      playerIds: string[];
+    }
+
     const idValues = doubles
       ? [ids.a1, ids.a2, ids.b1, ids.b2]
       : [ids.a1, ids.b1];
@@ -78,7 +83,7 @@ export default function RecordSportPage() {
       return;
     }
 
-    const participants = doubles
+    const participants: MatchParticipant[] = doubles
       ? [
           { side: "A", playerIds: [ids.a1].concat(ids.a2 ? [ids.a2] : []) },
           { side: "B", playerIds: [ids.b1].concat(ids.b2 ? [ids.b2] : []) },
@@ -89,10 +94,6 @@ export default function RecordSportPage() {
         ];
 
     try {
-      interface MatchParticipant {
-        side: "A" | "B";
-        playerIds: string[];
-      }
       interface MatchPayload {
         sport: string;
         participants: MatchParticipant[];

--- a/apps/web/src/components/charts/MatchHeatmap.tsx
+++ b/apps/web/src/components/charts/MatchHeatmap.tsx
@@ -8,6 +8,7 @@ import {
   Legend,
   type ScriptableContext,
   type TooltipItem,
+  type ChartOptions,
 } from 'chart.js';
 import { MatrixController, MatrixElement } from 'chartjs-chart-matrix';
 import { Chart } from 'react-chartjs-2';
@@ -48,12 +49,17 @@ export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
       },
     ],
   };
-  const options = {
+  const options: ChartOptions<'matrix'> = {
     responsive: true,
-    maintainAspectRatio: false as const,
+    maintainAspectRatio: false,
     scales: {
-      x: { type: 'category', labels: xLabels, offset: true },
-      y: { type: 'category', labels: yLabels, offset: true, reverse: true },
+      x: { type: 'category' as const, labels: xLabels, offset: true },
+      y: {
+        type: 'category' as const,
+        labels: yLabels,
+        offset: true,
+        reverse: true,
+      },
     },
     plugins: {
       tooltip: {

--- a/apps/web/src/components/charts/RankingHistoryChart.tsx
+++ b/apps/web/src/components/charts/RankingHistoryChart.tsx
@@ -8,6 +8,7 @@ import {
   LineElement,
   Tooltip,
   Legend,
+  type ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
@@ -38,11 +39,12 @@ export function RankingHistoryChart({ data }: { data: RankingPoint[] }) {
       },
     ],
   };
-  const options = {
+  const options: ChartOptions<'line'> = {
     responsive: true,
-    maintainAspectRatio: false as const,
+    maintainAspectRatio: false,
     scales: {
       y: {
+        type: 'linear' as const,
         reverse: true,
         beginAtZero: true,
       },

--- a/apps/web/src/components/charts/WinRateChart.tsx
+++ b/apps/web/src/components/charts/WinRateChart.tsx
@@ -8,6 +8,7 @@ import {
   LineElement,
   Tooltip,
   Legend,
+  type ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
@@ -38,14 +39,17 @@ export function WinRateChart({ data }: { data: WinRatePoint[] }) {
       },
     ],
   };
-  const options = {
+  const options: ChartOptions<'line'> = {
     responsive: true,
-    maintainAspectRatio: false as const,
+    maintainAspectRatio: false,
     scales: {
       y: {
+        type: 'linear' as const,
         beginAtZero: true,
         max: 100,
-        ticks: { callback: (val: number) => val + '%' },
+        ticks: {
+          callback: (val: number | string) => `${val}%`,
+        },
       },
     },
   };


### PR DESCRIPTION
## Summary
- fix player chart component imports
- add MatchParticipant typing and Chart.js option types

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b68257cf4c832383e3c5b7ac75c2fd