### PR TITLE
Enforce 12-character password minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Create an admin user
 curl -X POST http://localhost:8000/api/v0/auth/signup \
   -H 'Content-Type: application/json' \
   -H 'X-Admin-Secret: <admin-secret>' \
-  -d '{"username":"alice","password":"Str0ng!Pass","is_admin":true}'
+  -d '{"username":"alice","password":"Str0ng!Pass!","is_admin":true}'
 
 Example: create a Padel match
 

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -4,6 +4,8 @@ import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch, currentUsername, logout } from "../../lib/api";
 
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
+
 export default function LoginPage() {
   const router = useRouter();
   const [user, setUser] = useState(currentUsername());
@@ -42,11 +44,22 @@ export default function LoginPage() {
   const handleSignup = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    const trimmedUser = newUser.trim();
+    if (trimmedUser.length < 3) {
+      setError("Username must be at least 3 characters");
+      return;
+    }
+    if (newPass.length < 12 || !PASSWORD_REGEX.test(newPass)) {
+      setError(
+        "Password must be at least 12 characters and include letters, numbers, and symbols",
+      );
+      return;
+    }
     try {
       const res = await apiFetch("/v0/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: newUser, password: newPass }),
+        body: JSON.stringify({ username: trimmedUser, password: newPass }),
       });
       if (res.ok) {
         const data = await res.json();

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -36,9 +36,9 @@ export default function ProfilePage() {
       setError("Username must be at least 3 characters");
       return;
     }
-    if (password && (password.length < 8 || !PASSWORD_REGEX.test(password))) {
+    if (password && (password.length < 12 || !PASSWORD_REGEX.test(password))) {
       setError(
-        "Password must be at least 8 characters and include letters, numbers, and symbols",
+        "Password must be at least 12 characters and include letters, numbers, and symbols",
       );
       return;
     }

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -357,7 +357,7 @@ async def player_stats(
     opp_stats: dict[str, dict[str, int]] = defaultdict(
         lambda: {"wins": 0, "total": 0}
     )
-    team stats: dict[str, dict[str, int]] = defaultdict(
+    team_stats: dict[str, dict[str, int]] = defaultdict(
         lambda: {"wins": 0, "total": 0}
     )
     results: list[bool] = []
@@ -376,7 +376,7 @@ async def player_stats(
         for tid in teammates:
             team_stats[tid]["total"] += 1
             if is_win:
-                team stats[tid]["wins"] += 1
+                team_stats[tid]["wins"] += 1
 
         others = [p for p in match_to_parts[match.id] if p.id != mp.id]
         opp_ids = [pid for part in others for pid in part.player_ids]
@@ -414,7 +414,7 @@ async def player_stats(
         worst_against = min(records, key=lambda r: r.winPct)
 
     if team_stats:
-        records = [to_record(pid, s) for pid, s in team stats.items()]
+        records = [to_record(pid, s) for pid, s in team_stats.items()]
         best_with = max(records, key=lambda r: r.winPct)
         worst_with = min(records, key=lambda r: r.winPct)
         with_records = records
@@ -435,7 +435,7 @@ async def player_stats(
     streak_info = compute_streaks(results)
     streaks = StreakSummary(**streak_info)
 
-    rolling = rolling win_percentage(results, span) if results else []
+    rolling = rolling_win_percentage(results, span) if results else []
 
     return PlayerStatsOut(
         playerId=player_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -131,7 +131,7 @@ class EventIn(BaseModel):
 class UserCreate(BaseModel):
     """Schema for user signup requests."""
     username: str = Field(..., min_length=3, max_length=50)
-    password: str = Field(..., min_length=8)
+    password: str = Field(..., min_length=12)
     is_admin: bool = False
 
     @field_validator("password")
@@ -162,7 +162,7 @@ class UserOut(BaseModel):
 class UserUpdate(BaseModel):
     """Payload for updating the current user."""
     username: Optional[str] = Field(None, min_length=3, max_length=50)
-    password: Optional[str] = Field(None, min_length=8)
+    password: Optional[str] = Field(None, min_length=12)
 
     @field_validator("password")
     def _check_password_complexity(cls, v: str | None) -> str | None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -57,7 +57,7 @@ def setup_db():
 def test_signup_login_and_protected_access():
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "alice", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "alice", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
@@ -73,23 +73,23 @@ def test_signup_login_and_protected_access():
 
         user = asyncio.run(fetch_user())
         assert user.password_hash != "pw"
-        assert pwd_context.verify("Str0ng!Pass", user.password_hash)
+        assert pwd_context.verify("Str0ng!Pass!", user.password_hash)
 
         resp = client.post(
-            "/auth/login", json={"username": "alice", "password": "Str0ng!Pass"}
+            "/auth/login", json={"username": "alice", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         user_token = resp.json()["access_token"]
 
         resp = client.post(
             "/auth/signup",
-            json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+            json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
         )
         assert resp.status_code == 403
 
         admin_token = client.post(
             "/auth/signup",
-            json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+            json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
             headers={"X-Admin-Secret": "admintest"},
         ).json()["access_token"]
 
@@ -128,7 +128,7 @@ def test_signup_links_orphan_player():
     pid = asyncio.run(create_player("charlie"))
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "charlie", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "charlie", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
 
@@ -151,7 +151,7 @@ def test_signup_rejects_attached_player():
     asyncio.run(create_player("dave", user_id="attached"))
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "dave", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "dave", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 400
         assert resp.json()["detail"] == "player exists"
@@ -170,16 +170,16 @@ def test_login_rate_limited():
     auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "rate", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "rate", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         for _ in range(5):
             ok = client.post(
-                "/auth/login", json={"username": "rate", "password": "Str0ng!Pass"}
+                "/auth/login", json={"username": "rate", "password": "Str0ng!Pass!"}
             )
             assert ok.status_code == 200
         resp = client.post(
-            "/auth/login", json={"username": "rate", "password": "Str0ng!Pass"}
+            "/auth/login", json={"username": "rate", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 429
 
@@ -188,7 +188,7 @@ def test_login_rate_limited_per_ip():
     with TestClient(app) as client:
         resp = client.post(
             "/auth/signup",
-            json={"username": "iprate", "password": "Str0ng!Pass"},
+            json={"username": "iprate", "password": "Str0ng!Pass!"},
         )
         assert resp.status_code == 200
         h1 = {"X-Forwarded-For": "1.1.1.1"}
@@ -196,19 +196,19 @@ def test_login_rate_limited_per_ip():
         for _ in range(5):
             ok = client.post(
                 "/auth/login",
-                json={"username": "iprate", "password": "Str0ng!Pass"},
+                json={"username": "iprate", "password": "Str0ng!Pass!"},
                 headers=h1,
             )
             assert ok.status_code == 200
         resp = client.post(
             "/auth/login",
-            json={"username": "iprate", "password": "Str0ng!Pass"},
+            json={"username": "iprate", "password": "Str0ng!Pass!"},
             headers=h1,
         )
         assert resp.status_code == 429
         ok2 = client.post(
             "/auth/login",
-            json={"username": "iprate", "password": "Str0ng!Pass"},
+            json={"username": "iprate", "password": "Str0ng!Pass!"},
             headers=h2,
         )
         assert ok2.status_code == 200
@@ -217,7 +217,7 @@ def test_login_rate_limit_not_bypassed_by_spoofed_x_forwarded_for():
     auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "spoof", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "spoof", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         real_ip = "9.9.9.9"
@@ -225,14 +225,14 @@ def test_login_rate_limit_not_bypassed_by_spoofed_x_forwarded_for():
             headers = {"X-Forwarded-For": f"{i}.0.0.1, {real_ip}"}
             ok = client.post(
                 "/auth/login",
-                json={"username": "spoof", "password": "Str0ng!Pass"},
+                json={"username": "spoof", "password": "Str0ng!Pass!"},
                 headers=headers,
             )
             assert ok.status_code == 200
         headers = {"X-Forwarded-For": f"random, {real_ip}"}
         resp = client.post(
             "/auth/login",
-            json={"username": "spoof", "password": "Str0ng!Pass"},
+            json={"username": "spoof", "password": "Str0ng!Pass!"},
             headers=headers,
         )
         assert resp.status_code == 429
@@ -279,7 +279,7 @@ def test_me_endpoints():
     auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "meuser", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "meuser", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
@@ -291,7 +291,7 @@ def test_me_endpoints():
 
         resp = client.put(
             "/auth/me",
-            json={"username": "meuser2", "password": "NewStr0ng!Pass"},
+            json={"username": "meuser2", "password": "NewStr0ng!Pass!"},
             headers=headers,
         )
         assert resp.status_code == 200
@@ -302,11 +302,11 @@ def test_me_endpoints():
         assert resp.json()["username"] == "meuser2"
 
         bad_login = client.post(
-            "/auth/login", json={"username": "meuser", "password": "Str0ng!Pass"}
+            "/auth/login", json={"username": "meuser", "password": "Str0ng!Pass!"}
         )
         assert bad_login.status_code == 401
 
         good_login = client.post(
-            "/auth/login", json={"username": "meuser2", "password": "NewStr0ng!Pass"}
+            "/auth/login", json={"username": "meuser2", "password": "NewStr0ng!Pass!"}
         )
         assert good_login.status_code == 200

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -39,7 +39,7 @@ def setup_db():
 def test_get_and_update_me():
     auth.limiter.reset()
     with TestClient(app) as client:
-        resp = client.post("/auth/signup", json={"username": "alice", "password": "Str0ng!Pass"})
+        resp = client.post("/auth/signup", json={"username": "alice", "password": "Str0ng!Pass!"})
         assert resp.status_code == 200
         token = resp.json()["access_token"]
 
@@ -49,19 +49,19 @@ def test_get_and_update_me():
 
         resp = client.put(
             "/auth/me",
-            json={"username": "alice2", "password": "N3w!Pass"},
+            json={"username": "alice2", "password": "N3w!LongPass"},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
         new_token = resp.json()["access_token"]
 
         bad_login = client.post(
-            "/auth/login", json={"username": "alice", "password": "Str0ng!Pass"}
+            "/auth/login", json={"username": "alice", "password": "Str0ng!Pass!"}
         )
         assert bad_login.status_code == 401
 
         good_login = client.post(
-            "/auth/login", json={"username": "alice2", "password": "N3w!Pass"}
+            "/auth/login", json={"username": "alice2", "password": "N3w!LongPass"}
         )
         assert good_login.status_code == 200
 
@@ -75,7 +75,7 @@ def test_get_and_update_me():
 def test_update_me_conflicting_player_name():
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -58,13 +58,13 @@ def test_comment_crud():
     auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
         admin_token = client.post(
             "/auth/signup",
-            json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+            json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
             headers={"X-Admin-Secret": "admintest"},
         ).json()["access_token"]
         pid = client.post(

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -314,12 +314,12 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 
   token_resp = client.post(
       "/auth/signup",
-      json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+      json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
       headers={"X-Admin-Secret": "admintest"},
   )
   if token_resp.status_code != 200:
     token_resp = client.post(
-        "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
+        "/auth/login", json={"username": "admin", "password": "Str0ng!Pass!"}
     )
   token = token_resp.json()["access_token"]
 
@@ -367,12 +367,12 @@ async def test_delete_match_missing_returns_404(tmp_path):
   with TestClient(app) as client:
     token_resp = client.post(
         "/auth/signup",
-        json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+        json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
         headers={"X-Admin-Secret": "admintest"},
     )
     if token_resp.status_code != 200:
       token_resp = client.post(
-          "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
+          "/auth/login", json={"username": "admin", "password": "Str0ng!Pass!"}
       )
     token = token_resp.json()["access_token"]
     resp = client.delete(

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -63,12 +63,12 @@ def admin_token(client: TestClient) -> str:
     auth.limiter.reset()
     resp = client.post(
         "/auth/signup",
-        json={"username": "admin", "password": "Str0ng!Pass", "is_admin": True},
+        json={"username": "admin", "password": "Str0ng!Pass!", "is_admin": True},
         headers={"X-Admin-Secret": "admintest"},
     )
     if resp.status_code != 200:
         resp = client.post(
-            "/auth/login", json={"username": "admin", "password": "Str0ng!Pass"}
+            "/auth/login", json={"username": "admin", "password": "Str0ng!Pass!"}
         )
     return resp.json()["access_token"]
 
@@ -126,7 +126,7 @@ def test_hard_delete_player_allows_username_reuse() -> None:
 
         # initial signup creates both user and player
         resp = client.post(
-            "/auth/signup", json={"username": "Eve", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "Eve", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
 
@@ -143,7 +143,7 @@ def test_hard_delete_player_allows_username_reuse() -> None:
 
         # signup again with the same username should now succeed
         resp = client.post(
-            "/auth/signup", json={"username": "Eve", "password": "Str0ng!Pass"}
+            "/auth/signup", json={"username": "Eve", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
- require at least 12 characters for user passwords in backend schemas
- add matching 12-character validations to login and profile pages
- update tests and sample docs, fix minor players router syntax

## Testing
- `pytest backend/tests/test_auth.py backend/tests/test_comments.py backend/tests/test_players.py backend/tests/test_matches.py -q`
- `pytest backend/tests/test_auth_me.py -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe03199c88323a17c16c4a5981952