### PR TITLE
Handle API fetch failures with detailed errors

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -43,15 +43,18 @@ describe("PlayersPage", () => {
   });
 
   it("filters players by search input", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        players: [
-          { id: "1", name: "Alice" },
-          { id: "2", name: "Bob" },
-        ],
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "1", name: "Alice" },
+            { id: "2", name: "Bob" },
+          ],
+        }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
 
     await act(async () => {
@@ -70,15 +73,18 @@ describe("PlayersPage", () => {
   });
 
   it("filters out Albert accounts", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        players: [
-          { id: "1", name: "Albert" },
-          { id: "2", name: "Bob" },
-        ],
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "1", name: "Albert" },
+            { id: "2", name: "Bob" },
+          ],
+        }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
 
     await act(async () => {
@@ -90,15 +96,18 @@ describe("PlayersPage", () => {
   });
 
   it("shows a message when no players match the search", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        players: [
-          { id: "1", name: "Alice" },
-          { id: "2", name: "Bob" },
-        ],
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "1", name: "Alice" },
+            { id: "2", name: "Bob" },
+          ],
+        }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
 
     await act(async () => {
@@ -157,6 +166,7 @@ describe("PlayersPage", () => {
         ok: true,
         json: async () => ({ players: [{ id: "1", name: "Alice" }] }),
       })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({
         ok: true,

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -126,7 +126,9 @@ describe("RecordPadelPage", () => {
   });
 
   it("shows error on unauthorized players request", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => "" });
     global.fetch = fetchMock as typeof fetch;
 
     render(<RecordPadelPage />);

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -44,17 +44,13 @@ export default function RecordPadelPage() {
     async function loadPlayers() {
       try {
         const res = await apiFetch(`/v0/players`);
-        if (res.ok) {
-          const data = (await res.json()) as { players: Player[] };
-          setPlayers(data.players || []);
-        } else if (res.status === 401) {
-          setError("Failed to load players");
-          router.push("/login");
-        } else {
-          setError("Failed to load players");
-        }
-      } catch {
+        const data = (await res.json()) as { players: Player[] };
+        setPlayers(data.players || []);
+      } catch (err: any) {
         setError("Failed to load players");
+        if (err?.status === 401) {
+          router.push("/login");
+        }
       }
     }
     loadPlayers();
@@ -119,7 +115,6 @@ export default function RecordPadelPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      if (!res.ok) return;
       const data = (await res.json()) as { id: string };
       const setPayload = {
         sets: sets

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,7 +20,14 @@ export async function apiFetch(path: string, init?: RequestInit) {
     if (token) headers.set("Authorization", `Bearer ${token}`);
   }
   try {
-    return await fetch(apiUrl(path), { ...init, headers });
+    const res = await fetch(apiUrl(path), { ...init, headers });
+    if (!res.ok) {
+      const text = await res.text();
+      const err = new Error(`HTTP ${res.status}: ${text}`);
+      (err as any).status = res.status;
+      throw err;
+    }
+    return res;
   } catch (err) {
     console.error("API request failed", err);
     throw err;
@@ -77,7 +84,6 @@ export function isAdmin(): boolean {
 
 export async function fetchMe() {
   const res = await apiFetch("/v0/auth/me");
-  if (!res.ok) throw new Error("Failed to load profile");
   return res.json();
 }
 
@@ -90,6 +96,5 @@ export async function updateMe(data: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error("Failed to update profile");
   return res.json();
 }

--- a/apps/web/src/lib/useMatchStream.ts
+++ b/apps/web/src/lib/useMatchStream.ts
@@ -47,9 +47,7 @@ export function useMatchStream(id: string) {
           const res = (await apiFetch(
             `/v0/matches/${encodeURIComponent(id)}`
           )) as Response;
-          if (res.ok) {
-            setEvent((await res.json()) as MatchEvent);
-          }
+          setEvent((await res.json()) as MatchEvent);
         } catch (err) {
           console.error("polling failed", err);
         }


### PR DESCRIPTION
## Summary
- Throw detailed errors in `apiFetch` including status and response text
- Update components and hooks to catch thrown fetch errors
- Adjust tests to mock fetch responses with error handling

## Testing
- `cd apps/web && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c3e0d763588323b98ea33ef50c00e3