### PR TITLE
Add profile endpoints and UI

### DIFF
--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -76,6 +76,11 @@ export default function Header() {
           )}
           {user ? (
             <>
+              <li>
+                <Link href="/profile" onClick={() => setOpen(false)}>
+                  Profile
+                </Link>
+              </li>
               <li className="user-status">Logged in as {user}</li>
               <li>
                 <button onClick={handleLogout}>Logout</button>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { fetchMe, updateMe, isLoggedIn } from "../../lib/api";
+
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isLoggedIn()) {
+      router.push("/login");
+      return;
+    }
+    fetchMe()
+      .then((data) => {
+        setUsername(data.username);
+        setLoading(false);
+      })
+      .catch(() => router.push("/login"));
+  }, [router]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    if (username.length < 3) {
+      setError("Username must be at least 3 characters");
+      return;
+    }
+    if (password && (password.length < 8 || !PASSWORD_REGEX.test(password))) {
+      setError(
+        "Password must be at least 8 characters and include letters, numbers, and symbols",
+      );
+      return;
+    }
+    try {
+      const body: { username: string; password?: string } = { username };
+      if (password) body.password = password;
+      const res = await updateMe(body);
+      if (res.access_token) {
+        window.localStorage.setItem("token", res.access_token);
+        window.dispatchEvent(new Event("storage"));
+      }
+      setPassword("");
+      setMessage("Profile updated");
+    } catch {
+      setError("Update failed");
+    }
+  };
+
+  if (loading) {
+    return (
+      <main className="container">
+        <p>Loading...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container">
+      <h1 className="heading">Profile</h1>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="New password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Save</button>
+      </form>
+      {message && (
+        <p role="status" className="success">
+          {message}
+        </p>
+      )}
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -74,3 +74,22 @@ export function isAdmin(): boolean {
   const payload = getTokenPayload();
   return !!payload?.is_admin;
 }
+
+export async function fetchMe() {
+  const res = await apiFetch("/v0/auth/me");
+  if (!res.ok) throw new Error("Failed to load profile");
+  return res.json();
+}
+
+export async function updateMe(data: {
+  username?: string;
+  password?: string;
+}) {
+  const res = await apiFetch("/v0/auth/me", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Failed to update profile");
+  return res.json();
+}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -14,7 +14,7 @@ import jwt
 
 from ..db import get_session
 from ..models import User, Player
-from ..schemas import UserCreate, UserLogin, TokenOut
+from ..schemas import UserCreate, UserLogin, TokenOut, UserOut, UserUpdate
 
 
 def get_jwt_secret() -> str:
@@ -154,3 +154,35 @@ async def get_current_user(
   if not user:
     raise HTTPException(status_code=401, detail="user not found")
   return user
+
+
+@router.get("/me", response_model=UserOut)
+async def read_me(current: User = Depends(get_current_user)):
+  return UserOut(id=current.id, username=current.username, is_admin=current.is_admin)
+
+
+@router.put("/me", response_model=TokenOut)
+async def update_me(
+    body: UserUpdate,
+    current: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+  if body.username and body.username != current.username:
+    existing = (
+        await session.execute(
+            select(User).where(User.username == body.username)
+        )
+    ).scalar_one_or_none()
+    if existing and existing.id != current.id:
+      raise HTTPException(status_code=400, detail="username exists")
+    current.username = body.username
+    player = (
+        await session.execute(select(Player).where(Player.user_id == current.id))
+    ).scalar_one_or_none()
+    if player:
+      player.name = body.username
+  if body.password:
+    current.password_hash = pwd_context.hash(body.password)
+  await session.commit()
+  token = create_token(current)
+  return TokenOut(access_token=token)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -149,6 +149,27 @@ class TokenOut(BaseModel):
     """Returned on successful authentication."""
     access_token: str
 
+
+class UserOut(BaseModel):
+    """Public user information."""
+    id: str
+    username: str
+    is_admin: bool
+
+
+class UserUpdate(BaseModel):
+    """Payload for updating the current user."""
+    username: Optional[str] = Field(None, min_length=3, max_length=50)
+    password: Optional[str] = Field(None, min_length=8)
+
+    @field_validator("password")
+    def _check_password_complexity(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not PASSWORD_REGEX.match(v):
+            raise ValueError("Password must contain letters, numbers, and symbols")
+        return v
+
 class CommentCreate(BaseModel):
     """Schema for creating a comment on a player."""
     content: str = Field(..., min_length=1, max_length=500)

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import asyncio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth_me.db"
+os.environ["JWT_SECRET"] = "x" * 32
+
+from app import db
+from app.models import User, Player
+from app.routers import auth
+
+app = FastAPI()
+app.state.limiter = auth.limiter
+app.add_exception_handler(RateLimitExceeded, auth.rate_limit_handler)
+app.include_router(auth.router)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    async def init_models():
+        if os.path.exists("./test_auth_me.db"):
+            os.remove("./test_auth_me.db")
+        db.engine = None
+        db.AsyncSessionLocal = None
+        engine = db.get_engine()
+        async with engine.begin() as conn:
+            await conn.run_sync(db.Base.metadata.create_all, tables=[User.__table__, Player.__table__])
+    asyncio.run(init_models())
+    yield
+    if os.path.exists("./test_auth_me.db"):
+        os.remove("./test_auth_me.db")
+
+
+def test_get_and_update_me():
+    with TestClient(app) as client:
+        resp = client.post("/auth/signup", json={"username": "alice", "password": "Str0ng!Pass"})
+        assert resp.status_code == 200
+        token = resp.json()["access_token"]
+
+        me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert me.status_code == 200
+        assert me.json()["username"] == "alice"
+
+        resp = client.put(
+            "/auth/me",
+            json={"username": "alice2", "password": "N3w!Pass"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        new_token = resp.json()["access_token"]
+
+        bad_login = client.post(
+            "/auth/login", json={"username": "alice", "password": "Str0ng!Pass"}
+        )
+        assert bad_login.status_code == 401
+
+        good_login = client.post(
+            "/auth/login", json={"username": "alice2", "password": "N3w!Pass"}
+        )
+        assert good_login.status_code == 200
+
+        me2 = client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {new_token}"}
+        )
+        assert me2.status_code == 200
+        assert me2.json()["username"] == "alice2"


### PR DESCRIPTION
## Summary
- add GET and PUT `/auth/me` endpoints for retrieving and updating user details
- create web profile page with username and password edit form and client-side validation
- show Profile link in header when logged in

## Testing
- `JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx pytest` *(fails: JWT_SECRET must be at least 32 characters and not a common default)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4fc5953c8323ad83b7b643cf74f2