### PR TITLE
Install Xvfb for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
           cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
       - run: npx cypress install
+      - run: sudo apt-get update && sudo apt-get install -y xvfb
       - run: npm test
-      - run: npm run test:e2e
+      - run: xvfb-run -a npm run test:e2e


### PR DESCRIPTION
## Summary
- ensure CI installs Xvfb before running tests
- run e2e tests under xvfb-run

## Testing
- `npm test` *(fails: run canceled – test runner waiting for file changes)*
- `xvfb-run -a npm run test:e2e` *(fails: missing library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2ff43a2c8323acb24f616b1e109e