### PR TITLE
Add Alembic migration for user table

### DIFF
--- a/backend/alembic/versions/0005_comments.py
+++ b/backend/alembic/versions/0005_comments.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 revision = '0005_comments'
 down_revision = '0004_soft_delete_columns'
 branch_labels = None
-depends_on = None
+depends_on = ('0005_users',)
 
 
 def upgrade():

--- a/backend/alembic/versions/0005_users.py
+++ b/backend/alembic/versions/0005_users.py
@@ -1,0 +1,21 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005_users'
+down_revision = '0004_soft_delete_columns'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('username', sa.String(), nullable=False, unique=True),
+        sa.Column('password_hash', sa.String(), nullable=False),
+        sa.Column('is_admin', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_table('user')


### PR DESCRIPTION
## Summary
- add migration creating `user` table with username, password hash and admin flag
- ensure comment migration runs after user migration

## Testing
- `pytest tests/test_comments.py -q` *(fails: cannot import name 'PlayerStatsOut' from 'app.schemas')*


------
https://chatgpt.com/codex/tasks/task_e_68b6b975d8748323b5f1158cdc501104