### PR TITLE
feat: add location input to padel recorder

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -33,6 +33,10 @@ describe("RecordPadelPage", () => {
 
     await waitFor(() => screen.getByLabelText("Player A1"));
 
+    fireEvent.change(screen.getByPlaceholderText("Location"), {
+      target: { value: "Center Court" },
+    });
+
     fireEvent.change(screen.getByLabelText("Player A1"), {
       target: { value: "p1" },
     });
@@ -75,6 +79,7 @@ describe("RecordPadelPage", () => {
         { side: "A", playerIds: ["p1", "p2"] },
         { side: "B", playerIds: ["p3", "p4"] },
       ],
+      location: "Center Court",
     });
     expect(setsPayload).toEqual({
       sets: [

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -28,6 +28,7 @@ interface CreateMatchPayload {
   participants: { side: string; playerIds: string[] }[];
   bestOf: number;
   playedAt?: string;
+  location?: string;
 }
 
 export default function RecordPadelPage() {
@@ -38,6 +39,7 @@ export default function RecordPadelPage() {
   const [sets, setSets] = useState<SetScore[]>([{ A: "", B: "" }]);
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
+  const [location, setLocation] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -98,6 +100,9 @@ export default function RecordPadelPage() {
           ? new Date(`${date}T${time}`).toISOString()
           : `${date}T00:00:00`;
       }
+      if (location) {
+        payload.location = location;
+      }
 
       const res = await apiFetch(`/v0/matches`, {
         method: "POST",
@@ -141,6 +146,14 @@ export default function RecordPadelPage() {
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
+
+        <input
+          type="text"
+          aria-label="Location"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
 
         <div className="players">
           <select


### PR DESCRIPTION
## Summary
- restore location selection on padel recording page
- cover location in padel recording test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba4f5bf13c832392ad2f30652d157e