### PR TITLE
Fix bowling score payload type mismatch

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -136,15 +136,15 @@ export default function RecordSportPage() {
         playedAt?: string;
         location?: string;
       }
+      const score = isBowling
+        ? entries.map((e) => Number(e.score))
+        : [Number(scoreA), Number(scoreB)];
+
       const payload: MatchPayload = {
         sport,
         participants,
+        score,
       };
-      if (isBowling) {
-        payload.score = entries.map((e) => Number(e.score));
-      } else {
-        payload.score = [Number(scoreA), Number(scoreB)];
-      }
       if (date) {
         if (time) {
           payload.playedAt = new Date(`${date}T${time}`).toISOString();


### PR DESCRIPTION
## Summary
- compute match score separately and include in payload to avoid tuple type issues

## Testing
- `npm test`
- `npm run build` *(fails: Syntax Error in apps/web/src/app/profile/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6b4c93448323843f2a75caf3fe6c