### PR TITLE
Ensure match list sorted by played_at

### DIFF
--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -109,8 +109,11 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
   with TestClient(app) as client:
     resp = client.get("/matches")
     assert resp.status_code == 200
-    data = resp.json
-    assert [m["id"] for m in data] == ["m2", "m1"]
+    data = resp.json()
+    ids = [m["id"] for m in data]
+    assert ids == ["m2", "m1"]
+    sorted_ids = [m["id"] for m in sorted(data, key=lambda m: m["playedAt"], reverse=True)]
+    assert ids == sorted_ids
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- assert match listing returns JSON and IDs sorted by playedAt
- confirm router orders matches by latest played_at

## Testing
- `pytest backend/tests/test_matches.py::test_list_matches_returns_most_recent_first -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ceae2a1c832387fbd7a4a9c067d4