### PR TITLE
Add admin override to disc golf match test

### DIFF
--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -15,10 +15,11 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import JSON
 
 from backend.app.db import Base, get_session
-from backend.app.models import Match, Sport, ScoreEvent, MatchParticipant
+from backend.app.models import Match, Sport, ScoreEvent, MatchParticipant, User
 from backend.app.routers import matches
 from backend.app.scoring import disc_golf
 from backend.app.routers.admin import require_admin
+from backend.app.routers.auth import get_current_user
 
 
 @pytest.fixture()
@@ -56,6 +57,9 @@ def client_and_session():
     app = FastAPI()
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_current_user] = lambda: User(
+        id="u1", username="admin", password_hash="", is_admin=True
+    )
     app.dependency_overrides[require_admin] = lambda: None
 
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- return admin user from `get_current_user` in disc golf events test to allow authenticated API calls

## Testing
- `pytest backend/tests/test_matches_disc_golf_events.py::test_create_and_append_event_hole -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ceaf29008323b3623c9c668faed8