### PR TITLE
fix: decode base64url jwt payload in isAdmin

### DIFF
--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,31 @@
+import { isAdmin } from './api';
+
+function buildToken(payload: Record<string, unknown>): string {
+  const json = JSON.stringify(payload);
+  const base64 = btoa(json);
+  const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `e30.${base64url}.sig`;
+}
+
+describe('isAdmin', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns true when token has is_admin true', () => {
+    const token = buildToken({ is_admin: true, char: 'ÿ' });
+    window.localStorage.setItem('token', token);
+    expect(isAdmin()).toBe(true);
+  });
+
+  it('returns false when token has is_admin false', () => {
+    const token = buildToken({ is_admin: false });
+    window.localStorage.setItem('token', token);
+    expect(isAdmin()).toBe(false);
+  });
+
+  it('returns false for malformed token', () => {
+    window.localStorage.setItem('token', 'bad.token');
+    expect(isAdmin()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -27,13 +27,19 @@ export async function apiFetch(path: string, init?: RequestInit) {
   }
 }
 
+function base64UrlDecode(str: string): string {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + (4 - (base64.length % 4)) % 4, "=");
+  return atob(padded);
+}
+
 export function isAdmin(): boolean {
   if (typeof window === "undefined") return false;
   const token = window.localStorage?.getItem("token");
   if (!token) return false;
   try {
     const [, payload] = token.split(".");
-    const decoded = JSON.parse(atob(payload));
+    const decoded = JSON.parse(base64UrlDecode(payload));
     return !!decoded.is_admin;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- decode JWT payload using base64url-safe routine before checking `is_admin`
- add tests for base64url token decoding

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8f32fb9248323a7bc27c8953bc81a