### PR TITLE
Enforce password complexity during signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Create an admin user
 curl -X POST http://localhost:8000/api/v0/auth/signup \
   -H 'Content-Type: application/json' \
   -H 'X-Admin-Secret: <admin-secret>' \
-  -d '{"username":"alice","password":"s3cret","is_admin":true}'
+  -d '{"username":"alice","password":"Str0ng!Pass","is_admin":true}'
 
 Example: create a Padel match
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,9 @@
 from typing import Any, Dict, List, Literal, Optional, Tuple
 from datetime import datetime
-from pydantic import BaseModel, Field, model_validator
+import re
+from pydantic import BaseModel, Field, model_validator, field_validator
+
+PASSWORD_REGEX = re.compile(r"^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$")
 
 class SportOut(BaseModel):
     id: str
@@ -125,8 +128,16 @@ class EventIn(BaseModel):
 class UserCreate(BaseModel):
     """Schema for user signup requests."""
     username: str = Field(..., min_length=3, max_length=50)
-    password: str
+    password: str = Field(..., min_length=8)
     is_admin: bool = False
+
+    @field_validator("password")
+    def _check_password_complexity(cls, v: str) -> str:
+        if not PASSWORD_REGEX.match(v):
+            raise ValueError(
+                "Password must contain letters, numbers, and symbols"
+            )
+        return v
 
 class UserLogin(BaseModel):
     """Schema for user login requests."""

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -57,12 +57,14 @@ def setup_db():
 
 def test_comment_crud():
     with TestClient(app) as client:
-        resp = client.post("/auth/signup", json={"username": "bob", "password": "pw"})
+        resp = client.post(
+            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass"}
+        )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
         admin_token = client.post(
             "/auth/signup",
-            json={"username": "admin", "password": "pw", "is_admin": True},
+            json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
             headers={"X-Admin-Secret": "admintest"},
         ).json()["access_token"]
         pid = client.post(

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -281,12 +281,12 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 
   token_resp = client.post(
       "/auth/signup",
-      json={"username": "admin", "password": "pw", "is_admin": True},
+      json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
       headers={"X-Admin-Secret": "admintest"},
   )
   if token_resp.status_code != 200:
     token_resp = client.post(
-        "/auth/login", json={"username": "admin", "password": "pw"}
+        "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
     )
   token = token_resp.json()["access_token"]
 
@@ -335,12 +335,12 @@ async def test_delete_match_missing_returns_404(tmp_path):
   with TestClient(app) as client:
     token_resp = client.post(
         "/auth/signup",
-        json={"username": "admin", "password": "pw", "is_admin": True},
+        json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
         headers={"X-Admin-Secret": "admintest"},
     )
     if token_resp.status_code != 200:
       token_resp = client.post(
-          "/auth/login", json={"username": "admin", "password": "pw"}
+          "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
       )
     token = token_resp.json()["access_token"]
     resp = client.delete(

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -63,12 +63,12 @@ def setup_db():
 def admin_token(client: TestClient) -> str:
     resp = client.post(
         "/auth/signup",
-        json={"username": "admin", "password": "pw", "is_admin": True},
+        json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
         headers={"X-Admin-Secret": "admintest"},
     )
     if resp.status_code != 200:
         resp = client.post(
-            "/auth/login", json={"username": "admin", "password": "pw"}
+            "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
         )
     return resp.json()["access_token"]
 


### PR DESCRIPTION
## Summary
- require user passwords to be at least 8 characters and include letters, numbers, and symbols
- update documentation and tests to reflect new password requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b958f388708323b7b77ded0e0e1559