### PR TITLE
Use numeric inputs for match scores

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -101,4 +101,43 @@ describe("RecordSportPage", () => {
       { side: "B", playerIds: ["3"] },
     ]);
   });
+
+  it("submits numeric scores", async () => {
+    sportParam = "padel";
+    const players = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+      { id: "3", name: "Cara" },
+      { id: "4", name: "Dan" },
+    ];
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock;
+
+    render(<RecordSportPage />);
+
+    await screen.findAllByText("Alice");
+
+    const selects = screen.getAllByRole("combobox");
+    fireEvent.change(selects[0], { target: { value: "1" } });
+    fireEvent.change(selects[1], { target: { value: "2" } });
+    fireEvent.change(selects[2], { target: { value: "3" } });
+    fireEvent.change(selects[3], { target: { value: "4" } });
+
+    fireEvent.change(screen.getByPlaceholderText("A"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("B"), {
+      target: { value: "7" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(payload.score).toEqual([5, 7]);
+  });
 });

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -96,13 +96,13 @@ export default function RecordSportPage() {
       interface MatchPayload {
         sport: string;
         participants: MatchParticipant[];
-        score: [string, string];
+        score: [number, number];
         playedAt?: string;
       }
       const payload: MatchPayload = {
         sport,
         participants,
-        score: [scoreA, scoreB],
+        score: [Number(scoreA), Number(scoreB)],
       };
       if (date) {
         payload.playedAt = new Date(
@@ -211,11 +211,17 @@ export default function RecordSportPage() {
 
         <div className="score">
           <input
+            type="number"
+            min="0"
+            step="1"
             placeholder="A"
             value={scoreA}
             onChange={(e) => setScoreA(e.target.value)}
           />
           <input
+            type="number"
+            min="0"
+            step="1"
             placeholder="B"
             value={scoreB}
             onChange={(e) => setScoreB(e.target.value)}


### PR DESCRIPTION
## Summary
- use number inputs for recording match scores
- submit scores as numbers
- add test ensuring numeric score submission

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b68159010c8323bb0b315e9d6c5ee2