### PR TITLE
test: use secure JWT secret in tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Provide a default JWT secret of at least 32 characters for tests
+os.environ.setdefault("JWT_SECRET", "x" * 32)

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -3,7 +3,6 @@ import os, sys, asyncio, pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_comments.db"
-os.environ["JWT_SECRET"] = "testsecret"
 os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -3,7 +3,6 @@ import os, sys, asyncio, pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
-os.environ["JWT_SECRET"] = "testsecret"
 os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- add shared test fixture that provides a 32+ character JWT secret
- clean up tests to rely on the shared secret and fix match tests' setup

## Testing
- `pip install passlib`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9619dbea08323ba420993ff674ede