### PR TITLE
Normalize timezone-aware match timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Tournaments (MVP): Round-robin + Single-elimination; seeding=random; RR tiebreak
 
 Ratings: ELO baseline 1000; K=24 (K=32 if <30 games); per-sport rows
 
-Timezone: Store UTC; render client TZ (default Australia/Melbourne)
+Timezone: Store UTC; render client TZ (default Australia/Melbourne). API accepts timezone-aware datetimes but stores them as UTC-naive
 
 Testing targets: Engines ≥ 90% coverage; Playwright E2E for core flows
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Literal, Optional, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 from pydantic import BaseModel, Field, model_validator, field_validator
 
@@ -86,6 +86,12 @@ class MatchCreate(BaseModel):
     location: Optional[str] = None
     score: Optional[List[int]] = None
 
+    @field_validator("playedAt")
+    def _normalize_played_at(cls, v: datetime | None) -> datetime | None:
+        if v and v.tzinfo:
+            return v.astimezone(timezone.utc).replace(tzinfo=None)
+        return v
+
 class ParticipantByName(BaseModel):
     side: Literal["A", "B", "C", "D", "E", "F"]
     playerNames: List[str]
@@ -97,6 +103,12 @@ class MatchCreateByName(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+
+    @field_validator("playedAt")
+    def _normalize_played_at(cls, v: datetime | None) -> datetime | None:
+        if v and v.tzinfo:
+            return v.astimezone(timezone.utc).replace(tzinfo=None)
+        return v
 
 class SetsIn(BaseModel):
     sets: List[Tuple[int, int]]


### PR DESCRIPTION
## Summary
- normalize timezone-aware datetimes to UTC-naive in `MatchCreate` and `MatchCreateByName`
- document timezone handling in README
- test that posting a timezone-aware `playedAt` stores a UTC-naive value

## Testing
- `pytest backend/tests/test_matches.py::test_create_match_normalizes_timezone -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3fa2d6b1083238ec8a950f29ac8c9