### PR TITLE
feat: add success message when creating players

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -67,5 +67,34 @@ describe("PlayersPage", () => {
     expect(screen.getByText("Bob")).toBeTruthy();
     vi.useRealTimers();
   });
+
+  it("shows a success message after adding a player", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "1" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
+    // @ts-expect-error override global fetch for test
+    global.fetch = fetchMock;
+
+    vi.useFakeTimers();
+    render(<PlayersPage />);
+
+    const input = screen.getByPlaceholderText(/name/i);
+    fireEvent.change(input, { target: { value: "New Player" } });
+    const button = screen.getByRole("button", { name: /add/i });
+    await act(async () => {
+      fireEvent.click(button);
+      await Promise.resolve();
+    });
+
+    screen.getByText(/added successfully/i);
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/added successfully/i)).toBeNull();
+    vi.useRealTimers();
+  });
 });
 

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -20,6 +20,7 @@ export default function PlayersPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
 
@@ -90,6 +91,7 @@ export default function PlayersPage() {
       return;
     }
     setError(null);
+    setSuccess(null);
     setCreating(true);
     try {
       const res = await apiFetch("/v0/players", {
@@ -112,6 +114,8 @@ export default function PlayersPage() {
       }
       setName("");
       load();
+      setSuccess("Player added successfully!");
+      setTimeout(() => setSuccess(null), 3000);
     } catch {
       setError("Failed to create player.");
       return;
@@ -169,6 +173,7 @@ export default function PlayersPage() {
       >
         {creating ? "Saving…" : "Add"}
       </button>
+      {success && <div className="text-green-600 mt-2">{success}</div>}
       {error && (
         <div className="text-red-500 mt-2">
           {error}


### PR DESCRIPTION
## Summary
- show a success message when a player is created
- clear the success message after a short delay and test the flow

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b68157f69c8323be64ea1b4635c79e