### PR TITLE
Fix missing refresh token table in test setups

### DIFF
--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import db
-from app.models import User, Player
+from app.models import User, Player, RefreshToken
 from app.routers import auth
 
 app = FastAPI()
@@ -30,7 +30,10 @@ def setup_db():
         db.AsyncSessionLocal = None
         engine = db.get_engine()
         async with engine.begin() as conn:
-            await conn.run_sync(db.Base.metadata.create_all, tables=[User.__table__, Player.__table__])
+            await conn.run_sync(
+                db.Base.metadata.create_all,
+                tables=[User.__table__, Player.__table__, RefreshToken.__table__],
+            )
     asyncio.run(init_models())
     yield
     if os.path.exists("./test_auth_me.db"):

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from fastapi.responses import JSONResponse
 from app import db
 from app.routers import players, auth
-from app.models import Player, User, Comment, Club
+from app.models import Player, User, Comment, Club, RefreshToken
 from app.exceptions import DomainException, ProblemDetail
 
 app = FastAPI()
@@ -46,7 +46,13 @@ def setup_db():
         async with engine.begin() as conn:
             await conn.run_sync(
                 db.Base.metadata.create_all,
-                tables=[Club.__table__, Player.__table__, User.__table__, Comment.__table__],
+                tables=[
+                    Club.__table__,
+                    Player.__table__,
+                    User.__table__,
+                    Comment.__table__,
+                    RefreshToken.__table__,
+                ],
             )
     asyncio.run(init_models())
     yield

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -319,7 +319,7 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
-  from app.models import Match, ScoreEvent, User, Player
+  from app.models import Match, ScoreEvent, User, Player, RefreshToken
   from app.routers import matches, auth
 
   db.engine = None
@@ -331,6 +331,7 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
     await conn.run_sync(ScoreEvent.__table__.create)
     await conn.run_sync(User.__table__.create)
     await conn.run_sync(Player.__table__.create)
+    await conn.run_sync(RefreshToken.__table__.create)
     await conn.exec_driver_sql(
         "CREATE TABLE match_participant (id TEXT PRIMARY KEY, match_id TEXT, side TEXT, player_ids TEXT)"
     )
@@ -399,7 +400,7 @@ async def test_delete_match_missing_returns_404(tmp_path):
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
-  from app.models import Match, User, Player
+  from app.models import Match, User, Player, RefreshToken
   from app.routers import matches, auth
 
   db.engine = None
@@ -410,6 +411,7 @@ async def test_delete_match_missing_returns_404(tmp_path):
     await conn.run_sync(Match.__table__.create)
     await conn.run_sync(User.__table__.create)
     await conn.run_sync(Player.__table__.create)
+    await conn.run_sync(RefreshToken.__table__.create)
 
   app = FastAPI()
   app.include_router(auth.router)

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -9,7 +9,15 @@ from fastapi.testclient import TestClient
 from fastapi.responses import JSONResponse
 from app import db
 from app.routers import players, auth, badges
-from app.models import Player, Club, User, Badge, PlayerBadge, PlayerMetric
+from app.models import (
+    Player,
+    Club,
+    User,
+    Badge,
+    PlayerBadge,
+    PlayerMetric,
+    RefreshToken,
+)
 from app.exceptions import DomainException, ProblemDetail
 
 app = FastAPI()
@@ -51,6 +59,7 @@ def setup_db():
                     Badge.__table__,
                     PlayerBadge.__table__,
                     PlayerMetric.__table__,
+                    RefreshToken.__table__,
                 ],
             )
     asyncio.run(init_models())


### PR DESCRIPTION
## Summary
- ensure RefreshToken table is created in tests using auth routes
- import RefreshToken in affected tests and include its table when initializing databases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4fee912d883239448fdaf9d30fe82