### PR TITLE
refactor: type fetch mocks and drop unused React

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, type MouseEvent } from 'react';
+import { useState, type MouseEvent, type ReactElement } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 import { enrichMatches, type MatchRow, type EnrichedMatch } from '../lib/matches';
@@ -28,7 +28,7 @@ export default function HomePageClient({
   matches: initialMatches,
   sportError: initialSportError,
   matchError: initialMatchError,
-}: Props): React.ReactElement {
+}: Props): ReactElement {
   const [sports, setSports] = useState(initialSports);
   const [matches, setMatches] = useState(initialMatches);
   const [sportError, setSportError] = useState(initialSportError);

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -9,7 +9,7 @@ describe("Leaderboard", () => {
 
   it("fetches disc_golf when showing all sports", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
-    global.fetch = fetchMock as unknown as typeof fetch;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<Leaderboard sport="all" />);
 

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 // Identifier type for players

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FormEvent, useState } from "react";
+import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../lib/api";
 

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import { useEffect, useState } from "react";
 import { useMatchStream } from "../../../lib/useMatchStream";
 
 export type SetData = Array<[number, number] | { A?: number; B?: number }> | null | undefined;
@@ -33,11 +33,11 @@ export default function LiveSummary({
   mid: string;
   initialSets?: SetData;
 }) {
-  const [sets, setSets] = React.useState(initialSets);
+  const [sets, setSets] = useState(initialSets);
   const { event, connected, fallback } = useMatchStream(mid);
   const isLive = connected && !fallback;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (event?.sets) {
       setSets(event.sets as SetData);
     }

--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { apiFetch } from "../../../lib/api";
 
 interface Comment {
@@ -29,7 +29,7 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
     load();
   }, [load]);
 
-  async function submit(e: React.FormEvent) {
+  async function submit(e: FormEvent) {
     e.preventDefault();
     if (!token) return;
     const resp = await apiFetch(`/v0/players/${playerId}/comments`, {

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/app/record/[sport]/page.tsx
 "use client";
 
-import React, { FormEvent, useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 

--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -13,7 +13,7 @@ describe("RecordDiscGolfPage", () => {
 
   it("posts hole events", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock as unknown as typeof fetch;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordDiscGolfPage />);
 

--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -27,7 +27,7 @@ describe("RecordPadelPage", () => {
       })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "m1" }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-    global.fetch = fetchMock as unknown as typeof fetch;
+    global.fetch = fetchMock as typeof fetch;
 
     render(<RecordPadelPage />);
 

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FormEvent, useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 


### PR DESCRIPTION
## Summary
- type global fetch mocks as `typeof fetch`
- remove unused default React imports and use explicit types

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8ef46f0688323934e8477bcdc1d94