### PR TITLE
feat: add location selector to padel recording

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -62,6 +62,10 @@ describe("RecordPadelPage", () => {
       target: { value: "2" },
     });
 
+    fireEvent.change(screen.getByPlaceholderText("Location"), {
+      target: { value: "Court 1" },
+    });
+
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
@@ -75,6 +79,7 @@ describe("RecordPadelPage", () => {
         { side: "A", playerIds: ["p1", "p2"] },
         { side: "B", playerIds: ["p3", "p4"] },
       ],
+      location: "Court 1",
     });
     expect(setsPayload).toEqual({
       sets: [

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -28,6 +28,7 @@ interface CreateMatchPayload {
   participants: { side: string; playerIds: string[] }[];
   bestOf: number;
   playedAt?: string;
+  location?: string;
 }
 
 export default function RecordPadelPage() {
@@ -38,6 +39,7 @@ export default function RecordPadelPage() {
   const [sets, setSets] = useState<SetScore[]>([{ A: "", B: "" }]);
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
+  const [location, setLocation] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -98,6 +100,9 @@ export default function RecordPadelPage() {
           ? new Date(`${date}T${time}`).toISOString()
           : `${date}T00:00:00`;
       }
+      if (location) {
+        payload.location = location;
+      }
 
       const res = await apiFetch(`/v0/matches`, {
         method: "POST",
@@ -141,6 +146,14 @@ export default function RecordPadelPage() {
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
+
+        <input
+          type="text"
+          aria-label="Location"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
 
         <div className="players">
           <select


### PR DESCRIPTION
## Summary
- add optional location field to padel match recording form
- include location in padel match creation payload
- update padel recording tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95e25bff883238d29edc5433989ee