### PR TITLE
feat: rate-limit login attempts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
 from .routers import (
     sports,
     rulesets,
@@ -40,6 +41,9 @@ app = FastAPI(
     redoc_url="/api/redoc",
     openapi_url="/api/openapi.json",
 )
+
+app.state.limiter = auth.limiter
+app.add_exception_handler(RateLimitExceeded, auth.rate_limit_handler)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ httpx>=0.23,<1.0
 PyJWT>=2.0,<3.0
 jinja2>=3.1,<4.0
 matplotlib>=3.7,<4.0
+slowapi>=0.1,<1.0


### PR DESCRIPTION
## Summary
- use slowapi to rate-limit login attempts
- wire limiter into FastAPI app and return 429 on excessive login requests
- test that repeated login attempts trigger rate limiting

## Testing
- `pytest backend/tests/test_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68b958f4a54483239f37d54a73d81c40