### PR TITLE
fix match details and location entry

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -3,49 +3,45 @@
 import { useEffect, useState } from "react";
 import { useMatchStream } from "../../../lib/useMatchStream";
 
-export type SetData = Array<[number, number] | { A?: number; B?: number }> | null | undefined;
+export type SummaryData = {
+  sets?: Record<string, number>;
+  games?: Record<string, number>;
+  points?: Record<string, number>;
+} | null | undefined;
 
-function normalizeSet(s: [number, number] | { A?: number; B?: number }): [number, number] {
-  if (Array.isArray(s) && s.length === 2) return [Number(s[0]) || 0, Number(s[1]) || 0];
-  const obj = s as { A?: number; B?: number };
-  return [Number(obj.A) || 0, Number(obj.B) || 0];
-}
-
-function formatScoreline(sets?: SetData): string {
-  if (!sets || !sets.length) return "—";
-  const ns = sets.map(normalizeSet);
-  const tallies = ns.reduce(
-    (acc, [a, b]) => {
-      if (a > b) acc.A += 1;
-      else if (b > a) acc.B += 1;
-      return acc;
-    },
-    { A: 0, B: 0 }
-  );
-  const setStr = ns.map(([a, b]) => `${a}-${b}`).join(", ");
-  return `${tallies.A}-${tallies.B} (${setStr})`;
+function formatScoreline(summary?: SummaryData): string {
+  if (!summary) return "—";
+  const format = (scores?: Record<string, number>) => {
+    const a = scores?.A ?? 0;
+    const b = scores?.B ?? 0;
+    return `${a}-${b}`;
+  };
+  if (summary.sets) return format(summary.sets);
+  if (summary.games) return format(summary.games);
+  if (summary.points) return format(summary.points);
+  return "—";
 }
 
 export default function LiveSummary({
   mid,
-  initialSets,
+  initialSummary,
 }: {
   mid: string;
-  initialSets?: SetData;
+  initialSummary?: SummaryData;
 }) {
-  const [sets, setSets] = useState(initialSets);
+  const [summary, setSummary] = useState<SummaryData>(initialSummary);
   const { event, connected, fallback } = useMatchStream(mid);
   const isLive = connected && !fallback;
 
   useEffect(() => {
-    if (event?.sets) {
-      setSets(event.sets as SetData);
+    if (event?.summary) {
+      setSummary(event.summary as SummaryData);
     }
   }, [event]);
 
   return (
     <div className="match-meta">
-      <span>Overall: {formatScoreline(sets)}</span>
+      <span>Overall: {formatScoreline(summary)}</span>
       <span className="connection-indicator">
         <span className={`dot ${isLive ? "dot-live" : "dot-polling"}`} />
         {isLive ? "Live" : "Polling…"}

--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -26,7 +26,7 @@ describe("MatchDetailPage", () => {
       status: "",
       playedAt: "2024-01-01T00:00:00",
       participants: [],
-      sets: [],
+      summary: {},
     };
     apiFetchMock.mockResolvedValueOnce({ ok: true, json: async () => match });
 
@@ -55,14 +55,19 @@ describe("MatchDetailPage", () => {
         { side: "B", playerIds: ["p2"] },
         { side: "C", playerIds: ["p3"] },
       ],
-      sets: [],
+      summary: {},
     };
 
     apiFetchMock
       .mockResolvedValueOnce({ ok: true, json: async () => match })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p1", name: "Ann" }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p2", name: "Ben" }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "p3", name: "Cam" }) });
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "p1", name: "Ann" },
+          { id: "p2", name: "Ben" },
+          { id: "p3", name: "Cam" },
+        ],
+      });
 
     render(await MatchDetailPage({ params: { mid: "m2" } }));
 

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -9,6 +9,12 @@ type ID = string;
 // "side" can be any identifier (A, B, C, ...), so keep it loose
 type Participant = { side: string; playerIds: string[] };
 
+type Summary = {
+  sets?: Record<string, number>;
+  games?: Record<string, number>;
+  points?: Record<string, number>;
+};
+
 type MatchDetail = {
   id: ID;
   sport?: string | null;
@@ -17,8 +23,7 @@ type MatchDetail = {
   playedAt?: string | null;
   location?: string | null;
   participants?: Participant[] | null;
-  // sets can be [[A,B], ...] or [{A,B}, ...] depending on backend normalization
-  sets?: Array<[number, number] | { A: number; B: number }> | null;
+  summary?: Summary | null;
 };
 
 async function fetchMatch(mid: string): Promise<MatchDetail> {
@@ -29,20 +34,26 @@ async function fetchMatch(mid: string): Promise<MatchDetail> {
   return (await res.json()) as MatchDetail;
 }
 
-async function fetchPlayerName(pid: string): Promise<string> {
-  const res = (await apiFetch(`/v0/players/${encodeURIComponent(pid)}`, {
-    cache: "no-store",
-  } as RequestInit)) as Response;
-  if (!res.ok) return pid;
-  const data = (await res.json()) as { id: string; name: string };
-  return data?.name ?? pid;
-}
-
-function normalizeSet(s: [number, number] | { A?: number; B?: number }): [number, number] {
-  // Accept either tuple or object
-  if (Array.isArray(s) && s.length === 2) return [Number(s[0]) || 0, Number(s[1]) || 0];
-  const obj = s as { A?: number; B?: number };
-  return [Number(obj.A) || 0, Number(obj.B) || 0];
+async function fetchPlayerNames(ids: string[]): Promise<Map<string, string>> {
+  if (!ids.length) return new Map();
+  const res = (await apiFetch(
+    `/v0/players/by-ids?ids=${ids.join(",")}`,
+    { cache: "no-store" }
+  )) as Response;
+  const map = new Map<string, string>();
+  if (!res.ok) return map;
+  const players = (await res.json()) as {
+    id?: string;
+    name?: string;
+    playerId?: string;
+    playerName?: string;
+  }[];
+  players.forEach((p) => {
+    const pid = p.id ?? p.playerId;
+    const pname = p.name ?? p.playerName;
+    if (pid && pname) map.set(pid, pname);
+  });
+  return map;
 }
 
 export default async function MatchDetailPage({
@@ -52,18 +63,11 @@ export default async function MatchDetailPage({
 }) {
   const match = await fetchMatch(params.mid);
 
-  // Resolve participant names (parallel)
   const parts = match.participants ?? [];
   const uniqueIds = Array.from(
     new Set(parts.flatMap((p) => p.playerIds ?? []))
   );
-  const idToName = new Map<string, string>();
-  await Promise.all(
-    uniqueIds.map(async (pid) => {
-      const name = await fetchPlayerName(pid);
-      idToName.set(pid, name);
-    })
-  );
+  const idToName = await fetchPlayerNames(uniqueIds);
 
   const sideNames: Record<string, string[]> = {};
   for (const p of parts) {
@@ -99,36 +103,7 @@ export default async function MatchDetailPage({
           {match.location ? ` · ${match.location}` : ""}
         </p>
       </header>
-
-      <section className="section">
-        <h2>Sets</h2>
-        {match.sets && match.sets.length ? (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left">
-                <th className="py-1 pr-4">#</th>
-                <th className="py-1 pr-4">A</th>
-                <th className="py-1">B</th>
-              </tr>
-            </thead>
-            <tbody>
-              {match.sets.map((s, i) => {
-                const [a, b] = normalizeSet(s);
-                return (
-                  <tr key={i} className="border-t">
-                    <td className="py-1 pr-4">{i + 1}</td>
-                    <td className={`py-1 pr-4${a > b ? " font-bold" : ""}`}>{a}</td>
-                    <td className={`py-1${b > a ? " font-bold" : ""}`}>{b}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        ) : (
-          <p className="match-meta">No sets recorded yet.</p>
-        )}
-      </section>
-      <LiveSummary mid={params.mid} initialSets={match.sets} />
+      <LiveSummary mid={params.mid} initialSummary={match.summary} />
     </main>
   );
 }

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -36,6 +36,7 @@ export default function RecordSportPage() {
   const [error, setError] = useState<string | null>(null);
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
+  const [location, setLocation] = useState("");
 
   // Padal is always doubles. Other sports default to singles unless specified.
   const [doubles, setDoubles] = useState(isPadel);
@@ -121,6 +122,7 @@ export default function RecordSportPage() {
         participants: MatchParticipant[];
         score?: [number, number];
         playedAt?: string;
+        location?: string;
       }
       const payload: MatchPayload = {
         sport,
@@ -135,6 +137,9 @@ export default function RecordSportPage() {
         } else {
           payload.playedAt = `${date}T00:00:00`;
         }
+      }
+      if (location) {
+        payload.location = location;
       }
       const res = await apiFetch(`/v0/matches`, {
         method: "POST",
@@ -177,6 +182,14 @@ export default function RecordSportPage() {
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
+
+        <input
+          type="text"
+          aria-label="Location"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
 
         {isBowling ? (
           <div className="players">


### PR DESCRIPTION
## Summary
- restore location entry when recording a match
- fetch player names and summary data to show match details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91d425b648323b3abdbde071cfef0