### PR TITLE
Guard against empty participant rosters in match headings

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -14,7 +14,7 @@ type MatchRow = {
 
 type Participant = {
   side: string;
-  playerIds: string[];
+  playerIds?: string[];
 };
 
 type MatchDetail = {
@@ -51,7 +51,7 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
 
   const ids = new Set<string>();
   for (const { detail } of details) {
-    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+    for (const p of detail.participants) (p.playerIds ?? []).forEach((id) => ids.add(id));
   }
   const idToName = new Map<string, string>();
   const idList = Array.from(ids);
@@ -79,7 +79,11 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
     const participants = detail.participants
       .slice()
       .sort((a, b) => a.side.localeCompare(b.side))
-      .map((p) => p.playerIds.map((id) => idToName.get(id) ?? id));
+      .map((p) => {
+        const ids = p.playerIds ?? [];
+        const names = ids.map((id) => idToName.get(id) ?? id);
+        return names.length ? names : [p.side];
+      });
     return { ...row, participants, summary: detail.summary };
   });
 }

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 type ID = string;
 
 // "side" can be any identifier (A, B, C, ...), so keep it loose
-type Participant = { side: string; playerIds: string[] };
+type Participant = { side: string; playerIds?: string[] };
 
 type Summary = {
   sets?: Record<string, number>;

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -14,7 +14,7 @@ type MatchRow = {
 
 type Participant = {
   side: string;
-  playerIds: string[];
+  playerIds?: string[];
 };
 
 type MatchDetail = {
@@ -54,7 +54,7 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   // Fetch all unique player names.
   const ids = new Set<string>();
   for (const { detail } of details) {
-    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+    for (const p of detail.participants) (p.playerIds ?? []).forEach((id) => ids.add(id));
   }
   const idToName = new Map<string, string>();
   const idList = Array.from(ids);
@@ -82,7 +82,11 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
     const participants = detail.participants
       .slice()
       .sort((a, b) => a.side.localeCompare(b.side))
-      .map((p) => p.playerIds.map((id) => idToName.get(id) ?? id));
+      .map((p) => {
+        const ids = p.playerIds ?? [];
+        const names = ids.map((id) => idToName.get(id) ?? id);
+        return names.length ? names : [p.side];
+      });
     return { ...row, participants, summary: detail.summary };
   });
 }

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -26,7 +26,7 @@ type MatchRow = {
   location: string | null;
 };
 
-type Participant = { side: string; playerIds: string[] };
+type Participant = { side: string; playerIds?: string[] };
 type MatchDetail = {
   participants: Participant[];
   summary?:
@@ -120,7 +120,8 @@ async function getMatches(
     let playerSide: string | null = null;
     for (const p of detail.participants ?? []) {
       const ids = p.playerIds ?? [];
-      names[p.side] = ids.map((id) => idToName.get(id) ?? id);
+      const mapped = ids.map((id) => idToName.get(id) ?? id);
+      names[p.side] = mapped.length ? mapped : [p.side];
       if (ids.includes(playerId)) {
         playerSide = p.side;
       }

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -8,7 +8,7 @@ export type MatchRow = {
 
 export type Participant = {
   side: string;
-  playerIds: string[];
+  playerIds?: string[];
 };
 
 export type MatchDetail = {
@@ -33,7 +33,7 @@ export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> 
 
   const ids = new Set<string>();
   for (const { detail } of details) {
-    for (const p of detail.participants) p.playerIds.forEach((id) => ids.add(id));
+    for (const p of detail.participants) (p.playerIds ?? []).forEach((id) => ids.add(id));
   }
 
   const idToName = new Map<string, string>();
@@ -61,7 +61,9 @@ export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> 
   return details.map(({ row, detail }) => {
     const names: Record<string, string[]> = {};
     for (const p of detail.participants) {
-      names[p.side] = p.playerIds.map((id) => idToName.get(id) ?? id);
+      const ids = p.playerIds ?? [];
+      const mapped = ids.map((id) => idToName.get(id) ?? id);
+      names[p.side] = mapped.length ? mapped : [p.side];
     }
     return { ...row, names };
   });


### PR DESCRIPTION
## Summary
- Allow participants without player IDs by treating `playerIds` as optional
- Fallback to side labels when rosters are empty in match listings and detail views
- Avoid errors when collecting player names for matches

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in tests, unused vars)*
- `npx eslint src/lib/matches.ts src/app/matches/page.tsx src/app/admin/matches/page.tsx src/app/players/[id]/page.tsx src/app/matches/[mid]/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96fe3544483239dfb943cbb459de7