### PR TITLE
Filter deleted players in players_by_ids

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -113,7 +113,11 @@ async def players_by_ids(ids: str = "", session: AsyncSession = Depends(get_sess
     if not id_list:
         return []
     rows = (
-        await session.execute(select(Player).where(Player.id.in_(id_list)))
+        await session.execute(
+            select(Player).where(
+                Player.id.in_(id_list), Player.deleted_at.is_(None)
+            )
+        )
     ).scalars().all()
     return [PlayerNameOut(id=p.id, name=p.name) for p in rows]
 


### PR DESCRIPTION
## Summary
- exclude soft-deleted players from `/players/by-ids`
- add regression test ensuring deleted players are omitted

## Testing
- `pytest backend/tests/test_players.py::test_players_by_ids_omits_deleted -q`
- `pytest backend/tests -q` *(fails: test_create_match_preserves_naive_date asserts 200 but got 401)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f9c1eb248323af03733944ef723e