### PR TITLE
feat(web): show match creation success

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -74,6 +74,9 @@ describe("RecordPadelPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/match recorded/i),
+    );
     const createPayload = JSON.parse(fetchMock.mock.calls[1][1].body);
     const setsPayload = JSON.parse(fetchMock.mock.calls[2][1].body);
 

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -39,6 +39,8 @@ export default function RecordPadelPage() {
   const [time, setTime] = useState("");
   const [location, setLocation] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [success, setSuccess] = useState(false);
 
   useEffect(() => {
     async function loadPlayers() {
@@ -74,7 +76,9 @@ export default function RecordPadelPage() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (saving) return;
     setError(null);
+    setSaving(true);
 
     const idValues = [ids.a1, ids.a2, ids.b1, ids.b2];
     const filtered = idValues.filter((v) => v);
@@ -128,8 +132,10 @@ export default function RecordPadelPage() {
           body: JSON.stringify(setPayload),
         });
       }
+      setSuccess(true);
       router.push(`/matches`);
     } catch {
+      setSaving(false);
       // ignore network errors
     }
   };
@@ -259,7 +265,14 @@ export default function RecordPadelPage() {
           </p>
         )}
 
-        <button type="submit">Save</button>
+        {success && (
+          <p role="status" className="success">
+            Match recorded!
+          </p>
+        )}
+        <button type="submit" disabled={saving}>
+          {saving ? "Saving..." : "Save"}
+        </button>
       </form>
     </main>
   );


### PR DESCRIPTION
## Summary
- show success banner after recording a padel match and disable resubmission
- test padel match recording shows success notice

## Testing
- `npm test` *(fails: RecordSportPage clears partners/score assertions)*
- `.venv/bin/pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5455c992c83238ae5c692cf57f5a9