### PR TITLE
Sort match participants by side

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -78,9 +78,10 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   }
 
   return details.map(({ row, detail }) => {
-    const participants = detail.participants.map((p) =>
-      p.playerIds.map((id) => idToName.get(id) ?? id)
-    );
+    const participants = detail.participants
+      .slice()
+      .sort((a, b) => a.side.localeCompare(b.side))
+      .map((p) => p.playerIds.map((id) => idToName.get(id) ?? id));
     return { ...row, participants, summary: detail.summary };
   });
 }
@@ -105,7 +106,7 @@ export default async function MatchesPage(
   }
 ) {
   const searchParams = props.searchParams ?? {};
-  the limit = Number(searchParams.limit) || 25;
+  const limit = Number(searchParams.limit) || 25;
   const offset = Number(searchParams.offset) || 0;
 
   try {


### PR DESCRIPTION
## Summary
- ensure match participants are sorted by side before rendering
- correct a typo in limit assignment when parsing search params

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7a2eb5083239e6a6888b7fd502f