### PR TITLE
test: centralize in-memory db setup

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,25 @@
 import os
+import sys
 import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import db
 
 # A sufficiently long JWT secret for tests
 TEST_JWT_SECRET = "x" * 32
 os.environ.setdefault("JWT_SECRET", TEST_JWT_SECRET)
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+
+@pytest.fixture(autouse=True)
+def _db(monkeypatch):
+    """Provide a clean in-memory database for each test."""
+    if not os.getenv("DATABASE_URL"):
+        monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    db.engine = None
+    db.AsyncSessionLocal = None
+    yield
+
 
 @pytest.fixture(autouse=True)
 def jwt_secret(monkeypatch):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,6 +19,10 @@ def _db(monkeypatch):
     db.engine = None
     db.AsyncSessionLocal = None
     yield
+    if db.engine is not None:
+        db.engine.sync_engine.dispose()
+    db.engine = None
+    db.AsyncSessionLocal = None
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -36,7 +36,7 @@ async def create_player(name: str, user_id: str | None = None) -> str:
         await session.commit()
         return pid
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_db():
     async def init_models():
         if os.path.exists("./test_auth.db"):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -10,7 +10,6 @@ from sqlalchemy import select
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth.db"
 # Use a sufficiently long JWT secret for tests
 os.environ["JWT_SECRET"] = "x" * 32
 os.environ["ADMIN_SECRET"] = "admintest"

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -20,7 +20,7 @@ app.add_exception_handler(RateLimitExceeded, auth.rate_limit_handler)
 app.include_router(auth.router)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_db():
     async def init_models():
         if os.path.exists("./test_auth_me.db"):

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -23,7 +23,6 @@ app.include_router(auth.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth_me.db"
         if os.path.exists("./test_auth_me.db"):
             os.remove("./test_auth_me.db")
         db.engine = None

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -34,7 +34,7 @@ app.include_router(auth.router)
 app.include_router(players.router)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_db():
     async def init_models():
         if os.path.exists("./test_comments.db"):

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -37,7 +37,6 @@ app.include_router(players.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_comments.db"
         if os.path.exists("./test_comments.db"):
             os.remove("./test_comments.db")
         db.engine = None

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -26,7 +26,7 @@ app = FastAPI()
 app.include_router(leaderboards.router)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_db():
     async def init_models():
         if os.path.exists("./test_leaderboards.db"):

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -11,9 +11,6 @@ from sqlalchemy.dialects.sqlite import JSON
 # Ensure backend app modules can be imported
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-# Configure database for tests
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_leaderboards.db"
-
 from app import db  # noqa: E402
 from app.models import (
     Player,

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -17,7 +17,6 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Player, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -48,7 +47,6 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_rejects_duplicate_players(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Sport, User
   from app.schemas import MatchCreate, Participant
@@ -80,7 +78,6 @@ async def test_create_match_rejects_duplicate_players(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_by_name_is_case_insensitive(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Player, Sport, Match, MatchParticipant, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -118,7 +115,6 @@ async def test_create_match_by_name_is_case_insensitive(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_with_scores(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Sport, User
   from app.schemas import MatchCreate, Participant
@@ -150,7 +146,6 @@ async def test_create_match_with_scores(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_normalizes_timezone(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -200,7 +195,6 @@ async def test_create_match_normalizes_timezone(tmp_path):
 
 @pytest.mark.anyio
 async def test_list_matches_returns_most_recent_first(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -243,7 +237,6 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
 
 @pytest.mark.anyio
 async def test_list_matches_upcoming_filter(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -281,7 +274,6 @@ async def test_list_matches_upcoming_filter(tmp_path):
 
 @pytest.mark.skip(reason="SQLite lacks ARRAY support for MatchParticipant")
 def test_list_matches_filters_by_player(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -352,7 +344,6 @@ def test_list_matches_filters_by_player(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -433,7 +424,6 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_missing_returns_404(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -473,8 +463,6 @@ async def test_delete_match_missing_returns_404(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
-  prev_db = os.environ.get("DATABASE_URL")
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from sqlalchemy.dialects.sqlite import JSON
   from app import db
   from app.models import (
@@ -578,15 +566,11 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
     assert ratings["p1"] == pytest.approx(1000.0)
     assert ratings["p2"] > ratings["p1"] > ratings["p3"]
 
-  if prev_db is None:
-    del os.environ["DATABASE_URL"]
-  else:
-    os.environ["DATABASE_URL"] = prev_db
+  # previous DB URL handling removed; no cleanup required
 
 
 @pytest.mark.anyio
 async def test_create_match_preserves_naive_date(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -630,7 +614,6 @@ async def test_create_match_preserves_naive_date(tmp_path):
 
 @pytest.mark.anyio
 async def test_user_with_multiple_player_records_can_modify_match(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Player, ScoreEvent, User
   from app.schemas import EventIn

--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_player_profile_metrics.py
+++ b/backend/tests/test_player_profile_metrics.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -40,7 +40,7 @@ app.include_router(auth.router)
 app.include_router(players.router)
 app.include_router(badges.router)
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_db():
     async def init_models():
         if os.path.exists("./test_players.db"):

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -43,7 +43,6 @@ app.include_router(badges.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
         if os.path.exists("./test_players.db"):
             os.remove("./test_players.db")
         db.engine = None

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -4,7 +4,6 @@ from typing import Tuple
 # Ensure the app package is importable and the DB URL is set for module import
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -16,7 +16,6 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_tournament_crud(tmp_path):
-    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     from app import db
     from app.models import Sport, Tournament, Stage
     from app.routers import tournaments
@@ -52,7 +51,6 @@ async def test_tournament_crud(tmp_path):
 
 @pytest.mark.anyio
 async def test_stage_crud(tmp_path):
-    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     from app import db
     from app.models import Sport, Tournament, Stage
     from app.routers import tournaments


### PR DESCRIPTION
## Summary
- add autouse fixture configuring in-memory database and resetting DB engine between tests
- remove per-test DATABASE_URL overrides

## Testing
- `pytest` *(fails: OperationalError no such table)*

------
https://chatgpt.com/codex/tasks/task_e_68c5764c81a083238ac4588afc16dcb2