### PR TITLE
feat(web): add location to padel recording

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -46,6 +46,10 @@ describe("RecordPadelPage", () => {
       target: { value: "p4" },
     });
 
+    fireEvent.change(screen.getByLabelText("Location"), {
+      target: { value: "Court 1" },
+    });
+
     fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
       target: { value: "6" },
     });
@@ -75,6 +79,7 @@ describe("RecordPadelPage", () => {
         { side: "A", playerIds: ["p1", "p2"] },
         { side: "B", playerIds: ["p3", "p4"] },
       ],
+      location: "Court 1",
     });
     expect(setsPayload).toEqual({
       sets: [

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -28,6 +28,7 @@ interface CreateMatchPayload {
   participants: { side: string; playerIds: string[] }[];
   bestOf: number;
   playedAt?: string;
+  location?: string;
 }
 
 export default function RecordPadelPage() {
@@ -38,6 +39,7 @@ export default function RecordPadelPage() {
   const [sets, setSets] = useState<SetScore[]>([{ A: "", B: "" }]);
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
+  const [location, setLocation] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -98,6 +100,9 @@ export default function RecordPadelPage() {
           ? new Date(`${date}T${time}`).toISOString()
           : `${date}T00:00:00`;
       }
+      if (location) {
+        payload.location = location;
+      }
 
       const res = await apiFetch(`/v0/matches`, {
         method: "POST",
@@ -141,6 +146,14 @@ export default function RecordPadelPage() {
             onChange={(e) => setTime(e.target.value)}
           />
         </div>
+
+        <input
+          type="text"
+          aria-label="Location"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
 
         <div className="players">
           <select


### PR DESCRIPTION
## Summary
- allow entering match location when recording padel games
- include location in match creation payload
- test padel recording flow with location

## Testing
- `cd apps/web && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ba4fcb8dc883238e1e0716468035b8