### PR TITLE
Add migration for password reset token table

### DIFF
--- a/backend/alembic/versions/0006_password_reset_tokens.py
+++ b/backend/alembic/versions/0006_password_reset_tokens.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006_password_reset_tokens'
+down_revision = '0005_users'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'password_reset_token',
+        sa.Column('token_hash', sa.String(), primary_key=True),
+        sa.Column('user_id', sa.String(), sa.ForeignKey('user.id'), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('password_reset_token')


### PR DESCRIPTION
## Summary
- add Alembic migration creating password_reset_token table for password reset flow

## Testing
- `pytest backend/tests/test_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96bb5aa708323b16fed4f599b6ae7