### PR TITLE
Use JSON for player ID lists and fix tests

### DIFF
--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,6 +1,5 @@
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision = "0001_initial"
 down_revision = None
@@ -35,7 +34,7 @@ def upgrade():
     op.create_table(
         "team",
         sa.Column("id", sa.String(), primary_key=True),
-        sa.Column("player_ids", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("player_ids", sa.JSON(), nullable=False),
     )
     op.create_table(
         "tournament",
@@ -64,7 +63,7 @@ def upgrade():
         sa.Column("id", sa.String(), primary_key=True),
         sa.Column("match_id", sa.String(), sa.ForeignKey("match.id"), nullable=False),
         sa.Column("side", sa.String(), nullable=False),
-        sa.Column("player_ids", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("player_ids", sa.JSON(), nullable=False),
     )
     op.create_table(
         "score_event",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     Boolean,
     Text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.sql import func
 from .db import Base
 
@@ -59,7 +58,7 @@ class PlayerBadge(Base):
 class Team(Base):
     __tablename__ = "team"
     id = Column(String, primary_key=True)
-    player_ids = Column(ARRAY(String), nullable=False)
+    player_ids = Column(JSON, nullable=False)
 
 class Tournament(Base):
     __tablename__ = "tournament"
@@ -91,7 +90,7 @@ class MatchParticipant(Base):
     id = Column(String, primary_key=True)
     match_id = Column(String, ForeignKey("match.id"), nullable=False)
     side = Column(String, nullable=False)  # "A" | "B"
-    player_ids = Column(ARRAY(String), nullable=False)
+    player_ids = Column(JSON, nullable=False)
 
 class ScoreEvent(Base):
     __tablename__ = "score_event"

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -3,7 +3,8 @@ import os, sys, asyncio, pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_comments.db"
-os.environ["JWT_SECRET"] = "testsecret"
+# Use a sufficiently long secret for JWTs in tests
+os.environ["JWT_SECRET"] = "x" * 32
 os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -9,7 +9,7 @@ from sqlalchemy import select, text
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-os.environ["JWT_SECRET"] = "testsecret"
+os.environ["JWT_SECRET"] = "x" * 32
 
 
 @pytest.fixture
@@ -90,7 +90,12 @@ async def test_create_match_with_scores(tmp_path):
 
   db.engine = None
   db.AsyncSessionLocal = None
-  db.get_engine()
+  engine = db.get_engine()
+  async with engine.begin() as conn:
+    await conn.run_sync(
+      db.Base.metadata.create_all,
+      tables=[Sport.__table__, Match.__table__, MatchParticipant.__table__],
+    )
 
   async with db.AsyncSessionLocal() as session:
     body = MatchCreate(

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -3,7 +3,8 @@ import os, sys, asyncio, pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
-os.environ["JWT_SECRET"] = "testsecret"
+# Use a sufficiently long secret for JWTs in tests
+os.environ["JWT_SECRET"] = "x" * 32
 os.environ["ADMIN_SECRET"] = "admintest"
 
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- replace PostgreSQL ARRAY columns with JSON to support SQLite
- use 32-character JWT secrets in tests and create tables for match scoring test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba4ef1af4083239d7c7c1cd1904a60