### PR TITLE
Add migration to convert player_ids columns to JSON

### DIFF
--- a/backend/alembic/versions/0006_convert_player_ids_to_json.py
+++ b/backend/alembic/versions/0006_convert_player_ids_to_json.py
@@ -1,0 +1,38 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0006_convert_player_ids_to_json'
+down_revision = '0005_add_player_columns'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'team',
+        'player_ids',
+        type_=sa.JSON(),
+        postgresql_using='to_json(player_ids)'
+    )
+    op.alter_column(
+        'match_participant',
+        'player_ids',
+        type_=sa.JSON(),
+        postgresql_using='to_json(player_ids)'
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'team',
+        'player_ids',
+        type_=postgresql.ARRAY(sa.String()),
+        postgresql_using="array(select json_array_elements_text(player_ids))"
+    )
+    op.alter_column(
+        'match_participant',
+        'player_ids',
+        type_=postgresql.ARRAY(sa.String()),
+        postgresql_using="array(select json_array_elements_text(player_ids))"
+    )


### PR DESCRIPTION
## Summary
- add Alembic migration converting `team.player_ids` and `match_participant.player_ids` from ARRAY to JSON

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba50c319b08323b2a0be70514bfb6d