### PR TITLE
Add migration for master rating table

### DIFF
--- a/backend/alembic/versions/0005_master_rating.py
+++ b/backend/alembic/versions/0005_master_rating.py
@@ -1,0 +1,22 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005_master_rating'
+down_revision = '0004_soft_delete_columns'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'master_rating',
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('player_id', sa.String(), sa.ForeignKey('player.id'), nullable=False),
+        sa.Column('value', sa.Float(), nullable=False),
+    )
+    op.create_index('ix_master_rating_player_id', 'master_rating', ['player_id'], unique=True)
+
+
+def downgrade():
+    op.drop_index('ix_master_rating_player_id', table_name='master_rating')
+    op.drop_table('master_rating')


### PR DESCRIPTION
## Summary
- add Alembic migration to create master_rating table
- add unique index on player_id for master_rating

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b6fdceded0832390034fb6c3ed228b