### PR TITLE
test: force deterministic JWT secret

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
 
-# Provide a default JWT secret of at least 32 characters for tests
-os.environ.setdefault("JWT_SECRET", "x" * 32)
+# Provide a JWT secret of at least 32 characters for tests
+# Set it unconditionally to avoid inherited, insecure values from the environment
+os.environ["JWT_SECRET"] = "x" * 32


### PR DESCRIPTION
## Summary
- Override `JWT_SECRET` in shared test fixture to ensure compliant length regardless of environment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b968aecc208323b0ed2224e20575c0