### PR TITLE
Handle date-only match timestamps

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import { execSync } from "child_process";
+
+vi.mock("../../../lib/api", () => ({
+  apiFetch: vi.fn(),
+  apiUrl: (p: string) => p,
+}));
+
+import MatchDetailPage from "./page";
+import { apiFetch } from "../../../lib/api";
+
+const apiFetchMock = apiFetch as unknown as ReturnType<typeof vi.fn>;
+
+describe("MatchDetailPage", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders date-only match consistently across time zones", async () => {
+    const match = {
+      id: "m1",
+      sport: "padel",
+      ruleset: "",
+      status: "",
+      playedAt: "2024-01-01T00:00:00",
+      participants: [],
+      sets: [],
+    };
+    apiFetchMock.mockResolvedValueOnce({ ok: true, json: async () => match });
+
+    render(await MatchDetailPage({ params: { mid: "m1" } }));
+
+    const displayed = new Date(match.playedAt).toLocaleDateString();
+    expect(screen.getByText((t) => t.includes(displayed))).toBeInTheDocument();
+
+    const laDate = execSync(
+      "TZ=America/Los_Angeles node -e \"console.log(new Date('2024-01-01T00:00:00').toLocaleDateString())\""
+    )
+      .toString()
+      .trim();
+    expect(displayed).toBe(laDate);
+  });
+});

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -106,9 +106,11 @@ export default function RecordSportPage() {
         score: [Number(scoreA), Number(scoreB)],
       };
       if (date) {
-        payload.playedAt = new Date(
-          `${date}T${time || "00:00"}`
-        ).toISOString();
+        if (time) {
+          payload.playedAt = new Date(`${date}T${time}`).toISOString();
+        } else {
+          payload.playedAt = `${date}T00:00:00`;
+        }
       }
       const res = await fetch(`${base}/v0/matches`, {
         method: "POST",


### PR DESCRIPTION
## Summary
- Preserve naive midnight timestamps when no time is provided during match recording
- Verify backend accepts and stores naive date-only `playedAt` values
- Add test ensuring date-only matches render consistently across time zones

## Testing
- `cd backend && pytest`
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6def4ab3c83238176f8c79c05b7b6