### PR TITLE
Ensure tests dispose database engines

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -56,6 +56,10 @@ def setup_db():
             )
     asyncio.run(init_models())
     yield
+    if db.engine is not None:
+        asyncio.run(db.engine.dispose())
+        db.engine = None
+        db.AsyncSessionLocal = None
     if os.path.exists("./test_auth.db"):
         os.remove("./test_auth.db")
 

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -58,6 +58,10 @@ def setup_db():
             )
     asyncio.run(init_models())
     yield
+    if db.engine is not None:
+        asyncio.run(db.engine.dispose())
+        db.engine = None
+        db.AsyncSessionLocal = None
     if os.path.exists("./test_comments.db"):
         os.remove("./test_comments.db")
 

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -110,6 +110,10 @@ def setup_db():
 
     asyncio.run(init_models())
     yield
+    if db.engine is not None:
+        asyncio.run(db.engine.dispose())
+        db.engine = None
+        db.AsyncSessionLocal = None
     if os.path.exists("./test_leaderboards.db"):
         os.remove("./test_leaderboards.db")
 

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -18,6 +18,17 @@ def anyio_backend():
   return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def dispose_engine():
+  """Dispose any leftover database engines after each test."""
+  yield
+  from app import db
+  if db.engine is not None:
+    await db.engine.dispose()
+    db.engine = None
+    db.AsyncSessionLocal = None
+
+
 @pytest.mark.anyio
 async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"

--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -63,6 +63,7 @@ def client_and_session():
 
     with TestClient(app) as client:
         yield client, async_session_maker
+    asyncio.run(engine.dispose())
 def test_create_and_append_event_hole(client_and_session):
     client, session_maker = client_and_session
 

--- a/backend/tests/test_player_profile_metrics.py
+++ b/backend/tests/test_player_profile_metrics.py
@@ -67,6 +67,7 @@ def client_and_session():
 
     with TestClient(app) as client:
         yield client, async_session_maker
+    asyncio.run(engine.dispose())
 
 
 def seed(session_maker):

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -50,6 +50,7 @@ def client_and_session():
 
     with TestClient(app) as client:
         yield client, async_session_maker
+    asyncio.run(engine.dispose())
 
 
 def seed(session_maker):

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -66,6 +66,10 @@ def setup_db():
             )
     asyncio.run(init_models())
     yield
+    if db.engine is not None:
+        asyncio.run(db.engine.dispose())
+        db.engine = None
+        db.AsyncSessionLocal = None
     if os.path.exists("./test_players.db"):
         os.remove("./test_players.db")
 

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -58,6 +58,7 @@ def client_and_session():
 
     with TestClient(app) as client:
         yield client, async_session_maker
+    asyncio.run(engine.dispose())
 
 
 def seed_match(session_maker, mid: str) -> None:

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -14,6 +14,17 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 def anyio_backend():
     return "asyncio"
 
+
+@pytest.fixture(autouse=True)
+async def dispose_engine():
+    """Ensure database engines are closed after each test."""
+    yield
+    from app import db
+    if db.engine is not None:
+        await db.engine.dispose()
+        db.engine = None
+        db.AsyncSessionLocal = None
+
 @pytest.mark.anyio
 async def test_tournament_crud(tmp_path):
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"


### PR DESCRIPTION
## Summary
- dispose SQLAlchemy engines in test fixtures to prevent lingering resources
- add autouse fixtures to close engines after match and tournament tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9c31d7774832394a0f69630affce6