### PR TITLE
Add profile endpoints and UI

### DIFF
--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -76,6 +76,11 @@ export default function Header() {
           )}
           {user ? (
             <>
+              <li>
+                <Link href="/profile" onClick={() => setOpen(false)}>
+                  Profile
+                </Link>
+              </li>
               <li className="user-status">Logged in as {user}</li>
               <li>
                 <button onClick={handleLogout}>Logout</button>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch, currentUsername } from "../../lib/api";
+
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch("/v0/auth/me").then(async (res) => {
+      if (res.ok) {
+        const data = await res.json();
+        setUsername(data.username);
+      } else if (res.status === 401) {
+        router.push("/login");
+      }
+    });
+  }, [router]);
+
+  const validate = () => {
+    if (username.trim().length < 3) {
+      setError("Username must be at least 3 characters");
+      return false;
+    }
+    if (password && (password.length < 8 || !PASSWORD_REGEX.test(password))) {
+      setError(
+        "Password must be at least 8 characters and include letters, numbers, and symbols"
+      );
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    if (!validate()) return;
+    const body: Record<string, string> = {};
+    if (username) body.username = username;
+    if (password) body.password = password;
+    const res = await apiFetch("/v0/auth/me", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.access_token) {
+        window.localStorage.setItem("token", data.access_token);
+        window.dispatchEvent(new Event("storage"));
+      }
+      setPassword("");
+      setSuccess("Profile updated");
+    } else {
+      setError("Update failed");
+    }
+  };
+
+  if (!currentUsername()) {
+    return null; // render nothing while redirecting
+  }
+
+  return (
+    <main className="container">
+      <h1 className="heading">Profile</h1>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="New Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Save</button>
+      </form>
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p role="status" className="success">
+          {success}
+        </p>
+      )}
+    </main>
+  );
+}
+

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -14,7 +14,7 @@ import jwt
 
 from ..db import get_session
 from ..models import User, Player
-from ..schemas import UserCreate, UserLogin, TokenOut
+from ..schemas import UserCreate, UserLogin, TokenOut, UserOut, UserUpdate
 
 
 def get_jwt_secret() -> str:
@@ -154,3 +154,42 @@ async def get_current_user(
   if not user:
     raise HTTPException(status_code=401, detail="user not found")
   return user
+
+
+@router.get("/me", response_model=UserOut)
+async def read_me(current: User = Depends(get_current_user)):
+  """Return the current user's profile."""
+  return UserOut(id=current.id, username=current.username, is_admin=current.is_admin)
+
+
+@router.put("/me", response_model=TokenOut)
+async def update_me(
+    body: UserUpdate,
+    current: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+  if body.username and body.username != current.username:
+    existing = (
+        await session.execute(
+            select(User).where(User.username == body.username)
+        )
+    ).scalar_one_or_none()
+    if existing:
+      raise HTTPException(status_code=400, detail="username exists")
+    existing_player = (
+        await session.execute(select(Player).where(Player.name == body.username))
+    ).scalar_one_or_none()
+    if existing_player and existing_player.user_id != current.id:
+      raise HTTPException(status_code=400, detail="player exists")
+    player = (
+        await session.execute(select(Player).where(Player.user_id == current.id))
+    ).scalar_one_or_none()
+    if player:
+      player.name = body.username
+    current.username = body.username
+  if body.password:
+    current.password_hash = pwd_context.hash(body.password)
+  await session.commit()
+  await session.refresh(current)
+  token = create_token(current)
+  return TokenOut(access_token=token)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -149,6 +149,29 @@ class TokenOut(BaseModel):
     """Returned on successful authentication."""
     access_token: str
 
+
+class UserOut(BaseModel):
+    """Public user information."""
+    id: str
+    username: str
+    is_admin: bool
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating user profile."""
+    username: str | None = Field(None, min_length=3, max_length=50)
+    password: str | None = Field(None, min_length=8)
+
+    @field_validator("password")
+    def _check_password_complexity(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not PASSWORD_REGEX.match(v):
+            raise ValueError(
+                "Password must contain letters, numbers, and symbols"
+            )
+        return v
+
 class CommentCreate(BaseModel):
     """Schema for creating a comment on a player."""
     content: str = Field(..., min_length=1, max_length=500)


### PR DESCRIPTION
## Summary
- add GET/PUT /auth/me routes to fetch and update user profile with new token
- expose UserOut/UserUpdate schemas for profile data
- build profile page with username/password form and add Profile link in header

## Testing
- `pytest` *(fails: JWT_SECRET must be at least 32 characters and not a common default)*
- `pytest tests/test_auth.py::test_me_endpoints -vv`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96205bc708323ae949eaa2716a9cd