### PR TITLE
Ignore matches without a winner in player stats

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -321,8 +321,16 @@ async def player_stats(
 
     a_sets = Match.details["sets"]["A"].as_integer()
     b_sets = Match.details["sets"]["B"].as_integer()
-    winner = case((a_sets > b_sets, literal("A")), (b_sets > a_sets, literal("B")), else_=literal(None))
-    is_win = case((winner == mp.side, 1), else_=0)
+    winner = case(
+        (a_sets > b_sets, literal("A")),
+        (b_sets > a_sets, literal("B")),
+        else_=literal(None),
+    )
+    is_win = case(
+        (winner == mp.side, 1),
+        (winner.is_(None), None),
+        else_=0,
+    )
 
     pm = (
         select(
@@ -340,6 +348,7 @@ async def player_stats(
         .join(self_ids, true())
         .where(self_ids.c.value == player_id)
         .where(Match.deleted_at.is_(None))
+        .where(winner.is_not(None))
     ).cte("pm")
 
     rows = (

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -153,6 +153,63 @@ def seed_with_singles(session_maker):
     asyncio.run(_seed())
 
 
+def seed_with_unknown_results(session_maker):
+    async def _seed():
+        async with session_maker() as session:
+            session.add(Sport(id="padel", name="Padel"))
+            session.add_all(
+                [
+                    Player(id="p1", name="Alice"),
+                    Player(id="p2", name="Bob"),
+                    Player(id="p3", name="Cara"),
+                    Player(id="p4", name="Dan"),
+                ]
+            )
+            # Match 1: p1+p2 beat p3+p4
+            session.add(
+                Match(id="m1", sport_id="padel", details={"sets": {"A": 2, "B": 0}})
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp1", match_id="m1", side="A", player_ids=["p1", "p2"]
+                )
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp2", match_id="m1", side="B", player_ids=["p3", "p4"]
+                )
+            )
+            # Match 2: p1+p3 lose to p2+p4
+            session.add(
+                Match(id="m2", sport_id="padel", details={"sets": {"A": 0, "B": 2}})
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp3", match_id="m2", side="A", player_ids=["p1", "p3"]
+                )
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp4", match_id="m2", side="B", player_ids=["p2", "p4"]
+                )
+            )
+            # Match 3: details missing, winner unknown
+            session.add(Match(id="m3", sport_id="padel"))
+            session.add(
+                MatchParticipant(
+                    id="mp5", match_id="m3", side="A", player_ids=["p1", "p4"]
+                )
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp6", match_id="m3", side="B", player_ids=["p2", "p3"]
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_seed())
+
+
 def test_player_stats(client_and_session):
     client, session_maker = client_and_session
     seed(session_maker)
@@ -202,3 +259,19 @@ def test_player_stats_with_singles(client_and_session):
     assert sf[("padel", "doubles")]["losses"] == 1
     assert sf[("padel", "singles")]["wins"] == 1
     assert sf[("padel", "singles")]["losses"] == 0
+
+
+def test_player_stats_ignores_matches_without_winner(client_and_session):
+    client, session_maker = client_and_session
+    seed_with_unknown_results(session_maker)
+
+    resp = client.get("/players/p1/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Only the two matches with a known outcome should be counted
+    assert data["rollingWinPct"] == [1.0, 0.5]
+    sf = data["sportFormatStats"][0]
+    assert sf["wins"] == 1 and sf["losses"] == 1
+    records = {r["playerId"]: r for r in data["withRecords"]}
+    assert "p4" not in records


### PR DESCRIPTION
## Summary
- skip matches without a determinable winner when computing player stats
- test that matches with missing results are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3dfd2f8f483238630a0499d058725