### PR TITLE
Require admin token for match and player creation

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -14,10 +14,15 @@ export function apiUrl(path: string): string {
 }
 
 export async function apiFetch(path: string, init?: RequestInit) {
+  const headers = new Headers(init?.headers);
+  if (typeof window !== "undefined") {
+    const token = window.localStorage?.getItem("token");
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+  }
   try {
-    return await fetch(apiUrl(path), init);
+    return await fetch(apiUrl(path), { ...init, headers });
   } catch (err) {
-    console.error('API request failed', err);
+    console.error("API request failed", err);
     throw err;
   }
 }

--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -77,7 +77,11 @@ async def list_matches(
 
 # POST /api/v0/matches
 @router.post("", response_model=MatchIdOut)
-async def create_match(body: MatchCreate, session: AsyncSession = Depends(get_session)):
+async def create_match(
+    body: MatchCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     mid = uuid.uuid4().hex
     match = Match(
         id=mid,
@@ -111,7 +115,11 @@ async def create_match(body: MatchCreate, session: AsyncSession = Depends(get_se
 
 
 @router.post("/by-name", response_model=MatchIdOut)
-async def create_match_by_name(body: MatchCreateByName, session: AsyncSession = Depends(get_session)):
+async def create_match_by_name(
+    body: MatchCreateByName,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     name_to_id = {}
     names = [n for part in body.participants for n in part.playerNames]
     if names:
@@ -143,7 +151,7 @@ async def create_match_by_name(body: MatchCreateByName, session: AsyncSession = 
         playedAt=body.playedAt,
         location=body.location,
     )
-    return await create_match(mc, session)
+    return await create_match(mc, session, user)
 
 # GET /api/v0/matches/{mid}
 @router.get("/{mid}", response_model=MatchOut)
@@ -260,7 +268,12 @@ async def delete_match(
 
 # POST /api/v0/matches/{mid}/events
 @router.post("/{mid}/events")
-async def append_event(mid: str, ev: EventIn, session: AsyncSession = Depends(get_session)):
+async def append_event(
+    mid: str,
+    ev: EventIn,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     m = (await session.execute(select(Match).where(Match.id == mid))).scalar_one_or_none()
     if not m:
         raise HTTPException(404, "match not found")
@@ -299,7 +312,12 @@ async def append_event(mid: str, ev: EventIn, session: AsyncSession = Depends(ge
 
 
 @router.post("/{mid}/sets")
-async def record_sets_endpoint(mid: str, body: SetsIn, session: AsyncSession = Depends(get_session)):
+async def record_sets_endpoint(
+    mid: str,
+    body: SetsIn,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
     m = (await session.execute(select(Match).where(Match.id == mid))).scalar_one_or_none()
     if not m:
         raise HTTPException(404, "match not found")

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -46,7 +46,9 @@ router = APIRouter(
 
 @router.post("", response_model=PlayerOut)
 async def create_player(
-    body: PlayerCreate, session: AsyncSession = Depends(get_session)
+    body: PlayerCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
 ):
     exists = (
         await session.execute(select(Player).where(Player.name == body.name))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -54,15 +54,8 @@ def test_signup_login_and_protected_access():
         assert resp.status_code == 200
         user_token = resp.json()["access_token"]
 
-        pid = client.post("/players", json={"name": "Bob"}).json()["id"]
-        resp = client.delete(
-            f"/players/{pid}", headers={"Authorization": f"Bearer {user_token}"}
-        )
-        assert resp.status_code == 403
-
         resp = client.post(
-            "/auth/signup",
-            json={"username": "admin", "password": "pw", "is_admin": True},
+            "/auth/signup", json={"username": "admin", "password": "pw", "is_admin": True}
         )
         assert resp.status_code == 403
 
@@ -71,6 +64,17 @@ def test_signup_login_and_protected_access():
             json={"username": "admin", "password": "pw", "is_admin": True},
             headers={"X-Admin-Secret": "admintest"},
         ).json()["access_token"]
+
+        pid = client.post(
+            "/players",
+            json={"name": "Bob"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        ).json()["id"]
+        resp = client.delete(
+            f"/players/{pid}", headers={"Authorization": f"Bearer {user_token}"}
+        )
+        assert resp.status_code == 403
+
         resp = client.delete(
             f"/players/{pid}", headers={"Authorization": f"Bearer {admin_token}"}
         )

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -60,7 +60,15 @@ def test_comment_crud():
         resp = client.post("/auth/signup", json={"username": "bob", "password": "pw"})
         assert resp.status_code == 200
         token = resp.json()["access_token"]
-        pid = client.post("/players", json={"name": "Player1"}).json()["id"]
+        admin_token = client.post(
+            "/auth/signup",
+            json={"username": "admin", "password": "pw", "is_admin": True},
+            headers={"X-Admin-Secret": "admintest"},
+        ).json()["access_token"]
+        pid = client.post(
+            "/players", json={"name": "Player1"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        ).json()["id"]
         resp = client.post(
             f"/players/{pid}/comments",
             json={"content": "Great!"},

--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -17,6 +17,7 @@ from backend.app.db import Base, get_session
 from backend.app.models import Match, Sport, ScoreEvent
 from backend.app.routers import matches
 from backend.app.scoring import disc_golf
+from backend.app.routers.admin import require_admin
 
 
 @pytest.fixture()
@@ -51,6 +52,7 @@ def client_and_session():
     app = FastAPI()
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[require_admin] = lambda: None
 
     with TestClient(app) as client:
         yield client, async_session_maker

--- a/backend/tests/test_player_profile_metrics.py
+++ b/backend/tests/test_player_profile_metrics.py
@@ -23,6 +23,7 @@ from backend.app.models import (
     ScoreEvent,
 )
 from backend.app.routers import players, matches
+from backend.app.routers.admin import require_admin
 
 
 @pytest.fixture()
@@ -62,6 +63,7 @@ def client_and_session():
     app.include_router(players.router)
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[require_admin] = lambda: None
 
     with TestClient(app) as client:
         yield client, async_session_maker

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -18,6 +18,7 @@ from backend.app.db import Base, get_session
 from backend.app.models import Match, Sport, ScoreEvent
 from backend.app.routers import matches
 from backend.app.scoring import padel
+from backend.app.routers.admin import require_admin
 
 
 @pytest.fixture()
@@ -53,6 +54,7 @@ def client_and_session():
     app = FastAPI()
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[require_admin] = lambda: None
 
     with TestClient(app) as client:
         yield client, async_session_maker


### PR DESCRIPTION
## Summary
- require admin auth to create players, matches, and modify match details
- send stored auth token on all client API requests
- update tests for new permission checks

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec404cf48323aaafc755b639b025