### PR TITLE
feat: add user auth and match recording

### DIFF
--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -43,6 +43,11 @@ export default function Header() {
               Leaderboard
             </Link>
           </li>
+          <li>
+            <Link href="/login" onClick={() => setOpen(false)}>
+              Login
+            </Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch } from "../../lib/api";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [newUser, setNewUser] = useState("");
+  const [newPass, setNewPass] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await apiFetch("/v0/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        window.localStorage.setItem("token", data.access_token);
+        router.push("/");
+      } else {
+        setError("Login failed");
+      }
+    } catch {
+      setError("Login failed");
+    }
+  };
+
+  const handleSignup = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await apiFetch("/v0/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: newUser, password: newPass }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        window.localStorage.setItem("token", data.access_token);
+        router.push("/");
+      } else {
+        setError("Signup failed");
+      }
+    } catch {
+      setError("Signup failed");
+    }
+  };
+
+  return (
+    <main className="container">
+      <h1 className="heading">Login</h1>
+      <form onSubmit={handleLogin} className="auth-form">
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Login</button>
+      </form>
+
+      <h2 className="heading">Sign Up</h2>
+      <form onSubmit={handleSignup} className="auth-form">
+        <input
+          type="text"
+          placeholder="Username"
+          value={newUser}
+          onChange={(e) => setNewUser(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={newPass}
+          onChange={(e) => setNewPass(e.target.value)}
+        />
+        <button type="submit">Sign Up</button>
+      </form>
+
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -3,6 +3,7 @@
 
 import React, { FormEvent, useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
+import { apiFetch } from "../../../lib/api";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -112,7 +113,7 @@ export default function RecordSportPage() {
           payload.playedAt = `${date}T00:00:00`;
         }
       }
-      const res = await fetch(`${base}/v0/matches`, {
+      const res = await apiFetch(`/v0/matches`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- create player automatically on user signup
- let authenticated players record their own matches
- add login/sign-up page and navigation link

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6f8d82f3c832385f3b41d36c05fbe