### PR TITLE
Fix Alembic migration path in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           pip install pytest
       - name: Run migrations
         working-directory: backend
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///./ci.db
         run: alembic upgrade head
       - name: Run tests
         env:


### PR DESCRIPTION
## Summary
- ensure Alembic migrations run from backend directory in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50aab045483238f685ab09f0a14cc