### PR TITLE
refactor: move revoked default removal into batch op

### DIFF
--- a/backend/alembic/versions/0013_reconcile_refresh_tokens.py
+++ b/backend/alembic/versions/0013_reconcile_refresh_tokens.py
@@ -34,8 +34,8 @@ def upgrade() -> None:
                         "revoked", sa.Boolean(), nullable=False, server_default=sa.false()
                     )
                 )
-        # remove server default now that column is populated
-        op.alter_column("refresh_token", "revoked", server_default=None)
+            # remove server default now that column is populated
+            batch_op.alter_column("revoked", server_default=None)
 
 
 def downgrade() -> None:
@@ -45,6 +45,7 @@ def downgrade() -> None:
 
     with op.batch_alter_table("refresh_token") as batch_op:
         if "revoked" in columns:
+            batch_op.alter_column("revoked", server_default=sa.false())
             batch_op.drop_column("revoked")
         if "token" not in columns:
             batch_op.add_column(sa.Column("token", sa.String(), nullable=False))


### PR DESCRIPTION
## Summary
- move `revoked` default removal inside batch alter table
- mirror `batch_op.alter_column` usage in downgrade

## Testing
- `DATABASE_URL=sqlite+aiosqlite:///test.db alembic -c alembic.ini upgrade 0012_refresh_token_table` *(fails: No support for ALTER of constraints in SQLite dialect)*


------
https://chatgpt.com/codex/tasks/task_e_68c51998577c8323b3efd8b98c6b5656