### PR TITLE
Allow variable-length score array

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -132,7 +132,7 @@ export default function RecordSportPage() {
       interface MatchPayload {
         sport: string;
         participants: MatchParticipant[];
-        score?: [number, number];
+        score?: number[];
         playedAt?: string;
         location?: string;
       }


### PR DESCRIPTION
## Summary
- allow scores to include more than two players, fixing build failure for bowling matches

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba4d37f0c0832388edfad60919f516