### PR TITLE
Render all match participants dynamically

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -43,4 +43,32 @@ describe("MatchDetailPage", () => {
       .trim();
     expect(displayed).toBe(laDate);
   });
+
+  it("renders all participants dynamically", async () => {
+    const match = {
+      id: "m2",
+      sport: "bowling",
+      ruleset: "",
+      status: "",
+      playedAt: null,
+      participants: [
+        { side: "A", playerIds: ["p1"] },
+        { side: "B", playerIds: ["p2"] },
+        { side: "C", playerIds: ["p3"] },
+      ],
+      sets: [],
+    };
+
+    apiFetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => match })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p1", name: "Ann" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p2", name: "Ben" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p3", name: "Cam" }) });
+
+    render(await MatchDetailPage({ params: { mid: "m2" } }));
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Ann vs Ben vs Cam" })
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -5,7 +5,8 @@ import LiveSummary from "./live-summary";
 
 type ID = string;
 
-type Participant = { side: "A" | "B"; playerIds: string[] };
+// "side" can be any identifier (A, B, C, ...), so keep it loose
+type Participant = { side: string; playerIds: string[] };
 
 type MatchDetail = {
   id: ID;
@@ -63,7 +64,7 @@ export default async function MatchDetailPage({
     })
   );
 
-  const sideNames: Record<"A" | "B", string[]> = { A: [], B: [] };
+  const sideNames: Record<string, string[]> = {};
   for (const p of parts) {
     const names = (p.playerIds ?? []).map((id) => idToName.get(id) ?? id);
     sideNames[p.side] = names;
@@ -86,8 +87,9 @@ export default async function MatchDetailPage({
 
       <header className="section">
         <h1 className="heading">
-          {sideNames.A.length ? sideNames.A.join(" / ") : "A"} vs {" "}
-          {sideNames.B.length ? sideNames.B.join(" / ") : "B"}
+          {Object.keys(sideNames)
+            .map((s) => (sideNames[s]?.length ? sideNames[s].join(" / ") : s))
+            .join(" vs ") || "A vs B"}
         </h1>
         <p className="match-meta">
           {match.sport || "sport"} · {match.ruleset || "rules"} · {" "}


### PR DESCRIPTION
## Summary
- allow match detail page to handle any number of participant sides
- show all participant names in match header
- test that multiple bowling players render correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7c46358388323b761a34c452bdca0