### PR TITLE
Prefix uploaded player photos with API path

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -42,6 +42,8 @@ from .auth import get_current_user
 
 
 UPLOAD_DIR = Path(__file__).resolve().parent.parent / "static" / "players"
+API_PREFIX = os.getenv("API_PREFIX", "/api").rstrip("/")
+UPLOAD_URL_PREFIX = f"{API_PREFIX}/static/players"
 router = APIRouter(
     prefix="/players",
     tags=["players"],
@@ -177,7 +179,7 @@ async def upload_player_photo(
     with open(filepath, "wb") as f:
         f.write(contents)
 
-    p.photo_url = f"/static/players/{filename}"
+    p.photo_url = f"{UPLOAD_URL_PREFIX}/{filename}"
     await session.commit()
     return PlayerNameOut(id=p.id, name=p.name, photo_url=p.photo_url)
 

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -188,3 +188,24 @@ def test_players_by_ids_omits_deleted() -> None:
         assert resp.status_code == 200
         data = resp.json()
         assert data == [{"id": active_id, "name": "Active", "photo_url": None}]
+
+
+def test_upload_player_photo_prefixed_url() -> None:
+    with TestClient(app) as client:
+        token = admin_token(client)
+        pid = client.post(
+            "/players", json={"name": "Pic"}, headers={"Authorization": f"Bearer {token}"}
+        ).json()["id"]
+        files = {"file": ("avatar.png", b"avatar", "image/png")}
+        resp = client.post(
+            f"/players/{pid}/photo",
+            files=files,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["photo_url"].startswith("/api/static/players/")
+        filename = data["photo_url"].split("/")[-1]
+        filepath = players.UPLOAD_DIR / filename
+        if filepath.exists():
+            filepath.unlink()


### PR DESCRIPTION
## Summary
- ensure uploaded player photos are served under the API's `/api/static` path
- add test verifying uploaded photo URLs are prefixed with `/api`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba662dbcec83239865c6e08a2df8c2