### PR TITLE
feat(web): improve type safety for player creation and tests

### DIFF
--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -12,7 +12,8 @@ describe('LoginPage', () => {
   });
 
   it('shows error on failed login', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+    global.fetch =
+      vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
     render(<LoginPage />);
     const username = screen.getAllByPlaceholderText(/username/i)[0];
     const password = screen.getAllByPlaceholderText(/password/i)[0];
@@ -26,7 +27,8 @@ describe('LoginPage', () => {
   });
 
   it('shows error on failed signup', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as any;
+    global.fetch =
+      vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
     render(<LoginPage />);
     const username = screen.getAllByPlaceholderText(/username/i)[1];
     const password = screen.getAllByPlaceholderText(/password/i)[1];

--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -37,7 +37,7 @@ describe('MatchesPage', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => matches })
       .mockResolvedValueOnce({ ok: true, json: async () => detail })
       .mockResolvedValueOnce({ ok: true, json: async () => players });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     const page = await MatchesPage({ searchParams: {} });
     render(page);

--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -20,7 +20,7 @@ describe('PlayersPage', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: '1' }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     await act(async () => {
       render(<PlayersPage />);

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -11,7 +11,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
   return (
     <main className="container" style={{ padding: "2rem" }}>
       <h2>Something went wrong.</h2>
-      <p>We're working to fix the issue. Please try again.</p>
+      <p>We&apos;re working to fix the issue. Please try again.</p>
       <button onClick={() => reset()}>Try again</button>
     </main>
   );

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -16,6 +16,12 @@ interface Player {
   photo_url?: string | null;
 }
 
+interface ErrorResponse {
+  detail?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
 export default function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [recentMatches, setRecentMatches] =
@@ -117,14 +123,14 @@ export default function PlayersPage() {
       });
       const data = (await res.json().catch(() => null)) as
         | Player
-        | (Record<string, unknown> & { detail?: string; message?: string })
+        | ErrorResponse
         | null;
       if (!res.ok || !data || !("id" in data)) {
         let message = "Failed to create player.";
-        if (data && typeof (data as any)["detail"] === "string")
-          message = (data as any)["detail"] as string;
-        else if (data && typeof (data as any)["message"] === "string")
-          message = (data as any)["message"] as string;
+        if (data && "detail" in data && typeof data.detail === "string")
+          message = data.detail;
+        else if (data && "message" in data && typeof data.message === "string")
+          message = data.message;
         setError(message);
         return;
       }

--- a/apps/web/src/app/reset-password/confirm.tsx
+++ b/apps/web/src/app/reset-password/confirm.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { useRouter } from "next/navigation";
 import { apiFetch } from "../../lib/api";
 
 export default function ResetConfirmPage() {
-  const router = useRouter();
   const [token, setToken] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- define ErrorResponse for player creation response and use `in` operator instead of `any`
- cast fetch mocks to `unknown as typeof fetch` in tests
- fix lint issues in error and reset-password pages

## Testing
- `npm run lint`
- `CI=1 npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9ad16688323935cd02e4b770004