### PR TITLE
feat: show login status and allow logout

### DIFF
--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -1,11 +1,29 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
-import { isAdmin } from '../lib/api';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { currentUsername, isAdmin, logout } from '../lib/api';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const [user, setUser] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const update = () => setUser(currentUsername());
+    update();
+    window.addEventListener('storage', update);
+    return () => window.removeEventListener('storage', update);
+  }, []);
+
+  const handleLogout = () => {
+    logout();
+    setUser(null);
+    setOpen(false);
+    router.push('/');
+  };
+
   return (
     <header className="nav">
       <button
@@ -56,11 +74,20 @@ export default function Header() {
               </Link>
             </li>
           )}
-          <li>
-            <Link href="/login" onClick={() => setOpen(false)}>
-              Login
-            </Link>
-          </li>
+          {user ? (
+            <>
+              <li className="user-status">Logged in as {user}</li>
+              <li>
+                <button onClick={handleLogout}>Logout</button>
+              </li>
+            </>
+          ) : (
+            <li>
+              <Link href="/login" onClick={() => setOpen(false)}>
+                Login
+              </Link>
+            </li>
+          )}
         </ul>
       </nav>
     </header>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,10 +2,11 @@
 
 import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { apiFetch } from "../../lib/api";
+import { apiFetch, currentUsername, logout } from "../../lib/api";
 
 export default function LoginPage() {
   const router = useRouter();
+  const [user, setUser] = useState(currentUsername());
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [newUser, setNewUser] = useState("");
@@ -53,6 +54,22 @@ export default function LoginPage() {
       setError("Signup failed");
     }
   };
+
+  if (user) {
+    return (
+      <main className="container">
+        <h1 className="heading">Logged in as {user}</h1>
+        <button
+          onClick={() => {
+            logout();
+            setUser(null);
+          }}
+        >
+          Logout
+        </button>
+      </main>
+    );
+  }
 
   return (
     <main className="container">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,15 +33,34 @@ function base64UrlDecode(str: string): string {
   return atob(padded);
 }
 
-export function isAdmin(): boolean {
-  if (typeof window === "undefined") return false;
+function getTokenPayload(): any | null {
+  if (typeof window === "undefined") return null;
   const token = window.localStorage?.getItem("token");
-  if (!token) return false;
+  if (!token) return null;
   try {
     const [, payload] = token.split(".");
-    const decoded = JSON.parse(base64UrlDecode(payload));
-    return !!decoded.is_admin;
+    return JSON.parse(base64UrlDecode(payload));
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function currentUsername(): string | null {
+  const payload = getTokenPayload();
+  return payload?.username ?? null;
+}
+
+export function isLoggedIn(): boolean {
+  return getTokenPayload() !== null;
+}
+
+export function logout() {
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem("token");
+  }
+}
+
+export function isAdmin(): boolean {
+  const payload = getTokenPayload();
+  return !!payload?.is_admin;
 }


### PR DESCRIPTION
## Summary
- show logged in user and logout button in navigation header
- block login form when already authenticated and add logout option
- add client-side helpers for reading and clearing auth tokens

## Testing
- `npx vitest run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9354ee4f08323bf7173d8a09ca467