### PR TITLE
Validate pagination parameters for player listing

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -1,7 +1,7 @@
 import uuid
 from pathlib import Path
 from collections import defaultdict
-from fastapi import APIRouter, Depends, Response, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, Response, HTTPException, UploadFile, File, Query
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import SQLAlchemyError
@@ -86,8 +86,8 @@ async def create_player(
 @router.get("", response_model=PlayerListOut)
 async def list_players(
     q: str = "",
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = select(Player).where(Player.deleted_at.is_(None))

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -75,7 +75,12 @@ def admin_token(client: TestClient) -> str:
 def test_list_players_pagination() -> None:
     with TestClient(app) as client:
         token = admin_token(client)
-        base_total = client.get("/players").json().get("total", 0)
+        default_resp = client.get("/players")
+        assert default_resp.status_code == 200
+        default_data = default_resp.json()
+        base_total = default_data.get("total", 0)
+        assert default_data["limit"] == 50
+        assert default_data["offset"] == 0
         for i in range(5):
             resp = client.post(
                 "/players",


### PR DESCRIPTION
## Summary
- enforce bounds on `limit` and `offset` query params using FastAPI `Query`
- test default player listing pagination values

## Testing
- `pytest backend/tests/test_players.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3d80d8c808323ba97b0be3bb9b9ad