### PR TITLE
feat: restore match list array response

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -265,13 +265,6 @@ class MatchSummaryOut(BaseModel):
     location: Optional[str] = None
 
 
-class MatchSummaryListOut(BaseModel):
-    matches: List[MatchSummaryOut]
-    total: int
-    limit: int
-    offset: int
-
-
 class ParticipantOut(BaseModel):
     """Participant information for a match."""
     id: str

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -152,13 +152,13 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
     resp = client.get("/matches")
     assert resp.status_code == 200
     data = resp.json()
-    matches = data["matches"]
-    ids = [m["id"] for m in matches]
+    ids = [m["id"] for m in data]
     sorted_ids = [
         m["id"]
-        for m in sorted(matches, key=lambda m: m["playedAt"], reverse=True)
+        for m in sorted(data, key=lambda m: m["playedAt"], reverse=True)
     ]
     assert ids == sorted_ids
+    assert resp.headers["X-Total-Count"] == "2"
 
 
 @pytest.mark.anyio
@@ -196,7 +196,8 @@ async def test_list_matches_upcoming_filter(tmp_path):
     resp = client.get("/matches", params={"upcoming": True})
     assert resp.status_code == 200
     data = resp.json()
-    assert [m["id"] for m in data["matches"]] == ["future"]
+    assert [m["id"] for m in data] == ["future"]
+    assert resp.headers["X-Total-Count"] == "1"
 
 
 @pytest.mark.skip(reason="SQLite lacks ARRAY support for MatchParticipant")


### PR DESCRIPTION
## Summary
- return a bare match array from `/matches` and expose totals via headers
- drop unused `MatchSummaryListOut` schema
- update tests for array response and header-based totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97197308c8323b34184585a282dc7