### PR TITLE
Add client error boundaries and global fallback

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+    // TODO: send error to monitoring service
+  }, [error]);
+
+  return (
+    <main className="container" style={{ padding: "2rem" }}>
+      <h2>Something went wrong.</h2>
+      <p>We're working to fix the issue. Please try again.</p>
+      <button onClick={() => reset()}>Try again</button>
+    </main>
+  );
+}
+

--- a/apps/web/src/app/leaderboard/[sport]/page.tsx
+++ b/apps/web/src/app/leaderboard/[sport]/page.tsx
@@ -1,5 +1,10 @@
 import Leaderboard from "../leaderboard";
+import ErrorBoundary from "../../../components/ErrorBoundary";
 
 export default function LeaderboardSportPage({ params }: { params: { sport: string } }) {
-  return <Leaderboard sport={params.sport} />;
+  return (
+    <ErrorBoundary>
+      <Leaderboard sport={params.sport} />
+    </ErrorBoundary>
+  );
 }

--- a/apps/web/src/app/leaderboard/master/page.tsx
+++ b/apps/web/src/app/leaderboard/master/page.tsx
@@ -1,6 +1,11 @@
 import Leaderboard from "../leaderboard";
+import ErrorBoundary from "../../../components/ErrorBoundary";
 
 export default function MasterLeaderboardPage() {
-  return <Leaderboard sport="master" />;
+  return (
+    <ErrorBoundary>
+      <Leaderboard sport="master" />
+    </ErrorBoundary>
+  );
 }
 

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,5 +1,10 @@
 import Leaderboard from "./leaderboard";
+import ErrorBoundary from "../../components/ErrorBoundary";
 
 export default function LeaderboardIndexPage() {
-  return <Leaderboard sport="all" />;
+  return (
+    <ErrorBoundary>
+      <Leaderboard sport="all" />
+    </ErrorBoundary>
+  );
 }

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { apiFetch, isAdmin } from "../../lib/api";
+import ErrorBoundary from "../../components/ErrorBoundary";
 
 const NAME_REGEX = /^[A-Za-z0-9 '-]{1,50}$/;
 
@@ -138,7 +139,8 @@ export default function PlayersPage() {
   }
 
   return (
-    <main className="container">
+    <ErrorBoundary>
+      <main className="container">
       <h1 className="heading">Players</h1>
       {loading && players.length === 0 ? (
         <div>Loading players…</div>
@@ -207,6 +209,7 @@ export default function PlayersPage() {
           </button>
         </div>
       )}
-    </main>
+      </main>
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import ErrorBoundary from "../../../components/ErrorBoundary";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -169,8 +170,9 @@ export default function RecordSportPage() {
   };
 
   return (
-    <main className="container">
-      <form onSubmit={handleSubmit}>
+    <ErrorBoundary>
+      <main className="container">
+        <form onSubmit={handleSubmit}>
         {isPickleball && (
           <label>
             <input
@@ -332,7 +334,8 @@ export default function RecordSportPage() {
 
         <button type="submit">Save</button>
       </form>
-    </main>
+      </main>
+    </ErrorBoundary>
   );
 }
 

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+    // TODO: send error and errorInfo to monitoring service here
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div>Something went wrong.</div>
+      );
+    }
+    return this.props.children;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add global `error.tsx` page to show friendly errors and log them
- create reusable `ErrorBoundary` component for client errors
- wrap leaderboard, player, and record pages in error boundaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96218c7a0832395ed5c8e4b8fc8b2