### PR TITLE
docs: add cypress guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,4 @@ jobs:
           cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
       - run: npm test
-      - run: npx playwright install --with-deps
-      - run: npx playwright test
+      - run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Ratings: ELO baseline 1000; K=24 (K=32 if <30 games); per-sport rows
 
 Timezone: Store UTC; render client TZ (default Australia/Melbourne)
 
-Testing targets: Engines ≥ 90% coverage; Playwright E2E for core flows
+Testing targets: Engines ≥ 90% coverage; Cypress E2E for core flows
 
 Deploy: Single VPS with Docker Compose; Caddy for HTTPS; nightly pg_dump backups
 
@@ -189,6 +189,22 @@ python seed.py  # adds default sports, rulesets, demo club/player
 ### Web
 cd ../apps/web
 npm install
+
+### Cypress E2E tests
+From `apps/web`:
+
+```bash
+# headless run
+npm run test:e2e
+
+# interactive mode
+npx cypress open
+```
+
+Troubleshooting:
+
+- Run `npx cypress verify` if the Cypress binary is missing.
+- Use `DEBUG=cypress:*` for verbose logs.
 
 ### Run backend & frontend together
 Start the API and UI in separate terminals:


### PR DESCRIPTION
## Summary
- run Cypress script in CI workflow
- document Cypress installation, usage, and troubleshooting

## Testing
- `npm test` *(fails: Failed to resolve import "@sentry/react" from "src/lib/monitoring.ts".)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bfccf768832396c94133e2987b1f