### PR TITLE
Handle optional player IDs in match views

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -90,10 +90,10 @@ export default async function MatchDetailPage({
         <h1 className="heading">
           {parts.map((p, idx) => (
             <span key={p.side}>
-              {p.playerIds.map((pid, j) => (
+              {(p.playerIds ?? []).map((pid, j, arr) => (
                 <span key={pid}>
                   <PlayerLabel id={pid} name={idToName.get(pid)} />
-                  {j < p.playerIds.length - 1 ? " / " : ""}
+                  {j < arr.length - 1 ? " / " : ""}
                 </span>
               ))}
               {idx < parts.length - 1 ? " vs " : ""}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -334,10 +334,10 @@ export default async function PlayerPage({
                           <Link href={`/matches/${m.id}`}>
                             {m.participants.map((p, idx) => (
                               <span key={p.side}>
-                                {p.playerIds.map((pid, j) => (
+                                {(p.playerIds ?? []).map((pid, j, arr) => (
                                   <span key={pid}>
                                     <PlayerLabel id={pid} />
-                                    {j < p.playerIds.length - 1 ? ' & ' : ''}
+                                    {j < arr.length - 1 ? ' & ' : ''}
                                   </span>
                                 ))}
                                 {idx < m.participants.length - 1 ? ' vs ' : ''}
@@ -437,10 +437,10 @@ export default async function PlayerPage({
                   <Link href={`/matches/${m.id}`}>
                     {m.participants.map((p, idx) => (
                       <span key={p.side}>
-                        {p.playerIds.map((pid, j) => (
+                        {(p.playerIds ?? []).map((pid, j, arr) => (
                           <span key={pid}>
                             <PlayerLabel id={pid} />
-                            {j < p.playerIds.length - 1 ? ' & ' : ''}
+                            {j < arr.length - 1 ? ' & ' : ''}
                           </span>
                         ))}
                         {idx < m.participants.length - 1 ? ' vs ' : ''}


### PR DESCRIPTION
## Summary
- Guard against undefined `playerIds` when rendering matches and player details

## Testing
- `cd apps/web && npm run build`
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ccf5d54083239b0db032f68b78c5