### PR TITLE
CI: provide Alembic config for migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install pytest
+      - name: Run migrations
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///./test.db
+        run: alembic -c backend/alembic.ini upgrade head
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- ensure Alembic migrations use the backend config during CI

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5018529748323913e46a5b5ee2f1f