### PR TITLE
Add padel route health check

### DIFF
--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -14,12 +14,12 @@ services:
       start_period: 20s
 
   web:
-    # web is a Node image; use Node to probe /
+    # web is a Node image; probe both / and /record/padel
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "node -e \"require('http').get('http://127.0.0.1:3000/',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\"",
+          "node -e \"const http=require('http');const paths=['/','/record/padel'];let pending=paths.length,err=0;paths.forEach(p=>http.get('http://127.0.0.1:3000'+p,r=>{if(r.statusCode!==200)err=1;if(--pending===0)process.exit(err)}).on('error',()=>{err=1;if(--pending===0)process.exit(err)}));\"",
         ]
       interval: 15s
       timeout: 3s


### PR DESCRIPTION
## Summary
- expand web container health check to hit `/record/padel`

## Testing
- `npm test -- --run`
- `PYTHONPATH=. pytest backend`
- `curl -I https://app.thatyellowhouse.org/record/padel` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e9d64af08323b0b3df27b3122732