### PR TITLE
Stream player photo uploads to disk and enforce size limit

### DIFF
--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -209,3 +209,19 @@ def test_upload_player_photo_prefixed_url() -> None:
         filepath = players.UPLOAD_DIR / filename
         if filepath.exists():
             filepath.unlink()
+
+
+def test_upload_player_photo_too_large() -> None:
+    with TestClient(app) as client:
+        token = admin_token(client)
+        pid = client.post(
+            "/players", json={"name": "BigPic"}, headers={"Authorization": f"Bearer {token}"}
+        ).json()["id"]
+        big_file = b"x" * (players.MAX_PHOTO_SIZE + 1)
+        files = {"file": ("big.png", big_file, "image/png")}
+        resp = client.post(
+            f"/players/{pid}/photo",
+            files=files,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 413


### PR DESCRIPTION
## Summary
- Stream player photo uploads to disk in chunks
- Enforce 5 MB maximum player photo upload size
- Add regression test for large photo uploads

## Testing
- `pytest tests/test_players.py::test_upload_player_photo_prefixed_url tests/test_players.py::test_upload_player_photo_too_large -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6a981c6c83239c664048bd4d97e8