### PR TITLE
Hash refresh tokens and backfill existing values

### DIFF
--- a/backend/alembic/versions/0014_hash_refresh_tokens.py
+++ b/backend/alembic/versions/0014_hash_refresh_tokens.py
@@ -1,0 +1,36 @@
+"""hash existing refresh tokens
+
+Revision ID: 0014_hash_refresh_tokens
+Revises: 0013_merge_heads
+Create Date: 2024-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import hashlib
+
+revision = "0014_hash_refresh_tokens"
+down_revision = "0013_merge_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("refresh_token", "id", new_column_name="token_hash")
+    refresh_token = sa.table(
+        "refresh_token",
+        sa.column("token_hash", sa.String),
+    )
+    bind = op.get_bind()
+    rows = bind.execute(sa.select(refresh_token.c.token_hash)).fetchall()
+    for (token,) in rows:
+        hashed = hashlib.sha256(token.encode()).hexdigest()
+        bind.execute(
+            refresh_token.update()
+            .where(refresh_token.c.token_hash == token)
+            .values(token_hash=hashed)
+        )
+
+
+def downgrade() -> None:
+    op.alter_column("refresh_token", "token_hash", new_column_name="id")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -140,7 +140,7 @@ class User(Base):
 
 class RefreshToken(Base):
     __tablename__ = "refresh_token"
-    id = Column(String, primary_key=True)
+    token_hash = Column(String, primary_key=True)
     user_id = Column(String, ForeignKey("user.id"), nullable=False)
     expires_at = Column(DateTime, nullable=False)
     revoked = Column(Boolean, nullable=False, default=False)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import hashlib
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Header, Request
 from fastapi.responses import JSONResponse
@@ -70,9 +71,10 @@ async def create_token(user: User, session: AsyncSession) -> tuple[str, str]:
   }
   access_token = jwt.encode(payload, get_jwt_secret(), algorithm=JWT_ALG)
   refresh_token = uuid.uuid4().hex
+  token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
   session.add(
       RefreshToken(
-          id=refresh_token,
+          token_hash=token_hash,
           user_id=user.id,
           expires_at=datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
           revoked=False,
@@ -215,7 +217,8 @@ async def update_me(
 async def refresh_tokens(
     body: RefreshRequest, session: AsyncSession = Depends(get_session)
 ):
-  token = await session.get(RefreshToken, body.refresh_token)
+  token_hash = hashlib.sha256(body.refresh_token.encode()).hexdigest()
+  token = await session.get(RefreshToken, token_hash)
   if (
       not token
       or token.revoked
@@ -235,7 +238,8 @@ async def refresh_tokens(
 async def revoke_token(
     body: RefreshRequest, session: AsyncSession = Depends(get_session)
 ):
-  token = await session.get(RefreshToken, body.refresh_token)
+  token_hash = hashlib.sha256(body.refresh_token.encode()).hexdigest()
+  token = await session.get(RefreshToken, token_hash)
   if token:
     token.revoked = True
     await session.commit()


### PR DESCRIPTION
## Summary
- Store refresh tokens as SHA-256 hashes and look up by hash
- Backfill hashes for existing refresh tokens via migration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5467d824c8323bcfcb0dde7de7dc3