### PR TITLE
Ensure unscheduled matches show up after saving

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -44,7 +44,7 @@ async def list_matches(
                 select(Match, MatchParticipant)
                 .join(MatchParticipant)
                 .where(Match.deleted_at.is_(None))
-                .order_by(Match.played_at.desc())
+                .order_by(Match.played_at.desc().nullsfirst())
             )
         ).all()
         matches: list[Match] = []
@@ -62,7 +62,7 @@ async def list_matches(
             stmt = stmt.where(
                 (Match.played_at.is_(None)) | (Match.played_at > func.now())
             )
-        stmt = stmt.order_by(Match.played_at.desc())
+        stmt = stmt.order_by(Match.played_at.desc().nullsfirst())
         matches = (await session.execute(stmt)).scalars().all()
 
     return [


### PR DESCRIPTION
## Summary
- order match listings with NULL playedAt values first so newly saved matches appear

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3bb7bc0ac8323a0e11cb90627329c