### PR TITLE
Run tests directly in CI without migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      DATABASE_URL: sqlite+aiosqlite:///./ci.db
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,11 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install pytest
-      - name: Run migrations
-        if: ${{ !startsWith(env.DATABASE_URL, 'sqlite') }}
-        run: alembic upgrade head
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}
-          DATABASE_URL: ${{ env.DATABASE_URL }}
-        run: pytest -q
+        run: DATABASE_URL=sqlite+aiosqlite:///./ci.db pytest -q


### PR DESCRIPTION
## Summary
- drop migration step from CI workflow
- run tests against SQLite using `DATABASE_URL=sqlite+aiosqlite:///./ci.db pytest -q`

## Testing
- `DATABASE_URL=sqlite+aiosqlite:///./ci.db pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c57725db888323b16a0e33aaa3a674