### PR TITLE
Restore player extra fields migration

### DIFF
--- a/backend/alembic/versions/0005_add_player_columns.py
+++ b/backend/alembic/versions/0005_add_player_columns.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0005_add_player_columns'
-down_revision = '0004_soft_delete_columns'
+down_revision = '0005_player_extra_fields'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0005_player_extra_fields.py
+++ b/backend/alembic/versions/0005_player_extra_fields.py
@@ -1,0 +1,14 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005_player_extra_fields'
+down_revision = '0004_soft_delete_columns'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
- add no-op migration for `0005_player_extra_fields`
- chain `0005_add_player_columns` after restored revision

## Testing
- `pytest` *(fails: ImportError cannot import name 'MatchIdOut')*


------
https://chatgpt.com/codex/tasks/task_e_68b6be747a8c8323b2a8b91b48d03d59