### PR TITLE
feat(web): add Suspense fallback for disc golf record

### DIFF
--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -60,9 +60,17 @@ function DiscGolfForm() {
   );
 }
 
+function DiscGolfLoading() {
+  return (
+    <main className="container">
+      <h1 className="heading">Record Disc Golf</h1>
+    </main>
+  );
+}
+
 export default function RecordDiscGolfPage() {
   return (
-    <Suspense fallback={<main className="container"><h1 className="heading">Record Disc Golf</h1></main>}>
+    <Suspense fallback={<DiscGolfLoading />}>
       <DiscGolfForm />
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- add dedicated loading fallback for disc golf record page and wrap form in React Suspense

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7e6011248832380d73c05e526730f