### PR TITLE
Fail fast on weak JWT secret

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Fail fast if JWT_SECRET is missing or weak
+auth.get_jwt_secret()
+
 
 @app.exception_handler(DomainException)
 async def domain_exception_handler(request: Request, exc: DomainException) -> JSONResponse:


### PR DESCRIPTION
## Summary
- ensure JWT secret is validated at startup to avoid running with weak tokens

## Testing
- `JWT_SECRET=short ALLOW_CREDENTIALS=false python - <<'PY'
import backend.app.main
PY`
- `ALLOW_CREDENTIALS=false JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba5144da8c8323842b99f7a86ec833