### PR TITLE
chore: switch to postgres for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ POSTGRES_HOST=postgresql16
 POSTGRES_USER=postgresql16
 POSTGRES_DB=crosssport
 POSTGRES_PASSWORD=
-DATABASE_URL=
+# PostgreSQL connection for local development
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport
 SECRET_KEY=
 # High-entropy secret for signing JWTs (minimum 32-character random string)
 JWT_SECRET=changemechangemechangemechangeme

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: crosssport_test
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 5s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          cd backend
+          pip install -r requirements.txt
+      - name: Run migrations
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_test
+        run: |
+          cd backend
+          alembic upgrade head

--- a/backend/alembic/versions/0008_player_metric.py
+++ b/backend/alembic/versions/0008_player_metric.py
@@ -2,8 +2,8 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0008_player_metric'
-# Merge branch `0006_convert_player_ids_to_json` into main migration chain
-down_revision = ('0007_rehash_sha256_passwords', '0006_convert_player_ids_to_json')
+# Continue from the previous master_rating migration
+down_revision = '0007_master_rating'
 branch_labels = None
 depends_on = None
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,12 @@
 import os
 import pytest
 
+# Default to a PostgreSQL database for tests
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_test",
+)
+
 # A sufficiently long JWT secret for tests
 TEST_JWT_SECRET = "x" * 32
 os.environ.setdefault("JWT_SECRET", TEST_JWT_SECRET)


### PR DESCRIPTION
## Summary
- default environments now use PostgreSQL via `DATABASE_URL`
- run Alembic migrations on PostgreSQL in CI
- fix Alembic revision chain for player metrics

## Testing
- `alembic upgrade heads`
- `alembic current`
- `pytest -q` *(fails: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68c44bf5336c83239ef3bd1401da7343