### PR TITLE
Ensure Alembic uses asyncpg for migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,6 +20,14 @@ except Exception:
 target_metadata = Base.metadata
 DATABASE_URL = os.getenv("DATABASE_URL")
 
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable is required")
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace(
+        "postgresql://", "postgresql+asyncpg://", 1
+    )
+
 def run_migrations_offline():
     context.configure(
         url=DATABASE_URL,


### PR DESCRIPTION
## Summary
- fix Alembic configuration to use asyncpg when DATABASE_URL uses PostgreSQL
- raise error if DATABASE_URL is missing

## Testing
- `pytest` *(fails: ImportError: cannot import name 'MatchIdOut' from 'backend.app.schemas')*


------
https://chatgpt.com/codex/tasks/task_e_68b68a1922c88323b1018a2e5bea8eed