### PR TITLE
Enhance accessibility across forms with reusable components

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch, currentUsername, logout } from "../../lib/api";
+import InputField from "../../components/InputField";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -12,10 +13,17 @@ export default function LoginPage() {
   const [newUser, setNewUser] = useState("");
   const [newPass, setNewPass] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loginErrors, setLoginErrors] = useState<{ username?: string; password?: string }>({});
+  const [signupErrors, setSignupErrors] = useState<{ username?: string; password?: string }>({});
 
   const handleLogin = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    const errs: { username?: string; password?: string } = {};
+    if (!username.trim()) errs.username = "Username required";
+    if (!password.trim()) errs.password = "Password required";
+    setLoginErrors(errs);
+    if (Object.keys(errs).length) return;
     try {
       const res = await apiFetch("/v0/auth/login", {
         method: "POST",
@@ -42,6 +50,11 @@ export default function LoginPage() {
   const handleSignup = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    const errs: { username?: string; password?: string } = {};
+    if (!newUser.trim()) errs.username = "Username required";
+    if (!newPass.trim()) errs.password = "Password required";
+    setSignupErrors(errs);
+    if (Object.keys(errs).length) return;
     try {
       const res = await apiFetch("/v0/auth/signup", {
         method: "POST",
@@ -83,34 +96,44 @@ export default function LoginPage() {
     <main className="container">
       <h1 className="heading">Login</h1>
       <form onSubmit={handleLogin} className="auth-form">
-        <input
-          type="text"
+        <InputField
+          id="login-username"
+          label="Username"
           placeholder="Username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
+          error={loginErrors.username}
         />
-        <input
+        <InputField
+          id="login-password"
           type="password"
+          label="Password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          error={loginErrors.password}
         />
         <button type="submit">Login</button>
       </form>
 
       <h2 className="heading">Sign Up</h2>
       <form onSubmit={handleSignup} className="auth-form">
-        <input
-          type="text"
+        <InputField
+          id="signup-username"
+          label="Username"
           placeholder="Username"
           value={newUser}
           onChange={(e) => setNewUser(e.target.value)}
+          error={signupErrors.username}
         />
-        <input
+        <InputField
+          id="signup-password"
           type="password"
+          label="Password"
           placeholder="Password"
           value={newPass}
           onChange={(e) => setNewPass(e.target.value)}
+          error={signupErrors.password}
         />
         <button type="submit">Sign Up</button>
       </form>

--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { apiFetch } from "../../../lib/api";
+import TextareaField from "../../../components/TextareaField";
 
 interface Comment {
   id: string;
@@ -15,6 +16,7 @@ interface Comment {
 export default function PlayerComments({ playerId }: { playerId: string }) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [content, setContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const token =
     typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
@@ -32,6 +34,11 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
   async function submit(e: FormEvent) {
     e.preventDefault();
     if (!token) return;
+    if (!content.trim()) {
+      setError("Comment cannot be empty");
+      return;
+    }
+    setError(null);
     const resp = await apiFetch(`/v0/players/${playerId}/comments`, {
       method: "POST",
       headers: {
@@ -43,6 +50,8 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
     if (resp.ok) {
       setContent("");
       await load();
+    } else {
+      setError("Failed to add comment");
     }
   }
 
@@ -84,10 +93,13 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
       )}
       {token && (
         <form onSubmit={submit} className="mt-2">
-          <textarea
+          <TextareaField
+            id="comment"
+            label="Add a comment"
+            className="border p-2 w-full"
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="border p-2 w-full"
+            error={error || undefined}
           />
           <button type="submit" className="btn mt-2">
             Add Comment

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { apiFetch, isAdmin } from "../../lib/api";
+import InputField from "../../components/InputField";
 
 const NAME_REGEX = /^[A-Za-z0-9 '-]{1,50}$/;
 
@@ -144,7 +145,9 @@ export default function PlayersPage() {
         <div>Loading players…</div>
       ) : (
         <>
-          <input
+          <InputField
+            id="player-search"
+            label="Search"
             className="input mb-2"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -179,28 +182,36 @@ export default function PlayersPage() {
           )}
         </>
       )}
-      <input
-        className="input"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="name"
-      />
-      {!nameIsValid && trimmedName !== "" && (
-        <div className="text-red-500 mt-2">
-          Name must be 1-50 characters and contain only letters,
-          numbers, spaces, hyphens, or apostrophes.
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          create();
+        }}
+      >
+        <InputField
+          id="new-player"
+          label="Player name"
+          className="input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="name"
+          error={!nameIsValid && trimmedName !== "" ? "Name must be 1-50 characters and contain only letters, numbers, spaces, hyphens, or apostrophes." : undefined}
+        />
+        <button
+          className="button"
+          type="submit"
+          disabled={creating || name.trim() === ""}
+        >
+          {creating ? "Saving…" : "Add"}
+        </button>
+      </form>
+      {success && (
+        <div className="text-green-600 mt-2" role="alert">
+          {success}
         </div>
       )}
-      <button
-        className="button"
-        onClick={create}
-        disabled={creating || name.trim() === ""}
-      >
-        {creating ? "Saving…" : "Add"}
-      </button>
-      {success && <div className="text-green-600 mt-2">{success}</div>}
       {error && (
-        <div className="text-red-500 mt-2">
+        <div className="text-red-500 mt-2" role="alert">
           {error}
           <button className="ml-2 underline" onClick={load}>
             Retry

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -4,6 +4,8 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import InputField from "../../../components/InputField";
+import SelectField from "../../../components/SelectField";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -183,23 +185,26 @@ export default function RecordSportPage() {
         )}
 
         <div className="datetime">
-          <input
+          <InputField
+            id="match-date"
             type="date"
-            aria-label="Date"
+            label="Date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
-          <input
+          <InputField
+            id="match-time"
             type="time"
-            aria-label="Time"
+            label="Time"
             value={time}
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
 
-        <input
+        <InputField
+          id="match-location"
           type="text"
-          aria-label="Location"
+          label="Location"
           placeholder="Location"
           value={location}
           onChange={(e) => setLocation(e.target.value)}
@@ -209,8 +214,9 @@ export default function RecordSportPage() {
           <div className="players">
             {bowlingIds.map((id, idx) => (
               <div key={idx} className="bowling-player">
-                <select
-                  aria-label={`Player ${idx + 1}`}
+                <SelectField
+                  id={`bowler-${idx}`}
+                  label={`Player ${idx + 1}`}
                   value={id}
                   onChange={(e) => handleBowlingIdChange(idx, e.target.value)}
                 >
@@ -220,14 +226,18 @@ export default function RecordSportPage() {
                       {p.name}
                     </option>
                   ))}
-                </select>
-                <input
+                </SelectField>
+                <InputField
+                  id={`bowler-${idx}-score`}
                   type="number"
                   min="0"
                   step="1"
+                  label="Score"
                   placeholder="Score"
                   value={bowlingScores[idx]}
-                  onChange={(e) => handleBowlingScoreChange(idx, e.target.value)}
+                  onChange={(e) =>
+                    handleBowlingScoreChange(idx, e.target.value)
+                  }
                 />
               </div>
             ))}
@@ -246,8 +256,9 @@ export default function RecordSportPage() {
         ) : (
           <>
             <div className="players">
-              <select
-                aria-label="Player A1"
+              <SelectField
+                id="player-a1"
+                label="Player A1"
                 value={ids.a1}
                 onChange={(e) => handleIdChange("a1", e.target.value)}
               >
@@ -257,11 +268,12 @@ export default function RecordSportPage() {
                     {p.name}
                   </option>
                 ))}
-              </select>
+              </SelectField>
 
               {doubles && (
-                <select
-                  aria-label="Player A2"
+                <SelectField
+                  id="player-a2"
+                  label="Player A2"
                   value={ids.a2}
                   onChange={(e) => handleIdChange("a2", e.target.value)}
                 >
@@ -271,11 +283,12 @@ export default function RecordSportPage() {
                       {p.name}
                     </option>
                   ))}
-                </select>
+                </SelectField>
               )}
 
-              <select
-                aria-label="Player B1"
+              <SelectField
+                id="player-b1"
+                label="Player B1"
                 value={ids.b1}
                 onChange={(e) => handleIdChange("b1", e.target.value)}
               >
@@ -285,11 +298,12 @@ export default function RecordSportPage() {
                     {p.name}
                   </option>
                 ))}
-              </select>
+              </SelectField>
 
               {doubles && (
-                <select
-                  aria-label="Player B2"
+                <SelectField
+                  id="player-b2"
+                  label="Player B2"
                   value={ids.b2}
                   onChange={(e) => handleIdChange("b2", e.target.value)}
                 >
@@ -299,23 +313,27 @@ export default function RecordSportPage() {
                       {p.name}
                     </option>
                   ))}
-                </select>
+                </SelectField>
               )}
             </div>
 
             <div className="score">
-              <input
+              <InputField
+                id="score-a"
                 type="number"
                 min="0"
                 step="1"
+                label="Score A"
                 placeholder="A"
                 value={scoreA}
                 onChange={(e) => setScoreA(e.target.value)}
               />
-              <input
+              <InputField
+                id="score-b"
                 type="number"
                 min="0"
                 step="1"
+                label="Score B"
                 placeholder="B"
                 value={scoreB}
                 onChange={(e) => setScoreB(e.target.value)}

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import InputField from "../../../components/InputField";
+import SelectField from "../../../components/SelectField";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -128,23 +130,26 @@ export default function RecordPadelPage() {
     <main className="container">
       <form onSubmit={handleSubmit}>
         <div className="datetime">
-          <input
+          <InputField
+            id="padel-date"
             type="date"
-            aria-label="Date"
+            label="Date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
-          <input
+          <InputField
+            id="padel-time"
             type="time"
-            aria-label="Time"
+            label="Time"
             value={time}
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
 
         <div className="players">
-          <select
-            aria-label="Player A1"
+          <SelectField
+            id="padel-a1"
+            label="Player A1"
             value={ids.a1}
             onChange={(e) => handleIdChange("a1", e.target.value)}
           >
@@ -154,10 +159,11 @@ export default function RecordPadelPage() {
                 {p.name}
               </option>
             ))}
-          </select>
+          </SelectField>
 
-          <select
-            aria-label="Player A2"
+          <SelectField
+            id="padel-a2"
+            label="Player A2"
             value={ids.a2}
             onChange={(e) => handleIdChange("a2", e.target.value)}
           >
@@ -167,10 +173,11 @@ export default function RecordPadelPage() {
                 {p.name}
               </option>
             ))}
-          </select>
+          </SelectField>
 
-          <select
-            aria-label="Player B1"
+          <SelectField
+            id="padel-b1"
+            label="Player B1"
             value={ids.b1}
             onChange={(e) => handleIdChange("b1", e.target.value)}
           >
@@ -180,10 +187,11 @@ export default function RecordPadelPage() {
                 {p.name}
               </option>
             ))}
-          </select>
+          </SelectField>
 
-          <select
-            aria-label="Player B2"
+          <SelectField
+            id="padel-b2"
+            label="Player B2"
             value={ids.b2}
             onChange={(e) => handleIdChange("b2", e.target.value)}
           >
@@ -193,37 +201,39 @@ export default function RecordPadelPage() {
                 {p.name}
               </option>
             ))}
-          </select>
+          </SelectField>
         </div>
 
-        <label>
-          Best of
-          <select
-            aria-label="Best of"
-            value={bestOf}
-            onChange={(e) => setBestOf(e.target.value)}
-          >
-            <option value="1">1</option>
-            <option value="3">3</option>
-            <option value="5">5</option>
-          </select>
-        </label>
+        <SelectField
+          id="padel-bestof"
+          label="Best of"
+          value={bestOf}
+          onChange={(e) => setBestOf(e.target.value)}
+        >
+          <option value="1">1</option>
+          <option value="3">3</option>
+          <option value="5">5</option>
+        </SelectField>
 
         <div className="sets">
           {sets.map((s, idx) => (
             <div key={idx} className="set">
-              <input
+              <InputField
+                id={`set-${idx}-a`}
                 type="number"
                 min="0"
                 step="1"
+                label={`Set ${idx + 1} A`}
                 placeholder={`Set ${idx + 1} A`}
                 value={s.A}
                 onChange={(e) => handleSetChange(idx, "A", e.target.value)}
               />
-              <input
+              <InputField
+                id={`set-${idx}-b`}
                 type="number"
                 min="0"
                 step="1"
+                label={`Set ${idx + 1} B`}
                 placeholder={`Set ${idx + 1} B`}
                 value={s.B}
                 onChange={(e) => handleSetChange(idx, "B", e.target.value)}

--- a/apps/web/src/components/InputField.tsx
+++ b/apps/web/src/components/InputField.tsx
@@ -1,0 +1,27 @@
+import { InputHTMLAttributes } from "react";
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+  error?: string;
+}
+
+export default function InputField({ id, label, error, ...props }: Props) {
+  const errorId = `${id}-error`;
+  return (
+    <div className="field">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error ? errorId : undefined}
+        {...props}
+      />
+      {error && (
+        <p id={errorId} role="alert" className="error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/SelectField.tsx
+++ b/apps/web/src/components/SelectField.tsx
@@ -1,0 +1,36 @@
+import { SelectHTMLAttributes, ReactNode } from "react";
+
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
+  id: string;
+  label: string;
+  error?: string;
+  children: ReactNode;
+}
+
+export default function SelectField({
+  id,
+  label,
+  error,
+  children,
+  ...props
+}: Props) {
+  const errorId = `${id}-error`;
+  return (
+    <div className="field">
+      <label htmlFor={id}>{label}</label>
+      <select
+        id={id}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error ? errorId : undefined}
+        {...props}
+      >
+        {children}
+      </select>
+      {error && (
+        <p id={errorId} role="alert" className="error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/TextareaField.tsx
+++ b/apps/web/src/components/TextareaField.tsx
@@ -1,0 +1,27 @@
+import { TextareaHTMLAttributes } from "react";
+
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  id: string;
+  label: string;
+  error?: string;
+}
+
+export default function TextareaField({ id, label, error, ...props }: Props) {
+  const errorId = `${id}-error`;
+  return (
+    <div className="field">
+      <label htmlFor={id}>{label}</label>
+      <textarea
+        id={id}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error ? errorId : undefined}
+        {...props}
+      />
+      {error && (
+        <p id={errorId} role="alert" className="error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable InputField, TextareaField, and SelectField components with labels and inline error alerts
- refactor login, player, comment, and match record pages to use common accessible form fields
- display validation messages using `role="alert"` and tie inputs to labels/aria descriptors

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9621c66908323a0fa90c30aaba536