### PR TITLE
test: add cypress auth and score tests

### DIFF
--- a/apps/web/cypress/e2e/auth.cy.ts
+++ b/apps/web/cypress/e2e/auth.cy.ts
@@ -1,0 +1,34 @@
+/// <reference types="cypress" />
+
+describe('Authentication', () => {
+  it('user can log in', () => {
+    cy.intercept('POST', '**/v0/auth/login', (req) => {
+      expect(req.body).to.deep.equal({ username: 'alice', password: 'secret' });
+      req.reply({ statusCode: 200, body: { access_token: 't' } });
+    }).as('login');
+
+    cy.visit('/login');
+    cy.get('input[placeholder="Username"]').first().type('alice');
+    cy.get('input[placeholder="Password"]').first().type('secret');
+    cy.contains('button', 'Login').click();
+
+    cy.wait('@login');
+    cy.location('pathname').should('eq', '/');
+  });
+
+  it('failed signup shows error', () => {
+    cy.intercept('POST', '**/v0/auth/signup', {
+      statusCode: 400,
+      body: {},
+    }).as('signup');
+
+    cy.visit('/login');
+    cy.get('input[placeholder="Username"]').eq(1).type('bob');
+    cy.get('input[placeholder="Password"]').eq(1).type('pass');
+    cy.contains('button', 'Sign Up').click();
+
+    cy.wait('@signup');
+    cy.get('[role="alert"]').should('contain.text', 'Signup failed');
+  });
+});
+

--- a/apps/web/cypress/e2e/score.cy.ts
+++ b/apps/web/cypress/e2e/score.cy.ts
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+
+describe('Padel scoring', () => {
+  it('records padel match', () => {
+    cy.intercept('GET', '**/v0/players', {
+      statusCode: 200,
+      body: {
+        players: [
+          { id: '1', name: 'Alice' },
+          { id: '2', name: 'Bob' },
+          { id: '3', name: 'Cara' },
+          { id: '4', name: 'Dan' },
+        ],
+      },
+    }).as('players');
+
+    cy.intercept('POST', '**/v0/matches', {
+      statusCode: 200,
+      body: { id: 'm1' },
+    }).as('match');
+
+    cy.intercept('POST', '**/v0/matches/m1/sets', (req) => {
+      expect(req.body).to.deep.equal({ sets: [{ A: 6, B: 4 }] });
+      req.reply({ statusCode: 200, body: {} });
+    }).as('sets');
+
+    cy.visit('/record/padel');
+    cy.wait('@players');
+
+    cy.get('#padel-a1').select('1');
+    cy.get('#padel-a2').select('2');
+    cy.get('#padel-b1').select('3');
+    cy.get('#padel-b2').select('4');
+    cy.get('#set-0-a').type('6');
+    cy.get('#set-0-b').type('4');
+    cy.contains('button', 'Save').click();
+
+    cy.wait('@match');
+    cy.wait('@sets');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Cypress tests for login and signup flows
- add Cypress test to record a padel match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9bfcb3d588323a20b5344f58b95ae