### PR TITLE
chore: mock sentry for vitest

### DIFF
--- a/apps/web/__mocks__/@sentry/react.ts
+++ b/apps/web/__mocks__/@sentry/react.ts
@@ -1,0 +1,3 @@
+export const init = () => {};
+export const captureException = () => {};
+export default { init, captureException };

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,4 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   test: {
@@ -7,5 +11,10 @@ export default defineConfig({
   },
   esbuild: {
     jsx: 'automatic',
+  },
+  resolve: {
+    alias: {
+      '@sentry/react': resolve(rootDir, '__mocks__/@sentry/react.ts'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- alias @sentry/react to a test mock in vitest config
- add no-op mock module to avoid bundling real Sentry code during tests

## Testing
- `npx vitest run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6b38a5083238912618ce75c7d32