### PR TITLE
Type padel match payload and fetch mocks

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -10,7 +10,7 @@ describe("Leaderboard", () => {
 
   it("fetches disc_golf when showing all sports", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     render(<Leaderboard sport="all" />);
 

--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";

--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -14,7 +14,7 @@ describe("RecordDiscGolfPage", () => {
 
   it("posts hole events", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     render(<RecordDiscGolfPage />);
 

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -28,7 +28,7 @@ describe("RecordPadelPage", () => {
       })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "m1" }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     render(<RecordPadelPage />);
 

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -23,6 +23,13 @@ interface SetScore {
   B: string;
 }
 
+interface CreateMatchPayload {
+  sport: string;
+  participants: { side: string; playerIds: string[] }[];
+  bestOf: number;
+  playedAt?: string;
+}
+
 export default function RecordPadelPage() {
   const router = useRouter();
   const [players, setPlayers] = useState<Player[]>([]);
@@ -81,7 +88,7 @@ export default function RecordPadelPage() {
     ];
 
     try {
-      const payload: any = {
+      const payload: CreateMatchPayload = {
         sport: "padel",
         participants,
         bestOf: Number(bestOf),


### PR DESCRIPTION
## Summary
- define `CreateMatchPayload` and use it for padel match creation
- cast test fetch mocks to `typeof fetch` instead of `any`
- clean up an unused React import in match detail test

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b7d9aa7c388323b3d7c3966761b175