### PR TITLE
Use Response for empty 204 responses

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,7 +4,7 @@ import hashlib
 import uuid
 import secrets
 from datetime import datetime, timedelta
-from fastapi import APIRouter, Depends, HTTPException, Header, Request
+from fastapi import APIRouter, Depends, HTTPException, Header, Request, Response
 from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
@@ -248,7 +248,7 @@ async def reset_confirm(
     user.password_hash = pwd_context.hash(body.new_password)
     await session.delete(rec)
     await session.commit()
-    return JSONResponse(status_code=204, content=None)
+    return Response(status_code=204)
 
 
 async def get_current_user(
@@ -350,6 +350,6 @@ async def logout(
         if rec:
             await session.delete(rec)
             await session.commit()
-    resp = JSONResponse(status_code=204, content=None)
+    resp = Response(status_code=204)
     resp.delete_cookie("refresh_token")
     return resp


### PR DESCRIPTION
## Summary
- replace JSONResponse with Response for 204 empty responses in password reset and logout
- import `Response` from FastAPI

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b080de3c8323afe779c685269bad