### PR TITLE
fix: stabilize e2e selectors

### DIFF
--- a/apps/web/e2e/auth.e2e.ts
+++ b/apps/web/e2e/auth.e2e.ts
@@ -21,5 +21,7 @@ test('failed signup shows error', async ({ page }) => {
   await page.getByPlaceholder('Username').nth(1).fill('bob');
   await page.getByPlaceholder('Password').nth(1).fill('pass');
   await page.getByRole('button', { name: 'Sign Up' }).click();
-  await expect(page.getByRole('alert')).toHaveText(/signup failed/i);
+  await expect(
+    page.getByRole('alert', { name: /signup failed/i })
+  ).toHaveText(/signup failed/i);
 });

--- a/apps/web/e2e/score.e2e.ts
+++ b/apps/web/e2e/score.e2e.ts
@@ -28,10 +28,10 @@ test('record padel match', async ({ page }) => {
   });
 
   await page.goto('/record/padel');
-  await page.selectOption('select[aria-label="Player A1"]', '1');
-  await page.selectOption('select[aria-label="Player A2"]', '2');
-  await page.selectOption('select[aria-label="Player B1"]', '3');
-  await page.selectOption('select[aria-label="Player B2"]', '4');
+  await page.getByLabel('Player A1').selectOption('1');
+  await page.getByLabel('Player A2').selectOption('2');
+  await page.getByLabel('Player B1').selectOption('3');
+  await page.getByLabel('Player B2').selectOption('4');
   await page.getByPlaceholder('Set 1 A').fill('6');
   await page.getByPlaceholder('Set 1 B').fill('4');
   await page.getByRole('button', { name: 'Save' }).click();


### PR DESCRIPTION
## Summary
- target the signup error alert by its text to avoid strict mode violations
- select padel players using labels instead of aria-label CSS selectors

## Testing
- `npx playwright test` *(fails: Executable doesn't exist at chromium. Run npx playwright install)*
- `npx playwright install` *(fails: ERR_SOCKET_CLOSED during Chromium download)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ba4b504883238c0aec93185104f7