### PR TITLE
Add admin match management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ POST /api/v0/matches/{id}/sets
 GET  /api/v0/leaderboards?sport=padel
 WS   /api/v0/matches/{id}/stream
 
+Create an admin user
+
+curl -X POST http://localhost:8000/api/v0/auth/signup \
+  -H 'Content-Type: application/json' \
+  -H 'X-Admin-Secret: <admin-secret>' \
+  -d '{"username":"alice","password":"s3cret","is_admin":true}'
+
 Example: create a Padel match
 
 POST /api/v0/matches

--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { apiFetch, isAdmin } from "../../../lib/api";
+
+type MatchRow = {
+  id: string;
+  sport: string;
+  bestOf: number | null;
+  playedAt: string | null;
+  location: string | null;
+};
+
+type Participant = {
+  side: string;
+  playerIds: string[];
+};
+
+type MatchDetail = {
+  participants: Participant[];
+  summary?: {
+    sets?: Record<string, number>;
+    games?: Record<string, number>;
+    points?: Record<string, number>;
+  } | null;
+};
+
+type EnrichedMatch = MatchRow & {
+  participants: string[][];
+  summary?: MatchDetail["summary"];
+};
+
+async function getMatches(limit: number, offset: number): Promise<MatchRow[]> {
+  const r = await apiFetch(`/v0/matches?limit=${limit}&offset=${offset}`, {
+    cache: "no-store",
+  });
+  if (!r.ok) throw new Error(`Failed to load matches: ${r.status}`);
+  return (await r.json()) as MatchRow[];
+}
+
+async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
+  const details = await Promise.all(
+    rows.map(async (m) => {
+      const r = await apiFetch(`/v0/matches/${m.id}`, { cache: "no-store" });
+      if (!r.ok) throw new Error(`Failed to load match ${m.id}`);
+      const d = (await r.json()) as MatchDetail;
+      return { row: m, detail: d };
+    })
+  );
+
+  const ids = new Set<string>();
+  for (const { detail } of details) {
+    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+  }
+  const idToName = new Map<string, string>();
+  const idList = Array.from(ids);
+  if (idList.length) {
+    const r = await apiFetch(
+      `/v0/players/by-ids?ids=${idList.join(",")}`,
+      { cache: "no-store" }
+    );
+    if (r.ok) {
+      const players = (await r.json()) as {
+        id?: string;
+        name?: string;
+        playerId?: string;
+        playerName?: string;
+      }[];
+      players.forEach((p) => {
+        const pid = p.id ?? p.playerId;
+        const pname = p.name ?? p.playerName;
+        if (pid && pname) idToName.set(pid, pname);
+      });
+    }
+  }
+
+  return details.map(({ row, detail }) => {
+    const participants = detail.participants
+      .slice()
+      .sort((a, b) => a.side.localeCompare(b.side))
+      .map((p) => p.playerIds.map((id) => idToName.get(id) ?? id));
+    return { ...row, participants, summary: detail.summary };
+  });
+}
+
+function formatSummary(s?: MatchDetail["summary"]): string {
+  if (!s) return "";
+  const render = (scores: Record<string, number>, label: string) => {
+    const parts = Object.keys(scores)
+      .sort()
+      .map((k) => scores[k]);
+    return `${label} ${parts.join("-")}`;
+  };
+  if (s.sets) return render(s.sets, "Sets");
+  if (s.games) return render(s.games, "Games");
+  if (s.points) return render(s.points, "Points");
+  return "";
+}
+
+export default function AdminMatchesPage() {
+  const [matches, setMatches] = useState<EnrichedMatch[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const rows = await getMatches(100, 0);
+      rows.sort((a, b) => {
+        if (!a.playedAt) return 1;
+        if (!b.playedAt) return -1;
+        return new Date(b.playedAt).getTime() - new Date(a.playedAt).getTime();
+      });
+      const enriched = await enrichMatches(rows);
+      setMatches(enriched);
+      setError(null);
+    } catch {
+      setError("Failed to load matches.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin()) {
+      window.location.href = "/login";
+      return;
+    }
+    load();
+  }, [load]);
+
+  const handleDelete = async (id: string) => {
+    await apiFetch(`/v0/matches/${id}`, { method: "DELETE" });
+    await load();
+  };
+
+  return (
+    <main className="container">
+      <h1 className="heading">Admin Matches</h1>
+      {error && <p className="error">{error}</p>}
+      <ul className="match-list">
+        {matches.map((m) => (
+          <li key={m.id} className="card match-item">
+            <div style={{ fontWeight: 500 }}>
+              {m.participants.map((names) => names.join(" & ")).join(" vs ")}
+            </div>
+            <div className="match-meta">
+              {formatSummary(m.summary)}
+              {m.summary ? " · " : ""}
+              {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
+              {m.playedAt ? new Date(m.playedAt).toLocaleDateString() : "—"} ·{" "}
+              {m.location ?? "—"}
+            </div>
+            <div>
+              <Link href={`/matches/${m.id}`}>More info</Link>
+              <button
+                onClick={() => handleDelete(m.id)}
+                style={{ marginLeft: 8 }}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { isAdmin } from '../lib/api';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -48,6 +49,13 @@ export default function Header() {
               All Sports
             </Link>
           </li>
+          {isAdmin() && (
+            <li>
+              <Link href="/admin/matches" onClick={() => setOpen(false)}>
+                Admin
+              </Link>
+            </li>
+          )}
           <li>
             <Link href="/login" onClick={() => setOpen(false)}>
               Login

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -26,3 +26,16 @@ export async function apiFetch(path: string, init?: RequestInit) {
     throw err;
   }
 }
+
+export function isAdmin(): boolean {
+  if (typeof window === "undefined") return false;
+  const token = window.localStorage?.getItem("token");
+  if (!token) return false;
+  try {
+    const [, payload] = token.split(".");
+    const decoded = JSON.parse(atob(payload));
+    return !!decoded.is_admin;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- decode JWT to expose `isAdmin()` and use it to gate navigation
- add admin-only matches page with delete functionality
- document admin signup via API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e6f1ed78832388b25d94266dccc2