### PR TITLE
Fix syntax error in profile page

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -9,20 +9,6 @@ const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
 export default function ProfilePage() {
   const router = useRouter();
   const [username, setUsername] = useState("");
-  the repo in the final message may be large.  To maintain clarity and readability, a summarization of unchanged portions may be provided.  If so, the summarization *must* be clearly indicated.
-
-```tsx
-"use client";
-
-import { useEffect, useState, type FormEvent } from "react";
-import { useRouter } from "next/navigation";
-import { fetchMe, updateMe, isLoggedIn } from "../../lib/api";
-
-const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
-
-export default function ProfilePage() {
-  const router = useRouter();
-  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- remove stray text duplication causing profile page to fail

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba6d78142883239229a6b59d867fcb