### PR TITLE
Harden rate limiter against X-Forwarded-For spoofing

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -25,9 +25,9 @@ JWT_EXPIRE_SECONDS = 3600
 def _get_client_ip(request: Request) -> str:
   forwarded = request.headers.get("X-Forwarded-For")
   if forwarded:
-    ip = forwarded.split(",")[0].strip()
-    if ip:
-      return ip
+    parts = [ip.strip() for ip in forwarded.split(",") if ip.strip()]
+    if parts:
+      return parts[-1]
   real_ip = request.headers.get("X-Real-IP")
   if real_ip:
     return real_ip

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -211,6 +211,31 @@ def test_login_rate_limited_per_ip():
         )
         assert ok2.status_code == 200
 
+
+def test_login_rate_limit_not_bypassed_by_spoofed_x_forwarded_for():
+    auth.limiter.reset()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/auth/signup", json={"username": "spoof", "password": "Str0ng!Pass"}
+        )
+        assert resp.status_code == 200
+        real_ip = "9.9.9.9"
+        for i in range(5):
+            headers = {"X-Forwarded-For": f"{i}.0.0.1, {real_ip}"}
+            ok = client.post(
+                "/auth/login",
+                json={"username": "spoof", "password": "Str0ng!Pass"},
+                headers=headers,
+            )
+            assert ok.status_code == 200
+        headers = {"X-Forwarded-For": f"random, {real_ip}"}
+        resp = client.post(
+            "/auth/login",
+            json={"username": "spoof", "password": "Str0ng!Pass"},
+            headers=headers,
+        )
+        assert resp.status_code == 429
+
 def test_login_accepts_sha256_hash():
     auth.limiter.reset()
     async def create_legacy_user():


### PR DESCRIPTION
## Summary
- derive client IP from the rightmost X-Forwarded-For entry to prevent spoofing
- add test ensuring X-Forwarded-For spoofing cannot bypass login rate limits

## Testing
- `pip install passlib[bcrypt]`
- `pytest backend/tests/test_auth.py::test_login_rate_limit_not_bypassed_by_spoofed_x_forwarded_for -q`
- `pytest backend/tests/test_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96042a8b88323bf3f7747f42afc59