### PR TITLE
test: override auth with admin user for disc golf events

### DIFF
--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -18,7 +18,6 @@ from backend.app.db import Base, get_session
 from backend.app.models import Match, Sport, ScoreEvent, MatchParticipant, User
 from backend.app.routers import matches
 from backend.app.scoring import disc_golf
-from backend.app.routers.admin import require_admin
 from backend.app.routers.auth import get_current_user
 
 
@@ -54,13 +53,13 @@ def client_and_session():
     matches.broadcast = dummy_broadcast
     matches.importlib.import_module = lambda *args, **kwargs: disc_golf
 
+    async def admin_user() -> User:
+        return User(id="u1", username="admin", password_hash="", is_admin=True)
+
     app = FastAPI()
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
-    app.dependency_overrides[get_current_user] = lambda: User(
-        id="u1", username="admin", password_hash="", is_admin=True
-    )
-    app.dependency_overrides[require_admin] = lambda: None
+    app.dependency_overrides[get_current_user] = admin_user
 
     with TestClient(app) as client:
         yield client, async_session_maker


### PR DESCRIPTION
## Summary
- ensure disc golf event tests authenticate as admin user

## Testing
- `pytest backend/tests/test_matches_disc_golf_events.py::test_create_and_append_event_hole -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ef44726c832397481b0e62e8069d