### PR TITLE
fix(web): refresh header on same-tab auth changes

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -25,6 +25,11 @@ export default function LoginPage() {
       if (res.ok) {
         const data = await res.json();
         window.localStorage.setItem("token", data.access_token);
+        // The header listens for the `storage` event to refresh auth state,
+        // but that event isn't emitted in the same tab that updates
+        // localStorage.  Manually dispatch it so the header reflects the new
+        // login immediately.
+        window.dispatchEvent(new Event("storage"));
         router.push("/");
       } else {
         setError("Login failed");
@@ -46,6 +51,9 @@ export default function LoginPage() {
       if (res.ok) {
         const data = await res.json();
         window.localStorage.setItem("token", data.access_token);
+        // Notify other components of the updated auth token.  Without this the
+        // header will continue showing stale login state until a page reload.
+        window.dispatchEvent(new Event("storage"));
         router.push("/");
       } else {
         setError("Signup failed");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,7 +33,13 @@ function base64UrlDecode(str: string): string {
   return atob(padded);
 }
 
-function getTokenPayload(): any | null {
+interface TokenPayload {
+  username?: string;
+  is_admin?: boolean;
+  [key: string]: unknown;
+}
+
+function getTokenPayload(): TokenPayload | null {
   if (typeof window === "undefined") return null;
   const token = window.localStorage?.getItem("token");
   if (!token) return null;
@@ -57,6 +63,10 @@ export function isLoggedIn(): boolean {
 export function logout() {
   if (typeof window !== "undefined") {
     window.localStorage.removeItem("token");
+    // Manually notify listeners since the `storage` event doesn't fire in
+    // the same tab that performed the update.  Header components listen for
+    // this event to refresh login state.
+    window.dispatchEvent(new Event("storage"));
   }
 }
 


### PR DESCRIPTION
## Summary
- dispatch a `storage` event whenever login/signup/logout modify the auth token
- define a `TokenPayload` type to satisfy lint

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b939d40f4883239cd2ec1dd12d868c