### PR TITLE
Record rating changes in leaderboards

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -280,12 +280,15 @@ async def delete_match(
                     players_a,
                     players_b,
                     draws=players_a + players_b,
+                    match_id=match.id,
                 )
             else:
                 winner_side = "A" if sets["A"] > sets["B"] else "B"
                 winners = players_a if winner_side == "A" else players_b
                 losers = players_b if winner_side == "A" else players_a
-                await update_ratings(session, match.sport_id, winners, losers)
+                await update_ratings(
+                    session, match.sport_id, winners, losers, match_id=match.id
+                )
         await session.commit()
     except Exception:
         # Ignore errors (e.g., rating tables may not exist in some tests)
@@ -428,6 +431,7 @@ async def record_sets_endpoint(
                     players_a,
                     players_b,
                     draws=draws,
+                    match_id=mid,
                 )
             except Exception:
                 pass
@@ -439,7 +443,9 @@ async def record_sets_endpoint(
             winners = players_a if winner_side == "A" else players_b
             losers = players_b if winner_side == "A" else players_a
             try:
-                await update_ratings(session, m.sport_id, winners, losers)
+                await update_ratings(
+                    session, m.sport_id, winners, losers, match_id=mid
+                )
             except Exception:
                 pass
             await update_player_metrics(

--- a/backend/tests/test_player_profile_metrics.py
+++ b/backend/tests/test_player_profile_metrics.py
@@ -21,9 +21,11 @@ from backend.app.models import (
     Sport,
     PlayerMetric,
     ScoreEvent,
+    User,
 )
 from backend.app.routers import players, matches
 from backend.app.routers.admin import require_admin
+from backend.app.routers.auth import get_current_user
 
 
 @pytest.fixture()
@@ -64,6 +66,9 @@ def client_and_session():
     app.include_router(matches.router)
     app.dependency_overrides[get_session] = override_get_session
     app.dependency_overrides[require_admin] = lambda: None
+    app.dependency_overrides[get_current_user] = lambda: User(
+        id="u", username="u", password_hash="", is_admin=True
+    )
 
     with TestClient(app) as client:
         yield client, async_session_maker

--- a/backend/tests/test_rating_service.py
+++ b/backend/tests/test_rating_service.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from sqlalchemy import select
 
-from backend.app.models import Player, Rating, Match, MatchParticipant
+from backend.app.models import Player, Rating, Match, MatchParticipant, ScoreEvent
 from backend.app.services import update_ratings
 
 
@@ -139,3 +139,41 @@ def test_update_ratings_variable_k():
     assert abs(r1 - 1008) < 1e-6
     # p2 still uses default K-factor 32; expected change = -16 points
     assert abs(r2 - 984) < 1e-6
+
+
+def test_update_ratings_creates_score_events():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def run_test():
+        async with engine.begin() as conn:
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(Match.__table__.create)
+            await conn.run_sync(MatchParticipant.__table__.create)
+            await conn.run_sync(ScoreEvent.__table__.create)
+
+        async with async_session_maker() as session:
+            session.add_all([
+                Player(id="p1", name="A"),
+                Player(id="p2", name="B"),
+                Rating(id="r1", player_id="p1", sport_id="padel", value=1000),
+                Rating(id="r2", player_id="p2", sport_id="padel", value=1000),
+                Match(id="m1", sport_id="padel"),
+                MatchParticipant(id="mp1", match_id="m1", side="A", player_ids=["p1"]),
+                MatchParticipant(id="mp2", match_id="m1", side="B", player_ids=["p2"]),
+            ])
+            await session.commit()
+
+            await update_ratings(session, "padel", ["p1"], ["p2"], match_id="m1")
+            await session.commit()
+
+            events = (await session.execute(select(ScoreEvent))).scalars().all()
+            return [e.payload for e in events]
+
+    payloads = asyncio.run(run_test())
+    assert {p["playerId"] for p in payloads} == {"p1", "p2"}


### PR DESCRIPTION
## Summary
- log rating changes as `RATING` score events
- ensure match rating updates send match IDs for history tracking
- add test coverage and fix test auth overrides

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4478a77508323bd8690177f8761c9