### PR TITLE
Prune stale master ratings and commit upserts

### DIFF
--- a/backend/app/services/master_rating.py
+++ b/backend/app/services/master_rating.py
@@ -62,3 +62,13 @@ async def update_master_ratings(session: AsyncSession) -> None:
                 MasterRating(id=uuid.uuid4().hex, player_id=pid, value=avg)
             )
 
+    await session.commit()
+
+    # Remove players that no longer have ratings
+    stale_ids = set(existing_map) - set(player_norms)
+    for pid in stale_ids:
+        await session.delete(existing_map[pid])
+
+    if stale_ids:
+        await session.commit()
+

--- a/backend/tests/test_master_rating_service.py
+++ b/backend/tests/test_master_rating_service.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
+
+from backend.app.models import Player, Rating, MasterRating
+from backend.app.services import update_master_ratings
+
+
+def test_update_master_ratings_upsert_and_prune():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def run_test():
+        async with engine.begin() as conn:
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(MasterRating.__table__.create)
+
+        async with async_session_maker() as session:
+            session.add_all([
+                Player(id="p1", name="A"),
+                Player(id="p2", name="B"),
+                Player(id="p3", name="C"),
+                Rating(id="r1", player_id="p1", sport_id="padel", value=1200),
+                Rating(id="r2", player_id="p2", sport_id="padel", value=800),
+                MasterRating(id="m1", player_id="p1", value=500),
+                MasterRating(id="m3", player_id="p3", value=750),
+            ])
+            await session.commit()
+            await update_master_ratings(session)
+
+        async with async_session_maker() as session:
+            rows = (
+                await session.execute(
+                    select(MasterRating).order_by(MasterRating.player_id)
+                )
+            ).scalars().all()
+            return [(r.player_id, r.value) for r in rows]
+
+    results = asyncio.run(run_test())
+    assert len(results) == 2
+    assert results[0][0] == "p1" and abs(results[0][1] - 1000.0) < 1e-6
+    assert results[1][0] == "p2" and abs(results[1][1]) < 1e-6


### PR DESCRIPTION
## Summary
- Commit master rating upserts and remove entries for players without ratings
- Add test ensuring master ratings are updated and stale rows pruned

## Testing
- `PYTHONPATH=. pytest backend/tests/test_master_rating_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e0d5d0d88323a962452a4bbabca1