### PR TITLE
Set up Postgres for tests and CI migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Example (no secrets)
 DOMAIN=www.YourDomain.com
 # Required for health and backup services
-POSTGRES_HOST=postgresql16
-POSTGRES_USER=postgresql16
-POSTGRES_DB=crosssport
-POSTGRES_PASSWORD=
-DATABASE_URL=
+POSTGRES_HOST=localhost
+POSTGRES_USER=postgres
+POSTGRES_DB=crosssport_dev
+POSTGRES_PASSWORD=postgres
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_dev
 SECRET_KEY=
 # High-entropy secret for signing JWTs (minimum 32-character random string)
 JWT_SECRET=changemechangemechangemechangeme

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: crosssport_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_dev
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -17,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install pytest
+      - name: Run migrations
+        run: alembic -c backend/alembic.ini upgrade 0012_refresh_tokens
       - name: Run tests
-        env:
-          PYTHONPATH: ${{ github.workspace }}
         run: pytest -q


### PR DESCRIPTION
## Summary
- provide example DATABASE_URL in .env.example
- run migrations in CI against a Postgres service before tests
- expose backend package via PYTHONPATH for CI steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c50c4762ec8323b5f84fdd3a13859b