### PR TITLE
Fix bowling score payload typing and guard optional player lists

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -90,10 +90,10 @@ export default async function MatchDetailPage({
         <h1 className="heading">
           {parts.map((p, idx) => (
             <span key={p.side}>
-              {p.playerIds.map((pid, j) => (
+              {(p.playerIds || []).map((pid, j) => (
                 <span key={pid}>
                   <PlayerLabel id={pid} name={idToName.get(pid)} />
-                  {j < p.playerIds.length - 1 ? " / " : ""}
+                  {j < (p.playerIds?.length || 0) - 1 ? " / " : ""}
                 </span>
               ))}
               {idx < parts.length - 1 ? " vs " : ""}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -334,10 +334,10 @@ export default async function PlayerPage({
                           <Link href={`/matches/${m.id}`}>
                             {m.participants.map((p, idx) => (
                               <span key={p.side}>
-                                {p.playerIds.map((pid, j) => (
+                                {(p.playerIds || []).map((pid, j) => (
                                   <span key={pid}>
                                     <PlayerLabel id={pid} />
-                                    {j < p.playerIds.length - 1 ? ' & ' : ''}
+                                    {j < (p.playerIds?.length || 0) - 1 ? ' & ' : ''}
                                   </span>
                                 ))}
                                 {idx < m.participants.length - 1 ? ' vs ' : ''}
@@ -437,10 +437,10 @@ export default async function PlayerPage({
                   <Link href={`/matches/${m.id}`}>
                     {m.participants.map((p, idx) => (
                       <span key={p.side}>
-                        {p.playerIds.map((pid, j) => (
+                        {(p.playerIds || []).map((pid, j) => (
                           <span key={pid}>
                             <PlayerLabel id={pid} />
-                            {j < p.playerIds.length - 1 ? ' & ' : ''}
+                            {j < (p.playerIds?.length || 0) - 1 ? ' & ' : ''}
                           </span>
                         ))}
                         {idx < m.participants.length - 1 ? ' vs ' : ''}

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -131,14 +131,14 @@ export default function RecordSportPage() {
     }
 
     try {
-      interface MatchPayload {
+      interface CreateMatchPayload {
         sport: string;
         participants: MatchParticipant[];
         score?: number[];
         playedAt?: string;
         location?: string;
       }
-      const payload: MatchPayload = {
+      const payload: CreateMatchPayload = {
         sport,
         participants,
       };


### PR DESCRIPTION
## Summary
- Rename the match creation payload interface to avoid tuple type inference and allow variable-length bowling scores
- Safely render participant player lists by handling potentially missing playerIds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9cd4d013883239b928827e6d6617d