### PR TITLE
test: import models for test tables

### DIFF
--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -52,7 +52,7 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
 async def test_create_match_rejects_duplicate_players(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
-  from app.models import User
+  from app.models import Match, MatchParticipant, Sport, User
   from app.schemas import MatchCreate, Participant
   from app.routers.matches import create_match
 


### PR DESCRIPTION
## Summary
- import Sport, Match, and MatchParticipant models in duplicate-player test setup

## Testing
- `pytest` *(fails: JWT_SECRET must be at least 32 characters, missing tables)*

------
https://chatgpt.com/codex/tasks/task_e_68b961d7c4cc8323a12c49fdad8f1362