### PR TITLE
Backfill hashed refresh tokens during migration

### DIFF
--- a/backend/alembic/versions/0014_hash_refresh_tokens.py
+++ b/backend/alembic/versions/0014_hash_refresh_tokens.py
@@ -1,4 +1,4 @@
-"""rename refresh token id to token_hash
+"""rename refresh token id to token_hash and backfill hashes
 
 Revision ID: 0014_hash_refresh_tokens
 Revises: 0013_reconcile_refresh_tokens
@@ -6,6 +6,8 @@ Create Date: 2025-01-01 00:00:00.000000
 """
 
 from alembic import op
+import hashlib
+import sqlalchemy as sa
 
 revision = "0014_hash_refresh_tokens"
 down_revision = "0013_reconcile_refresh_tokens"
@@ -15,6 +17,19 @@ depends_on = None
 def upgrade() -> None:
     with op.batch_alter_table("refresh_token") as batch_op:
         batch_op.alter_column("id", new_column_name="token_hash")
+
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT token_hash FROM refresh_token")).fetchall()
+    for (token,) in rows:
+        if len(token) == 64 and all(c in "0123456789abcdef" for c in token):
+            continue
+        hashed = hashlib.sha256(token.encode()).hexdigest()
+        bind.execute(
+            sa.text(
+                "UPDATE refresh_token SET token_hash = :hashed WHERE token_hash = :token"
+            ),
+            {"hashed": hashed, "token": token},
+        )
 
 def downgrade() -> None:
     with op.batch_alter_table("refresh_token") as batch_op:


### PR DESCRIPTION
## Summary
- ensure existing refresh tokens are hashed during migration to token_hash

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c55846de9c832383adeaca2613b8bd