### PR TITLE
chore(ci): ensure cypress binary is installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
+      - run: npx cypress install
       - run: npm test
       - run: npm run test:e2e


### PR DESCRIPTION
## Summary
- run `npx cypress install` during CI to make sure the Cypress binary is available before tests

## Testing
- `npm ci`
- `npm test`
- `npm run test:e2e` *(fails: No version of Cypress is installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c84ff67c83238a8dc7f298b450ad