### PR TITLE
chore: import Suspense directly for disc golf page

### DIFF
--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";


### PR DESCRIPTION
## Summary
- import Suspense directly for disc golf recording page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8ef4774e48323bf35babb8a8e5c79