### PR TITLE
Ensure backend package importable in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- Add `pytest.ini` to include repository root on PYTHONPATH so the `backend` package is importable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c44e6c63dc8323b9fee1a4d2e62995