### PR TITLE
Rate-limit signup endpoint

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -124,6 +124,7 @@ def test_signup_login_and_protected_access():
     ],
 )
 def test_signup_rejects_invalid_password(username, password):
+    auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
             "/auth/signup", json={"username": username, "password": password}
@@ -131,6 +132,7 @@ def test_signup_rejects_invalid_password(username, password):
         assert resp.status_code == 422
 
 def test_signup_links_orphan_player():
+    auth.limiter.reset()
     pid = asyncio.run(create_player("charlie"))
     with TestClient(app) as client:
         resp = client.post(
@@ -154,6 +156,7 @@ def test_signup_links_orphan_player():
     assert len(same_name_players) == 1
 
 def test_signup_rejects_attached_player():
+    auth.limiter.reset()
     asyncio.run(create_player("dave", user_id="attached"))
     with TestClient(app) as client:
         resp = client.post(

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -81,6 +81,7 @@ def test_get_and_update_me():
 
 
 def test_update_me_conflicting_player_name():
+    auth.limiter.reset()
     with TestClient(app) as client:
         resp = client.post(
             "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass!"}


### PR DESCRIPTION
## Summary
- limit /auth/signup to 5 requests per minute
- optionally throttle flagged IPs via FLAGGED_IPS env var
- reset limiter in tests to account for signup rate limit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5449a6f20832398c390dd261ec6e2