### PR TITLE
Handle multi-sided matches generically

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -151,7 +151,9 @@ export default function HomePageClient({
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
                 <div style={{ fontWeight: 500 }}>
-                  {m.names.A.join(' & ')} vs {m.names.B.join(' & ')}
+                  {Object.values(m.names)
+                    .map((n) => n.join(' & '))
+                    .join(' vs ')}
                 </div>
                 <div className="match-meta">
                   {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}

--- a/apps/web/src/app/players/[id]/head-to-head.tsx
+++ b/apps/web/src/app/players/[id]/head-to-head.tsx
@@ -1,19 +1,31 @@
 import React from "react";
 import type { EnrichedMatch, MatchSummary } from "./types";
 
-function winner(summary?: MatchSummary): "A" | "B" | null {
+function winner(summary?: MatchSummary): string | null {
   if (!summary) return null;
-  if (summary.sets) {
-    if (summary.sets.A > summary.sets.B) return "A";
-    if (summary.sets.B > summary.sets.A) return "B";
-  }
-  if (summary.games) {
-    if (summary.games.A > summary.games.B) return "A";
-    if (summary.games.B > summary.games.A) return "B";
-  }
-  if (summary.points) {
-    if (summary.points.A > summary.points.B) return "A";
-    if (summary.points.B > summary.points.A) return "B";
+  const checks: (keyof NonNullable<MatchSummary>)[] = [
+    "sets",
+    "games",
+    "points",
+  ];
+  for (const key of checks) {
+    const scores = summary[key];
+    if (scores) {
+      const entries = Object.entries(scores);
+      let maxSide: string | null = null;
+      let maxVal = -Infinity;
+      let tie = false;
+      for (const [side, val] of entries) {
+        if (val > maxVal) {
+          maxVal = val;
+          maxSide = side;
+          tie = false;
+        } else if (val === maxVal) {
+          tie = true;
+        }
+      }
+      if (!tie && maxSide !== null) return maxSide;
+    }
   }
   return null;
 }
@@ -34,23 +46,24 @@ export function computeHeadToHead(
   const map = new Map<string, { name: string; wins: number; losses: number }>();
 
   for (const m of matches) {
-    const side = m.playerIds.A.includes(playerId)
-      ? "A"
-      : m.playerIds.B.includes(playerId)
-        ? "B"
-        : null;
-    if (!side) continue;
-    const oppSide = side === "A" ? "B" : "A";
+    const myEntry = Object.entries(m.playerIds).find(([, ids]) =>
+      ids.includes(playerId)
+    );
+    if (!myEntry) continue;
+    const mySide = myEntry[0];
     const winSide = winner(m.summary);
     if (!winSide) continue;
-    const playerWon = winSide === side;
-    m.playerIds[oppSide].forEach((oppId, idx) => {
-      const oppName = m.names[oppSide][idx] ?? oppId;
-      const rec = map.get(oppId) || { name: oppName, wins: 0, losses: 0 };
-      if (playerWon) rec.wins += 1; else rec.losses += 1;
-      rec.name = oppName;
-      map.set(oppId, rec);
-    });
+    const playerWon = winSide === mySide;
+    for (const [side, ids] of Object.entries(m.playerIds)) {
+      if (side === mySide) continue;
+      ids.forEach((oppId, idx) => {
+        const oppName = m.names[side][idx] ?? oppId;
+        const rec = map.get(oppId) || { name: oppName, wins: 0, losses: 0 };
+        if (playerWon) rec.wins += 1; else rec.losses += 1;
+        rec.name = oppName;
+        map.set(oppId, rec);
+      });
+    }
   }
 
   return Array.from(map.entries())

--- a/apps/web/src/app/players/[id]/types.ts
+++ b/apps/web/src/app/players/[id]/types.ts
@@ -1,7 +1,7 @@
 export type MatchSummary = {
-  sets?: { A: number; B: number };
-  games?: { A: number; B: number };
-  points?: { A: number; B: number };
+  sets?: Record<string, number>;
+  games?: Record<string, number>;
+  points?: Record<string, number>;
 } | null;
 
 export type EnrichedMatch = {
@@ -10,7 +10,7 @@ export type EnrichedMatch = {
   bestOf: number | null;
   playedAt: string | null;
   location: string | null;
-  names: Record<"A" | "B", string[]>;
-  playerIds: Record<"A" | "B", string[]>;
+  names: Record<string, string[]>;
+  playerIds: Record<string, string[]>;
   summary?: MatchSummary;
 };

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -7,7 +7,7 @@ export type MatchRow = {
 };
 
 export type Participant = {
-  side: 'A' | 'B';
+  side: string;
   playerIds: string[];
 };
 
@@ -16,7 +16,7 @@ export type MatchDetail = {
 };
 
 export type EnrichedMatch = MatchRow & {
-  names: Record<'A' | 'B', string[]>;
+  names: Record<string, string[]>;
 };
 
 import { apiFetch } from './api';
@@ -59,7 +59,7 @@ export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> 
   }
 
   return details.map(({ row, detail }) => {
-    const names: Record<'A' | 'B', string[]> = { A: [], B: [] };
+    const names: Record<string, string[]> = {};
     for (const p of detail.participants) {
       names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
     }


### PR DESCRIPTION
## Summary
- Treat participant sides as dynamic strings across match utilities
- Compute player results by comparing their score to all other sides
- Render match names generically for any number of sides and update head-to-head logic

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in leaderboard.test.tsx and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c471ed90832389dc7847d65f6a08