### PR TITLE
Enable bowling score input

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -165,6 +165,11 @@ describe("RecordSportPage", () => {
     fireEvent.change(selects[1], { target: { value: "2" } });
     fireEvent.change(selects[2], { target: { value: "3" } });
 
+    const scoreInputs = screen.getAllByPlaceholderText(/score/i);
+    fireEvent.change(scoreInputs[0], { target: { value: "100" } });
+    fireEvent.change(scoreInputs[1], { target: { value: "120" } });
+    fireEvent.change(scoreInputs[2], { target: { value: "90" } });
+
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -174,6 +179,6 @@ describe("RecordSportPage", () => {
       { side: "B", playerIds: ["2"] },
       { side: "C", playerIds: ["3"] },
     ]);
-    expect(payload.score).toBeUndefined();
+    expect(payload.score).toEqual([100, 120, 90]);
   });
 });

--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -120,6 +120,9 @@ async def create_match(
         )
         session.add(mp)
 
+    if body.score:
+        match.details = {"score": {chr(65 + i): s for i, s in enumerate(body.score)}}
+
     await session.commit()
     return MatchIdOut(id=mid)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -87,6 +87,7 @@ class MatchCreate(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    score: Optional[List[int]] = None
 
 class ParticipantByName(BaseModel):
     side: Literal["A", "B", "C", "D", "E", "F"]

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -12,7 +12,7 @@ from fastapi.responses import JSONResponse
 from app import db
 from app.routers import players, auth, badges
 from app.models import Player, Club, User, Badge, PlayerBadge, PlayerMetric
-from app.exceptions include DomainException, ProblemDetail
+from app.exceptions import DomainException, ProblemDetail
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- allow entering scores for each bowling player in record form
- capture bowling scores in API payload and persist match details
- test and schema updates

## Testing
- `cd apps/web && npm test`
- `cd backend && pytest` *(fails: ImportError: cannot import name 'pwd_context' from app.routers.auth)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e81f73c83238a73a692f26bb4ad