### PR TITLE
Avoid requiring JWT_SECRET at import time

### DIFF
--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def test_rejects_wildcard_with_credentials(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
     monkeypatch.setenv("ALLOWED_ORIGINS", "*")
     monkeypatch.setenv("ALLOW_CREDENTIALS", "true")
     sys.modules.pop("app.main", None)


### PR DESCRIPTION
## Summary
- Move JWT_SECRET validation from module import to a helper function in auth router
- Update CORS test to unset JWT_SECRET so configuration imports without auth context

## Testing
- `pytest backend/tests/test_cors.py backend/tests/test_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68b95ecd99748323954f64703ff226de