### PR TITLE
Require explicit JWT secret configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ POSTGRES_DB=crosssport
 POSTGRES_PASSWORD=
 DATABASE_URL=
 SECRET_KEY=
+# High-entropy secret for signing JWTs
+JWT_SECRET=
 # When cookies/credentials are enabled, list each trusted origin explicitly
 ADMIN_SECRET=YOUR_ADMIN_SECRET_FOR_API
 ALLOW_CREDENTIALS=true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Runtime: Python 3.12, Node 20, Postgres 16
 
 IDs & pagination: ULID strings, cursor-based pagination
 
-Auth: Credentials (username/password) for $0 email costs; magic-link later
+Auth: Credentials (username/password) for $0 email costs; magic-link later. JWT tokens require a high-entropy `JWT_SECRET` env var
 
 Multi-tenancy: Club-scoped (club_id on entities)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,7 +11,9 @@ from ..db import get_session
 from ..models import User, Player
 from ..schemas import UserCreate, UserLogin, TokenOut
 
-JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+  raise RuntimeError("JWT_SECRET environment variable is required")
 JWT_ALG = "HS256"
 JWT_EXPIRE_SECONDS = 3600
 

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -9,6 +9,8 @@ from sqlalchemy import select, text
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+os.environ["JWT_SECRET"] = "testsecret"
+
 
 @pytest.fixture
 def anyio_backend():
@@ -18,7 +20,6 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   from app import db
   from app.models import Player, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -77,7 +78,6 @@ async def test_create_match_rejects_duplicate_players(tmp_path):
 @pytest.mark.anyio
 async def test_list_matches_returns_most_recent_first(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -121,7 +121,6 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
 @pytest.mark.anyio
 async def test_list_matches_upcoming_filter(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -231,7 +230,6 @@ def test_list_matches_filters_by_player(tmp_path):
 @pytest.mark.anyio
 async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -312,7 +310,6 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 @pytest.mark.anyio
 async def test_delete_match_missing_returns_404(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -465,7 +462,6 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
 @pytest.mark.anyio
 async def test_create_match_preserves_naive_date(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
-  os.environ["JWT_SECRET"] = "testsecret"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db

--- a/docker-compose.unraid.yml
+++ b/docker-compose.unraid.yml
@@ -22,6 +22,7 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - SECRET_KEY=${SECRET_KEY}
       - ADMIN_SECRET=${ADMIN_SECRET}
+      - JWT_SECRET=${JWT_SECRET}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
       - PYTHONPATH=/app
     command: >

--- a/docker-compose.unraid.yml.bak
+++ b/docker-compose.unraid.yml.bak
@@ -18,6 +18,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - SECRET_KEY=${SECRET_KEY}
+      - JWT_SECRET=${JWT_SECRET}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
     command: >
       sh -c "alembic upgrade head &&

--- a/docker-compose.unraid.yml.bak.2025-08-27_0916
+++ b/docker-compose.unraid.yml.bak.2025-08-27_0916
@@ -21,6 +21,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - SECRET_KEY=${SECRET_KEY}
+      - JWT_SECRET=${JWT_SECRET}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
       - PYTHONPATH=/app
     command: >


### PR DESCRIPTION
## Summary
- error on startup when `JWT_SECRET` isn't set
- document JWT secret requirement and encourage high entropy
- pass JWT secret through docker compose and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b958f49a0c832395b7d9b218f55281