### PR TITLE
Type fetch mocks and drop unused React imports

### DIFF
--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HomePageClient from '../home-page-client';

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import Leaderboard from "./leaderboard";

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 import { apiFetch } from "../../../lib/api";
 import LiveSummary from "./live-summary";

--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import type { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import MatchesPage from "./page";
 import "@testing-library/jest-dom";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
 }));
@@ -48,8 +48,7 @@ describe("MatchesPage", () => {
       // players by ids
       .mockResolvedValueOnce({ ok: true, json: async () => players });
 
-    // @ts-expect-error override for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     const page = await MatchesPage({ searchParams: {} });
     render(page);
@@ -86,8 +85,7 @@ describe("MatchesPage", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => detail })
       // players by ids
       .mockResolvedValueOnce({ ok: true, json: async () => [] });
-    // @ts-expect-error override for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     const page = await MatchesPage({ searchParams: {} });
     render(page);

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 import Pager from "./pager";

--- a/apps/web/src/app/matches/pager.tsx
+++ b/apps/web/src/app/matches/pager.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { useRouter } from "next/navigation";
 
 interface PagerProps {

--- a/apps/web/src/app/players/[id]/head-to-head.tsx
+++ b/apps/web/src/app/players/[id]/head-to-head.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { EnrichedMatch, MatchSummary } from "./types";
 
 function winner(summary?: MatchSummary): string | null {

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 import { apiFetch } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";

--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import type { ReactNode } from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import PlayersPage from "./page";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
 }));
@@ -17,8 +17,7 @@ describe("PlayersPage", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
-    // @ts-expect-error override global fetch for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<PlayersPage />);
 
@@ -29,8 +28,7 @@ describe("PlayersPage", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
-    // @ts-expect-error override global fetch for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<PlayersPage />);
 
@@ -52,8 +50,7 @@ describe("PlayersPage", () => {
         ],
       }),
     });
-    // @ts-expect-error override global fetch for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<PlayersPage />);
     await screen.findByText("Alice");
@@ -78,8 +75,7 @@ describe("PlayersPage", () => {
         ],
       }),
     });
-    // @ts-expect-error override global fetch for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<PlayersPage />);
     await screen.findByText("Alice");
@@ -99,8 +95,7 @@ describe("PlayersPage", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "1" }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
-    // @ts-expect-error override global fetch for test
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     vi.useFakeTimers();
     render(<PlayersPage />);

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import RecordSportPage from "./page";
@@ -26,7 +25,7 @@ describe("RecordSportPage", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) });
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordSportPage />);
 
@@ -67,7 +66,7 @@ describe("RecordSportPage", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordSportPage />);
 
@@ -115,7 +114,7 @@ describe("RecordSportPage", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordSportPage />);
 
@@ -153,7 +152,7 @@ describe("RecordSportPage", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordSportPage />);
 

--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import RecordDiscGolfPage from "./page";

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import RecordPadelPage from "./page";

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -5,4 +5,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
   },
+  esbuild: {
+    jsx: 'automatic',
+  },
 });


### PR DESCRIPTION
## Summary
- type `global.fetch` overrides in tests as `typeof fetch`
- remove unused `React` imports, using type-only `ReactNode` where needed
- enable automatic JSX transform in Vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e5ffa7188323b662a943505a1300