### PR TITLE
Serve static assets under API prefix

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,3 @@
+import os
+
+API_PREFIX = os.getenv("API_PREFIX", "/api")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .routers import (
 )
 from .routes import player as player_pages
 from .exceptions import DomainException, ProblemDetail
+from .config import API_PREFIX
 import os
 
 
@@ -38,9 +39,9 @@ if ALLOW_CREDENTIALS and (not ALLOWED_ORIGINS or "*" in ALLOWED_ORIGINS):
 app = FastAPI(
     title="Cross Sport Tracker API",
     version="0.1.0",
-    docs_url="/api/docs",
-    redoc_url="/api/redoc",
-    openapi_url="/api/openapi.json",
+    docs_url=f"{API_PREFIX}/docs",
+    redoc_url=f"{API_PREFIX}/redoc",
+    openapi_url=f"{API_PREFIX}/openapi.json",
 )
 
 app.state.limiter = auth.limiter
@@ -59,7 +60,7 @@ auth.get_jwt_secret()
 
 static_dir = Path(__file__).resolve().parent / "static"
 static_dir.mkdir(parents=True, exist_ok=True)
-app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+app.mount(f"{API_PREFIX}/static", StaticFiles(directory=str(static_dir)), name="static")
 
 
 @app.exception_handler(DomainException)
@@ -97,22 +98,22 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         media_type="application/problem+json",
     )
 
-@app.get("/api/healthz")
+@app.get(f"{API_PREFIX}/healthz")
 def healthz():
     return {"status": "ok"}
 
-@app.get("/api")
+@app.get(API_PREFIX)
 def api_root():
-    return {"message": "Cross Sport Tracker API. See /api/docs."}
+    return {"message": f"Cross Sport Tracker API. See {API_PREFIX}/docs."}
 
 # Mount once with versioning
-app.include_router(sports.router,      prefix="/api/v0")
-app.include_router(rulesets.router,    prefix="/api/v0")
-app.include_router(players.router,     prefix="/api/v0")
-app.include_router(matches.router,     prefix="/api/v0")
-app.include_router(leaderboards.router, prefix="/api/v0")
-app.include_router(streams.router,      prefix="/api/v0")
-app.include_router(tournaments.router,  prefix="/api/v0")
-app.include_router(auth.router,         prefix="/api/v0")
-app.include_router(badges.router,       prefix="/api/v0")
+app.include_router(sports.router,      prefix=f"{API_PREFIX}/v0")
+app.include_router(rulesets.router,    prefix=f"{API_PREFIX}/v0")
+app.include_router(players.router,     prefix=f"{API_PREFIX}/v0")
+app.include_router(matches.router,     prefix=f"{API_PREFIX}/v0")
+app.include_router(leaderboards.router, prefix=f"{API_PREFIX}/v0")
+app.include_router(streams.router,      prefix=f"{API_PREFIX}/v0")
+app.include_router(tournaments.router,  prefix=f"{API_PREFIX}/v0")
+app.include_router(auth.router,         prefix=f"{API_PREFIX}/v0")
+app.include_router(badges.router,       prefix=f"{API_PREFIX}/v0")
 app.include_router(player_pages.router)

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -18,6 +18,7 @@ from ..models import (
     Badge,
     PlayerBadge,
 )
+from ..config import API_PREFIX
 from ..schemas import (
     PlayerCreate,
     PlayerOut,
@@ -177,7 +178,7 @@ async def upload_player_photo(
     with open(filepath, "wb") as f:
         f.write(contents)
 
-    p.photo_url = f"/static/players/{filename}"
+    p.photo_url = f"{API_PREFIX}/static/players/{filename}"
     await session.commit()
     return PlayerNameOut(id=p.id, name=p.name, photo_url=p.photo_url)
 


### PR DESCRIPTION
## Summary
- Introduce `API_PREFIX` setting and use it to configure FastAPI routes
- Mount static files at `API_PREFIX/static` so player photo URLs resolve correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba68d89bb88323bf63e1e92fd9321b