### PR TITLE
Validate padel match sides before submission

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -92,4 +92,36 @@ describe("RecordPadelPage", () => {
       ],
     });
   });
+
+  it("rejects submission with empty sides", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "p1", name: "A" },
+            { id: "p2", name: "B" },
+          ],
+        }),
+      });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordPadelPage />);
+
+    await waitFor(() => screen.getByLabelText("Player A1"));
+
+    fireEvent.change(screen.getByLabelText("Player A1"), {
+      target: { value: "p1" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /select at least one player for each side/i,
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -84,9 +84,16 @@ export default function RecordPadelPage() {
       return;
     }
 
+    const sideA = [ids.a1, ids.a2].filter(Boolean);
+    const sideB = [ids.b1, ids.b2].filter(Boolean);
+    if (!sideA.length || !sideB.length) {
+      setError("Select at least one player for each side");
+      return;
+    }
+
     const participants = [
-      { side: "A", playerIds: [ids.a1, ids.a2].filter(Boolean) },
-      { side: "B", playerIds: [ids.b1, ids.b2].filter(Boolean) },
+      { side: "A", playerIds: sideA },
+      { side: "B", playerIds: sideB },
     ];
 
     try {


### PR DESCRIPTION
## Summary
- Ensure padel match submission requires at least one player on each side
- Add test verifying form rejects submissions when a side is empty

## Testing
- `cd apps/web && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c3c5bca4e88323bea621975763ce5d