### PR TITLE
Skip Alembic migrations when using SQLite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite+aiosqlite:///./ci.db
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -17,7 +19,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install pytest
+      - name: Run migrations
+        if: ${{ !startsWith(env.DATABASE_URL, 'sqlite') }}
+        run: alembic upgrade head
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}
+          DATABASE_URL: ${{ env.DATABASE_URL }}
         run: pytest -q


### PR DESCRIPTION
## Summary
- configure CI to default DATABASE_URL to SQLite
- skip Alembic migrations when DATABASE_URL uses SQLite

## Testing
- `DATABASE_URL=sqlite+aiosqlite:///./ci.db bash -c 'if [[ ! "$DATABASE_URL" == sqlite* ]]; then alembic upgrade head; else echo "Skipping alembic migration"; fi'`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c514c7f700832386d9910987689c7a