### PR TITLE
Use bcrypt-based password hashing

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ httpx>=0.23,<1.0
 PyJWT>=2.0,<3.0
 jinja2>=3.1,<4.0
 matplotlib>=3.7,<4.0
+passlib[bcrypt]>=1.7,<2.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from app import db
 from app.models import User, Player, Club
 from app.routers import auth, players
+from app.routers.auth import pwd_context
 
 app = FastAPI()
 app.include_router(auth.router)
@@ -58,6 +59,18 @@ def test_signup_login_and_protected_access():
         assert resp.status_code == 200
         token = resp.json()["access_token"]
         assert token
+
+        async def fetch_user():
+            async with db.AsyncSessionLocal() as session:
+                return (
+                    await session.execute(
+                        select(User).where(User.username == "alice")
+                    )
+                ).scalar_one()
+
+        user = asyncio.run(fetch_user())
+        assert user.password_hash != "pw"
+        assert pwd_context.verify("pw", user.password_hash)
 
         resp = client.post(
             "/auth/login", json={"username": "alice", "password": "pw"}


### PR DESCRIPTION
## Summary
- Switch to `passlib` bcrypt hashing for user passwords
- Verify credentials using `CryptContext` instead of SHA256 comparisons
- Adjust auth tests to check bcrypt hashed passwords

## Testing
- `pytest backend/tests/test_auth.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b958f16bb483239f739d98a69e0b21