### PR TITLE
Mark dynamic pages to avoid build-time API calls

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { apiFetch } from "../../../lib/api";
 import LiveSummary from "./live-summary";
 
+export const dynamic = "force-dynamic";
+
 type ID = string;
 
 // "side" can be any identifier (A, B, C, ...), so keep it loose

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 import Pager from "./pager";
 
+export const dynamic = "force-dynamic";
+
 type MatchRow = {
   id: string;
   sport: string;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 60; // cache the page for one minute
+export const dynamic = 'force-dynamic';
 
 import { apiFetch } from '../lib/api';
 import HomePageClient from './home-page-client';

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -4,6 +4,8 @@ import { apiFetch } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
 
+export const dynamic = "force-dynamic";
+
 interface Player {
   id: string;
   name: string;

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 
+export const dynamic = "force-dynamic";
+
 type Sport = { id: string; name: string };
 
 export default async function RecordPage() {


### PR DESCRIPTION
## Summary
- mark server-rendered pages as dynamic to avoid calling APIs during build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e60165ac8323a762e259d2a74465