### PR TITLE
Normalize names for players and users

### DIFF
--- a/backend/alembic/versions/0014_player_name_lower_index.py
+++ b/backend/alembic/versions/0014_player_name_lower_index.py
@@ -1,0 +1,31 @@
+"""add case-insensitive uniqueness to player name
+
+Revision ID: 0014_player_name_lower_index
+Revises: 0013_reconcile_refresh_tokens
+Create Date: 2025-09-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0014_player_name_lower_index"
+down_revision = "0013_reconcile_refresh_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("player") as batch_op:
+        batch_op.drop_constraint("uq_player_name", type_="unique")
+    op.create_index(
+        "ix_player_name_lower",
+        "player",
+        [sa.text("lower(name)")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_player_name_lower", table_name="player")
+    op.create_unique_constraint("uq_player_name", "player", ["name"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Float,
     Boolean,
     Text,
+    Index,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
@@ -35,12 +36,15 @@ class Player(Base):
     __tablename__ = "player"
     id = Column(String, primary_key=True)
     user_id = Column(String, nullable=True)
-    name = Column(String, nullable=False, unique=True)
+    name = Column(String, nullable=False)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
     photo_url = Column(String, nullable=True)
     location = Column(String, nullable=True)
     ranking = Column(Integer, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
+    __table_args__ = (
+        Index("ix_player_name_lower", func.lower(name), unique=True),
+    )
 
 
 class Badge(Base):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.exc import IntegrityError
 from passlib.context import CryptContext
 import jwt
@@ -87,14 +87,19 @@ async def signup(
     session: AsyncSession = Depends(get_session),
     admin_secret: str | None = Header(default=None, alias="X-Admin-Secret"),
 ):
+  username = body.username.strip().lower()
   existing = (
-      await session.execute(select(User).where(User.username == body.username))
+      await session.execute(
+          select(User).where(func.lower(User.username) == username)
+      )
   ).scalar_one_or_none()
   if existing:
     raise HTTPException(status_code=400, detail="username exists")
 
   existing_player = (
-      await session.execute(select(Player).where(Player.name == body.username))
+      await session.execute(
+          select(Player).where(func.lower(Player.name) == username)
+      )
   ).scalar_one_or_none()
   if existing_player and existing_player.user_id is not None:
     raise HTTPException(status_code=400, detail="player exists")
@@ -109,15 +114,16 @@ async def signup(
   uid = uuid.uuid4().hex
   user = User(
       id=uid,
-      username=body.username,
+      username=username,
       password_hash=pwd_context.hash(body.password),
       is_admin=is_admin,
   )
   session.add(user)
   if existing_player:
     existing_player.user_id = uid
+    existing_player.name = username
   else:
-    player = Player(id=uuid.uuid4().hex, user_id=uid, name=body.username)
+    player = Player(id=uuid.uuid4().hex, user_id=uid, name=username)
     session.add(player)
   access_token, refresh_token = await create_token(user, session)
   await session.commit()
@@ -131,8 +137,11 @@ async def login(
     body: UserLogin,
     session: AsyncSession = Depends(get_session),
 ):
+  username = body.username.strip().lower()
   user = (
-      await session.execute(select(User).where(User.username == body.username))
+      await session.execute(
+          select(User).where(func.lower(User.username) == username)
+      )
   ).scalar_one_or_none()
   if not user:
     raise HTTPException(status_code=401, detail="invalid credentials")
@@ -174,29 +183,31 @@ async def update_me(
     current: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-  if body.username and body.username != current.username:
-    existing = (
-        await session.execute(
-            select(User).where(User.username == body.username)
-        )
-    ).scalar_one_or_none()
-    if existing and existing.id != current.id:
-      raise HTTPException(status_code=400, detail="username exists")
+  if body.username:
+    new_username = body.username.strip().lower()
+    if new_username != current.username:
+      existing = (
+          await session.execute(
+              select(User).where(func.lower(User.username) == new_username)
+          )
+      ).scalar_one_or_none()
+      if existing and existing.id != current.id:
+        raise HTTPException(status_code=400, detail="username exists")
 
-    existing_player = (
-        await session.execute(
-            select(Player).where(Player.name == body.username)
-        )
-    ).scalar_one_or_none()
-    if existing_player:
-      raise HTTPException(status_code=400, detail="player exists")
+      existing_player = (
+          await session.execute(
+              select(Player).where(func.lower(Player.name) == new_username)
+          )
+      ).scalar_one_or_none()
+      if existing_player:
+        raise HTTPException(status_code=400, detail="player exists")
 
-    current.username = body.username
-    player = (
-        await session.execute(select(Player).where(Player.user_id == current.id))
-    ).scalar_one_or_none()
-    if player:
-      player.name = body.username
+      current.username = new_username
+      player = (
+          await session.execute(select(Player).where(Player.user_id == current.id))
+      ).scalar_one_or_none()
+      if player:
+        player.name = new_username
   if body.password:
     current.password_hash = pwd_context.hash(body.password)
   try:

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -58,15 +58,18 @@ async def create_player(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(require_admin),
 ):
+    normalized_name = body.name.strip().lower()
     exists = (
-        await session.execute(select(Player).where(Player.name == body.name))
+        await session.execute(
+            select(Player).where(func.lower(Player.name) == normalized_name)
+        )
     ).scalar_one_or_none()
     if exists:
-        raise PlayerAlreadyExists(body.name)
+        raise PlayerAlreadyExists(normalized_name)
     pid = uuid.uuid4().hex
     p = Player(
         id=pid,
-        name=body.name,
+        name=normalized_name,
         club_id=body.club_id,
         photo_url=body.photo_url,
         location=body.location,

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -90,7 +90,7 @@ async def main():
             x.id for x in (await s.execute(select(Player))).scalars().all()
         }
         players = [
-            Player(id="demo-player", name="Demo Player", club_id="demo-club"),
+            Player(id="demo-player", name="demo player", club_id="demo-club"),
         ]
         for p in players:
             if p.id not in existing_players:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -63,7 +63,7 @@ def setup_db():
 def test_signup_login_and_protected_access():
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "alice", "password": "Str0ng!Pass!"}
+            "/auth/signup", json={"username": " Alice ", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
@@ -79,6 +79,7 @@ def test_signup_login_and_protected_access():
 
         user = asyncio.run(fetch_user())
         assert user.password_hash != "pw"
+        assert user.username == "alice"
         assert pwd_context.verify("Str0ng!Pass!", user.password_hash)
 
         resp = client.post(
@@ -134,7 +135,7 @@ def test_signup_links_orphan_player():
     pid = asyncio.run(create_player("charlie"))
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "charlie", "password": "Str0ng!Pass!"}
+            "/auth/signup", json={"username": "CHARLIE ", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
 
@@ -151,10 +152,12 @@ def test_signup_links_orphan_player():
 
     player, user, same_name_players = asyncio.run(fetch())
     assert player.user_id == user.id
+    assert player.name == "charlie"
+    assert user.username == "charlie"
     assert len(same_name_players) == 1
 
 def test_signup_rejects_attached_player():
-    asyncio.run(create_player("dave", user_id="attached"))
+    asyncio.run(create_player("DAVE", user_id="attached"))
     with TestClient(app) as client:
         resp = client.post(
             "/auth/signup", json={"username": "dave", "password": "Str0ng!Pass!"}

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -83,14 +83,14 @@ def test_get_and_update_me():
 def test_update_me_conflicting_player_name():
     with TestClient(app) as client:
         resp = client.post(
-            "/auth/signup", json={"username": "bob", "password": "Str0ng!Pass!"}
+            "/auth/signup", json={"username": " Bob ", "password": "Str0ng!Pass!"}
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
 
         async def create_player():
             async with db.AsyncSessionLocal() as session:
-                session.add(Player(id=uuid.uuid4().hex, name="taken"))
+                session.add(Player(id=uuid.uuid4().hex, name="Taken"))
                 await session.commit()
 
         asyncio.run(create_player())


### PR DESCRIPTION
## Summary
- normalize player names on creation and query using case-insensitive checks
- lowercase/trim usernames in auth routes and ensure player links use normalized names
- enforce case-insensitive uniqueness for player names via functional index and migration

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c54474af948323a67c48eb33e15291