### PR TITLE
Set PYTHONPATH for Alembic migrations in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install pytest
+      - name: Run migrations
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_test
+          PYTHONPATH: ${{ github.workspace }}
+        run: alembic upgrade head
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- run Alembic migrations from the repository root and expose the repo as `PYTHONPATH`

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: refresh_token)*
- `pytest backend/tests/test_auth_me.py::test_get_and_update_me -q` *(fails: sqlite3.OperationalError: no such table: refresh_token)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fb41a6bc8323a6e768a21ae4edb2