### PR TITLE
chore(ci): install Cypress dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: apps/web/package-lock.json
+      - name: Install Cypress dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libatk1.0-0 libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 libatk-bridge2.0-0 libdrm2 libgbm1 libxcb1 libxdamage1 libxrandr2
       - run: npm ci
       - run: npx cypress install
       - run: npm test
-      - run: npm run test:e2e
+      - run: xvfb-run -a npm run test:e2e


### PR DESCRIPTION
## Summary
- install GTK/ATK and other Cypress runtime libraries in CI
- run e2e tests with xvfb-run

## Testing
- `npm test`
- `xvfb-run -a npm run test:e2e` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba355ad05c8323873f057a0b5aaac2