### PR TITLE
test: add unit and e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: apps/web/package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npx playwright test

--- a/apps/web/e2e/auth.e2e.ts
+++ b/apps/web/e2e/auth.e2e.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('user can log in', async ({ page }) => {
+  await page.route('**/v0/auth/login', async (route) => {
+    const body = JSON.parse(route.request().postData() || '{}');
+    expect(body).toEqual({ username: 'alice', password: 'secret' });
+    await route.fulfill({ status: 200, body: JSON.stringify({ access_token: 't' }) });
+  });
+  await page.goto('/login');
+  await page.getByPlaceholder('Username').first().fill('alice');
+  await page.getByPlaceholder('Password').first().fill('secret');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page).toHaveURL('/');
+});
+
+test('failed signup shows error', async ({ page }) => {
+  await page.route('**/v0/auth/signup', (route) =>
+    route.fulfill({ status: 400, body: '{}' })
+  );
+  await page.goto('/login');
+  await page.getByPlaceholder('Username').nth(1).fill('bob');
+  await page.getByPlaceholder('Password').nth(1).fill('pass');
+  await page.getByRole('button', { name: 'Sign Up' }).click();
+  await expect(page.getByRole('alert')).toHaveText(/signup failed/i);
+});

--- a/apps/web/e2e/score.e2e.ts
+++ b/apps/web/e2e/score.e2e.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test('record padel match', async ({ page }) => {
+  await page.route('**/v0/players', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        players: [
+          { id: '1', name: 'Alice' },
+          { id: '2', name: 'Bob' },
+          { id: '3', name: 'Cara' },
+          { id: '4', name: 'Dan' },
+        ],
+      }),
+    })
+  );
+  let matchCalled = false;
+  await page.route('**/v0/matches', async (route) => {
+    matchCalled = true;
+    await route.fulfill({ status: 200, body: JSON.stringify({ id: 'm1' }) });
+  });
+  let setsCalled = false;
+  await page.route('**/v0/matches/m1/sets', async (route) => {
+    setsCalled = true;
+    const body = JSON.parse(route.request().postData() || '{}');
+    expect(body.sets).toEqual([{ A: 6, B: 4 }]);
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+
+  await page.goto('/record/padel');
+  await page.selectOption('select[aria-label="Player A1"]', '1');
+  await page.selectOption('select[aria-label="Player A2"]', '2');
+  await page.selectOption('select[aria-label="Player B1"]', '3');
+  await page.selectOption('select[aria-label="Player B2"]', '4');
+  await page.getByPlaceholder('Set 1 A').fill('6');
+  await page.getByPlaceholder('Set 1 B').fill('4');
+  await page.getByRole('button', { name: 'Save' }).click();
+  expect(matchCalled).toBe(true);
+  expect(setsCalled).toBe(true);
+});

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.2",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/node": "20.11.30",
@@ -922,6 +923,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5731,6 +5748,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build --no-lint",
     "start": "next start -p 3000",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "chart.js": "^4.5.0",
@@ -18,6 +19,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.2",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@types/node": "20.11.30",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /.*\.e2e\.ts/,
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    cwd: __dirname,
+  },
+});

--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoginPage from '../login/page';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('LoginPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows error on failed login', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+    render(<LoginPage />);
+    const username = screen.getAllByPlaceholderText(/username/i)[0];
+    const password = screen.getAllByPlaceholderText(/password/i)[0];
+    fireEvent.change(username, { target: { value: 'user' } });
+    fireEvent.change(password, { target: { value: 'pass' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/v0/auth/login', expect.any(Object));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/login failed/i);
+  });
+
+  it('shows error on failed signup', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+    render(<LoginPage />);
+    const username = screen.getAllByPlaceholderText(/username/i)[1];
+    const password = screen.getAllByPlaceholderText(/password/i)[1];
+    fireEvent.change(username, { target: { value: 'new' } });
+    fireEvent.change(password, { target: { value: 'pass' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/v0/auth/signup', expect.any(Object));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/signup failed/i);
+  });
+});

--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MatchesPage from '../matches/page';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('MatchesPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists matches with player names', async () => {
+    const matches = [
+      { id: 'm1', sport: 'padel', bestOf: 3, playedAt: null, location: null },
+    ];
+    const detail = {
+      participants: [
+        { side: 'A' as const, playerIds: ['1'] },
+        { side: 'B' as const, playerIds: ['2'] },
+      ],
+      summary: { points: { A: 11, B: 7 } },
+    };
+    const players = [
+      { playerId: '1', playerName: 'Alice' },
+      { playerId: '2', playerName: 'Bob' },
+    ];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => matches })
+      .mockResolvedValueOnce({ ok: true, json: async () => detail })
+      .mockResolvedValueOnce({ ok: true, json: async () => players });
+    global.fetch = fetchMock as any;
+
+    const page = await MatchesPage({ searchParams: {} });
+    render(page);
+
+    await screen.findByText('Alice vs Bob');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlayersPage from '../players/page';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('PlayersPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a player and shows success', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: '1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
+    global.fetch = fetchMock as any;
+
+    await act(async () => {
+      render(<PlayersPage />);
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/name/i), {
+      target: { value: 'New Player' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add/i }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v0/players',
+      expect.objectContaining({ method: 'POST' })
+    );
+    await screen.findByText(/added successfully/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add Testing Library tests for login, players, and matches
- configure Playwright with auth and score recording flows
- run unit and e2e tests in CI

## Testing
- `npx vitest run`
- `npx playwright install` *(fails: ERR_SOCKET_CLOSED)*
- `npx playwright test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1140/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68b962221e84832386404ba8ddc7cc6c