### PR TITLE
chore(web): pin typescript and eslint versions

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,12 +20,12 @@
         "@testing-library/react": "^16.3.0",
         "@types/node": "20.11.30",
         "@types/react": "18.3.3",
-        "@typescript-eslint/eslint-plugin": "^8.42.0",
-        "@typescript-eslint/parser": "^8.42.0",
+        "@typescript-eslint/eslint-plugin": "8.42.0",
+        "@typescript-eslint/parser": "8.42.0",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.2",
         "jsdom": "^22.1.0",
-        "typescript": "5.9.2",
+        "typescript": "^5.9.2",
         "vitest": "1.5.0"
       }
     },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,12 +22,12 @@
     "@testing-library/react": "^16.3.0",
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",
-    "@typescript-eslint/eslint-plugin": "^8.42.0",
-    "@typescript-eslint/parser": "^8.42.0",
+    "@typescript-eslint/eslint-plugin": "8.42.0",
+    "@typescript-eslint/parser": "8.42.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.2",
     "jsdom": "^22.1.0",
-    "typescript": "5.9.2",
+    "typescript": "^5.9.2",
     "vitest": "1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin `@typescript-eslint` packages to 8.42.0
- relax `typescript` to allow patch upgrades

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8ef476308832386ab516a34f67f73