### PR TITLE
chore: install browsers before running Playwright tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "test": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "npx playwright install --with-deps && npx playwright test"
   },
   "dependencies": {
     "chart.js": "^4.5.0",


### PR DESCRIPTION
## Summary
- install Playwright browsers in `npm run test:e2e`

## Testing
- `npm ci`
- `npm run test:e2e` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68b9933cd5608323a1c1f7394b0d3cfc