### PR TITLE
Linearize player_metric migration

### DIFF
--- a/backend/alembic/versions/0008_player_metric.py
+++ b/backend/alembic/versions/0008_player_metric.py
@@ -2,8 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0008_player_metric'
-# Merge branch `0006_convert_player_ids_to_json` into main migration chain
-down_revision = ('0007_rehash_sha256_passwords', '0006_convert_player_ids_to_json')
+down_revision = '0011_rehash_sha256_passwords'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- ensure player_metric migration depends on latest migration to avoid multiple heads

## Testing
- `alembic heads`
- `DATABASE_URL=sqlite+aiosqlite:// alembic upgrade head` *(fails: NotImplementedError: No support for ALTER of constraints in SQLite dialect. Please refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy.)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f58bd4c832395a438aa9a6af2a4