### PR TITLE
Add disc golf support

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import Leaderboard from "./leaderboard";
+
+describe("Leaderboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches disc_golf when showing all sports", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as any;
+
+    render(<Leaderboard sport="all" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("/api/v0/leaderboards?sport=disc_golf");
+  });
+});

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 
 // Identifier type for players
@@ -17,7 +17,7 @@ export type Leader = {
   sport?: string;
 };
 
-const SPORTS = ["padel", "badminton", "table-tennis"] as const;
+const SPORTS = ["padel", "badminton", "table-tennis", "disc_golf"] as const;
 
 type Props = {
   sport: string;

--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import RecordDiscGolfPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("mid=m1"),
+}));
+
+describe("RecordDiscGolfPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts hole events", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock as any;
+
+    render(<RecordDiscGolfPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("A"), { target: { value: "3" } });
+    fireEvent.change(screen.getByPlaceholderText("B"), { target: { value: "4" } });
+    fireEvent.click(screen.getByRole("button", { name: /record hole/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const payloads = fetchMock.mock.calls.map((c) => JSON.parse(c[1].body));
+    expect(payloads).toEqual([
+      { type: "HOLE", side: "A", hole: 1, strokes: 3 },
+      { type: "HOLE", side: "B", hole: 1, strokes: 4 },
+    ]);
+  });
+});

--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+
+export default function RecordDiscGolfPage() {
+  const params = useSearchParams();
+  const mid = params.get("mid") || "";
+  const [hole, setHole] = useState(1);
+  const [a, setA] = useState("");
+  const [b, setB] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!mid) return;
+    setError(null);
+    const events = [
+      { type: "HOLE", side: "A", hole, strokes: Number(a) },
+      { type: "HOLE", side: "B", hole, strokes: Number(b) },
+    ];
+    try {
+      for (const ev of events) {
+        await fetch(`${base}/v0/matches/${mid}/events`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(ev),
+        });
+      }
+      setHole((h) => h + 1);
+      setA("");
+      setB("");
+    } catch {
+      setError("Failed to record event.");
+    }
+  };
+
+  return (
+    <main className="container">
+      <h1 className="heading">Record Disc Golf</h1>
+      <p>Hole {hole}</p>
+      <div className="scores">
+        <input
+          type="number"
+          placeholder="A"
+          value={a}
+          onChange={(e) => setA(e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="B"
+          value={b}
+          onChange={(e) => setB(e.target.value)}
+        />
+      </div>
+      <button onClick={submit}>Record Hole</button>
+      {error && <p>{error}</p>}
+    </main>
+  );
+}

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -23,7 +23,7 @@ export default async function RecordPage() {
         <ul className="sport-list">
           {sports.map((s) => (
             <li key={s.id} className="sport-item">
-              <Link href={`/record/${s.id}`}>{s.name}</Link>
+              <Link href={`/record/${s.id.replace('_', '-')}`}>{s.name}</Link>
             </li>
           ))}
         </ul>

--- a/backend/app/scoring/__init__.py
+++ b/backend/app/scoring/__init__.py
@@ -1,1 +1,11 @@
-# scoring engines live here later (padel.py, bowling.py)
+"""Scoring engines for the various sports."""
+
+from . import bowling, disc_golf, padel, pickleball, tennis
+
+__all__ = [
+    "bowling",
+    "disc_golf",
+    "padel",
+    "pickleball",
+    "tennis",
+]

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -23,6 +23,7 @@ async def main():
             ("bowling", "Bowling"),
             ("tennis", "Tennis"),
             ("pickleball", "Pickleball"),
+            ("disc_golf", "Disc Golf"),
         ]:
             if sid not in have:
                 s.add(Sport(id=sid, name=name))
@@ -62,6 +63,12 @@ async def main():
                 sport_id="pickleball",
                 name="Pickleball standard",
                 config={"pointsTo": 11, "winBy": 2, "bestOf": 3},
+            ),
+            RuleSet(
+                id="disc-golf-standard",
+                sport_id="disc_golf",
+                name="Disc Golf standard",
+                config={"holes": 18},
             ),
         ]
         for rs in rulesets:

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -467,6 +467,8 @@ async def test_create_match_preserves_naive_date(tmp_path):
 
     app = FastAPI()
     app.include_router(matches.router)
+    from app.routers.admin import require_admin
+    app.dependency_overrides[require_admin] = lambda: None
 
     with TestClient(app) as client:
         payload = {


### PR DESCRIPTION
## Summary
- add disc_golf sport and default ruleset
- expose scoring engines and add disc golf match tests
- support disc golf recording and leaderboards in web UI

## Testing
- `npm test --prefix apps/web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f9f6a0e083238e8cc97db61a20d9