### PR TITLE
Add Cypress configuration for web app tests

### DIFF
--- a/apps/web/cypress.config.js
+++ b/apps/web/cypress.config.js
@@ -1,0 +1,10 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: false,
+    specPattern: 'cypress/e2e/**/*.cy.{js,ts}',
+  },
+  video: false,
+});


### PR DESCRIPTION
## Summary
- add Cypress config for web frontend

## Testing
- `npx vitest run`
- `npm run test:e2e` *(fails: No version of Cypress is installed; Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c62128388323bb394b5f5468d117