### PR TITLE
Force deterministic JWT secret in tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def force_jwt_secret():
+    os.environ["JWT_SECRET"] = "x" * 32
+


### PR DESCRIPTION
## Summary
- ensure JWT secret used during tests is always 32 characters

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: match)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f1abc80832388b13c49955f58be