### PR TITLE
Hide Albert accounts on players page

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -69,6 +69,26 @@ describe("PlayersPage", () => {
     vi.useRealTimers();
   });
 
+  it("filters out Albert accounts", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        players: [
+          { id: "1", name: "Albert" },
+          { id: "2", name: "Bob" },
+        ],
+      }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    await act(async () => {
+      render(<PlayersPage />);
+    });
+
+    expect(screen.queryByText("Albert")).toBeNull();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
   it("shows a message when no players match the search", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -36,7 +36,10 @@ export default function PlayersPage() {
       });
       if (res.ok) {
         const data = await res.json();
-        setPlayers(data.players);
+        const filtered = (data.players as Player[]).filter(
+          (p) => !p.name.toLowerCase().startsWith("albert")
+        );
+        setPlayers(filtered);
       } else {
         setError("Failed to load players.");
       }


### PR DESCRIPTION
## Summary
- filter out Albert player accounts from player list
- add test covering Albert account filtering

## Testing
- `CI=1 npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b93591119c8323a6141517005e09c0