### PR TITLE
Handle bowling score arrays

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -132,7 +132,7 @@ export default function RecordSportPage() {
       interface MatchPayload {
         sport: string;
         participants: MatchParticipant[];
-        score?: [number, number];
+        score?: number[];
         playedAt?: string;
         location?: string;
       }


### PR DESCRIPTION
## Summary
- allow score payloads to use variable-length arrays to support bowling matches

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b96685ac908323b7021cc266658460