### PR TITLE
Display all match participants on index page

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -12,7 +12,7 @@ type MatchRow = {
 };
 
 type Participant = {
-  side: "A" | "B";
+  side: string;
   playerIds: string[];
 };
 
@@ -26,7 +26,7 @@ type MatchDetail = {
 };
 
 type EnrichedMatch = MatchRow & {
-  names: Record<"A" | "B", string[]>;
+  participants: string[][];
   summary?: MatchDetail["summary"];
 };
 
@@ -78,11 +78,10 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   }
 
   return details.map(({ row, detail }) => {
-    const names: Record<"A" | "B", string[]> = { A: [], B: [] };
-    for (const p of detail.participants) {
-      names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
-    }
-    return { ...row, names, summary: detail.summary };
+    const participants = detail.participants.map((p) =>
+      p.playerIds.map((id) => idToName.get(id) ?? id)
+    );
+    return { ...row, participants, summary: detail.summary };
   });
 }
 
@@ -123,7 +122,9 @@ export default async function MatchesPage(
           {matches.map((m) => (
             <li key={m.id} className="card match-item">
               <div style={{ fontWeight: 500 }}>
-                {m.names.A.join(" & ")} vs {m.names.B.join(" & ")}
+                {m.participants
+                  .map((names) => names.join(" & "))
+                  .join(" vs ")}
               </div>
               <div className="match-meta">
                 {formatSummary(m.summary)}


### PR DESCRIPTION
## Summary
- Remove A/B-only names structure in matches index page
- Iterate over all participant sides to show every competitor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c46b33048323a3120f77173ea7b7