### PR TITLE
Add player_metric table migration

### DIFF
--- a/backend/alembic/versions/0008_player_metric.py
+++ b/backend/alembic/versions/0008_player_metric.py
@@ -1,0 +1,22 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0008_player_metric'
+# Merge branch `0006_convert_player_ids_to_json` into main migration chain
+down_revision = ('0007_rehash_sha256_passwords', '0006_convert_player_ids_to_json')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'player_metric',
+        sa.Column('player_id', sa.String(), sa.ForeignKey('player.id'), primary_key=True, nullable=False),
+        sa.Column('sport_id', sa.String(), sa.ForeignKey('sport.id'), primary_key=True, nullable=False),
+        sa.Column('metrics', sa.JSON(), nullable=False),
+        sa.Column('milestones', sa.JSON(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('player_metric')


### PR DESCRIPTION
## Summary
- add player_metric table via new Alembic migration
- merge stray migration branch into main chain

## Testing
- `DATABASE_URL=sqlite+aiosqlite:///./alembic_test.db alembic upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `PYTHONPATH=. pytest backend` *(4 failed, 85 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c44823a0548323afcd6744dc6b6473