### PR TITLE
Validate player photo MIME types

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -45,6 +45,7 @@ UPLOAD_DIR = Path(__file__).resolve().parent.parent / "static" / "players"
 UPLOAD_URL_PREFIX = f"{API_PREFIX}/static/players"
 MAX_PHOTO_SIZE = 5 * 1024 * 1024  # 5MB limit on upload size
 CHUNK_SIZE = 1024 * 1024  # 1MB chunks for streaming uploads
+ALLOWED_PHOTO_TYPES = {"image/jpeg", "image/png"}
 router = APIRouter(
     prefix="/players",
     tags=["players"],
@@ -171,6 +172,9 @@ async def upload_player_photo(
     p = await session.get(Player, player_id)
     if not p or p.deleted_at is not None:
         raise PlayerNotFound(player_id)
+
+    if file.content_type not in ALLOWED_PHOTO_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported media type")
 
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     suffix = Path(file.filename).suffix

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -229,3 +229,16 @@ def test_upload_player_photo_too_large() -> None:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 413
+
+
+def test_upload_player_photo_invalid_mime_type() -> None:
+    with TestClient(app) as client:
+        token = admin_token(client)
+        pid = client.post(
+            "/players", json={"name": "BadPic"}, headers={"Authorization": f"Bearer {token}"}
+        ).json()["id"]
+        files = {"file": ("avatar.gif", b"gif", "image/gif")}
+        resp = client.post(
+            f"/players/{pid}/photo", files=files, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 415


### PR DESCRIPTION
## Summary
- restrict player photo uploads to JPEG or PNG types
- add unit test for unsupported MIME type uploads

## Testing
- `pytest backend/tests/test_players.py::test_upload_player_photo_prefixed_url backend/tests/test_players.py::test_upload_player_photo_too_large backend/tests/test_players.py::test_upload_player_photo_invalid_mime_type -q`

------
https://chatgpt.com/codex/tasks/task_e_68c44c5fb24083238d72004808d2a425