### PR TITLE
feat(web): add not-found page

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main className="container">
+      <section className="card">
+        <h1 className="heading">Page not found</h1>
+        <p>
+          <Link href="/">Return home</Link>
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add not-found component with link to home

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6815b1a08832393692958b47874dd