### PR TITLE
Handle missing player names in player fetch

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -63,9 +63,30 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
     );
     if (r.ok) {
       const players = (await r.json()) as PlayerInfo[];
+      const remaining = new Set(idList);
+      const missing: string[] = [];
       players.forEach((p) => {
-        if (p.id && p.name) idToPlayer.set(p.id, p);
+        if (p.id) {
+          remaining.delete(p.id);
+          if (p.name) {
+            idToPlayer.set(p.id, p);
+          } else {
+            missing.push(p.id);
+            idToPlayer.set(p.id, { id: p.id, name: "Unknown" });
+          }
+        }
       });
+      if (remaining.size) {
+        missing.push(...Array.from(remaining));
+        remaining.forEach((id) =>
+          idToPlayer.set(id, { id, name: "Unknown" })
+        );
+      }
+      if (missing.length) {
+        console.warn(
+          `Player names missing for ids: ${missing.join(", ")}`
+        );
+      }
     }
   }
 
@@ -73,7 +94,9 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
     const participants = detail.participants
       .slice()
       .sort((a, b) => a.side.localeCompare(b.side))
-      .map((p) => p.playerIds.map((id) => idToPlayer.get(id) ?? { id, name: id }));
+      .map((p) =>
+        p.playerIds.map((id) => idToPlayer.get(id) ?? { id, name: "Unknown" })
+      );
     return { ...row, participants, summary: detail.summary };
   });
 }

--- a/apps/web/src/lib/matches.test.ts
+++ b/apps/web/src/lib/matches.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { enrichMatches, type MatchRow } from './matches';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('enrichMatches', () => {
+  it('falls back to Unknown when player name missing', async () => {
+    const rows: MatchRow[] = [
+      { id: 'm1', sport: 'padel', bestOf: 3, playedAt: null, location: null },
+    ];
+    const detail = {
+      participants: [
+        { side: 'A', playerIds: ['1'] },
+        { side: 'B', playerIds: ['2'] },
+      ],
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => detail })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: '1', name: 'Alice' }, { id: '2' }] });
+    global.fetch = fetchMock as any;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const enriched = await enrichMatches(rows);
+    expect(enriched[0].players.A[0]).toEqual({ id: '1', name: 'Alice' });
+    expect(enriched[0].players.B[0]).toEqual({ id: '2', name: 'Unknown' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('2'));
+  });
+});


### PR DESCRIPTION
## Summary
- detect missing player names after `/v0/players/by-ids` fetches and log warnings
- default missing players to `name: "Unknown"`
- test fallback for players without names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e0d81ef08323bb398cf2aa4a383a