### PR TITLE
Merge multiple Alembic heads

### DIFF
--- a/backend/alembic/versions/0013_merge_heads.py
+++ b/backend/alembic/versions/0013_merge_heads.py
@@ -1,0 +1,27 @@
+"""merge heads
+
+Revision ID: 0013_merge_heads
+Revises: 0008_player_metric, 0012_refresh_token_table, 0012_refresh_tokens
+Create Date: 2025-09-13 06:11:10.278954
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0013_merge_heads"
+down_revision = (
+    "0008_player_metric",
+    "0012_refresh_token_table",
+    "0012_refresh_tokens",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge existing migration branches into a single Alembic head

## Testing
- `alembic -c alembic.ini heads`
- `DATABASE_URL=postgresql://localhost/test alembic -c alembic.ini upgrade head` *(fails: Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c50ab1247c8323b6ae75ca8dcd8723