### PR TITLE
test: verify player pagination

### DIFF
--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -85,6 +85,7 @@ def test_list_players_pagination() -> None:
                 headers={"Authorization": f"Bearer {token}"},
             )
             assert resp.status_code == 200
+        full = client.get("/players").json()
         resp = client.get("/players", params={"limit": 2, "offset": 1})
         assert resp.status_code == 200
         data = resp.json()
@@ -92,6 +93,7 @@ def test_list_players_pagination() -> None:
         assert data["offset"] == 1
         assert data["total"] == base_total + 5
         assert len(data["players"]) == 2
+        assert data["players"] == full["players"][1:3]
 
 def test_delete_player_requires_token() -> None:
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- fix admin token call and add assertions checking player pagination limits

## Testing
- `pytest backend/tests/test_players.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba5c32b710832395041374a29c73b5