### PR TITLE
Fix player_ids type for SQLite compatibility

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -59,7 +59,9 @@ class PlayerBadge(Base):
 class Team(Base):
     __tablename__ = "team"
     id = Column(String, primary_key=True)
-    player_ids = Column(JSONB, nullable=False)
+    player_ids = Column(
+        JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
 
 class Tournament(Base):
     __tablename__ = "tournament"
@@ -91,7 +93,9 @@ class MatchParticipant(Base):
     id = Column(String, primary_key=True)
     match_id = Column(String, ForeignKey("match.id"), nullable=False)
     side = Column(String, nullable=False)  # "A" | "B"
-    player_ids = Column(JSONB, nullable=False)
+    player_ids = Column(
+        JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
 
 class ScoreEvent(Base):
     __tablename__ = "score_event"


### PR DESCRIPTION
## Summary
- Use JSON with Postgres JSONB variant for player_ids fields
- Enable SQLite-based tests to create match participants without type errors

## Testing
- `PYTHONPATH=. pytest backend/tests/test_matches.py::test_create_match_rejects_duplicate_players -q`
- `PYTHONPATH=. pytest backend/tests/test_matches.py::test_create_match_with_scores -q`
- `PYTHONPATH=. pytest backend/tests/test_matches.py::test_create_match_normalizes_timezone -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43f02042c832385b6af178a78fa30