### PR TITLE
Use apiFetch for padel players request

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -124,4 +124,18 @@ describe("RecordPadelPage", () => {
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("shows error on unauthorized players request", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordPadelPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /failed to load players/i,
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 
-const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
-
 interface Player {
   id: string;
   name: string;
@@ -45,13 +43,18 @@ export default function RecordPadelPage() {
   useEffect(() => {
     async function loadPlayers() {
       try {
-        const res = await fetch(`${base}/v0/players`);
+        const res = await apiFetch(`/v0/players`);
         if (res.ok) {
           const data = (await res.json()) as { players: Player[] };
           setPlayers(data.players || []);
+        } else if (res.status === 401) {
+          setError("Failed to load players");
+          router.push("/login");
+        } else {
+          setError("Failed to load players");
         }
       } catch {
-        // ignore errors
+        setError("Failed to load players");
       }
     }
     loadPlayers();


### PR DESCRIPTION
## Summary
- use apiFetch in padel record page to include auth token and handle 401 redirects
- test unauthorized players fetch displays an error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3c5bc64588323a55a49b28caad074