### PR TITLE
Expose pagination headers via CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,7 @@ app.add_middleware(
     allow_credentials=ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Total-Count", "X-Limit", "X-Offset"],
 )
 
 uploads_dir = Path(__file__).resolve().parents[1] / "uploads"

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,4 +1,8 @@
-import os, sys, importlib, pytest
+import os
+import sys
+import importlib
+import pytest
+from fastapi.testclient import TestClient
 
 # Ensure the app package is importable
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -11,4 +15,20 @@ def test_rejects_wildcard_with_credentials(monkeypatch):
     sys.modules.pop("app.main", None)
     with pytest.raises(ValueError):
         importlib.import_module("app.main")
+
+
+def test_exposes_pagination_headers(monkeypatch):
+    monkeypatch.setenv("ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("ALLOW_CREDENTIALS", "false")
+    sys.modules.pop("app.main", None)
+    app = importlib.import_module("app.main").app
+    with TestClient(app) as client:
+        resp = client.get("/api/healthz", headers={"Origin": "http://example.com"})
+        exposed = resp.headers.get("access-control-expose-headers")
+        assert exposed is not None
+        assert {h.strip() for h in exposed.split(',')} >= {
+            "X-Total-Count",
+            "X-Limit",
+            "X-Offset",
+        }
 


### PR DESCRIPTION
## Summary
- expose pagination headers in CORS middleware so clients can read pagination metadata
- test that exposed headers are accessible on cross-origin requests

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b9a814c5948323bfa31a84c53ec066