### PR TITLE
test: rebuild db schema after engine reset

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,13 @@
 import os
+import sys
+import asyncio
+from typing import Optional
+
 import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import db
 
 # A sufficiently long JWT secret for tests
 TEST_JWT_SECRET = "x" * 32
@@ -10,3 +18,43 @@ def jwt_secret(monkeypatch):
     """Ensure a strong JWT secret is present for all tests."""
     monkeypatch.setenv("JWT_SECRET", TEST_JWT_SECRET)
     yield
+
+
+async def _create_schema(engine) -> None:
+    """Create all database tables for the given engine."""
+
+    async with engine.begin() as conn:
+        await conn.run_sync(db.Base.metadata.create_all)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def ensure_schema(request):
+    """Rebuild database schema if the engine/session have been reset.
+
+    This fixture checks whether ``db.engine`` or ``db.AsyncSessionLocal`` have
+    been cleared or point to a different database URL. If so, it recreates the
+    engine and rebuilds the full schema. Modules that wish to keep their
+    database across tests can apply the ``@pytest.mark.preserve_db`` marker to
+    opt out of the final reset.
+    """
+
+    desired_url: Optional[str] = os.getenv("DATABASE_URL")
+    if desired_url and (
+        db.engine is None
+        or db.AsyncSessionLocal is None
+        or str(db.engine.url) != desired_url
+    ):
+        # Recreate engine/session for the desired URL and build schema
+        db.engine = None
+        db.AsyncSessionLocal = None
+        engine = db.get_engine()
+        asyncio.run(_create_schema(engine))
+
+    yield
+
+    if request.node.get_closest_marker("preserve_db"):
+        return
+
+    # Reset global engine/session so the next module starts with a clean slate
+    db.engine = None
+    db.AsyncSessionLocal = None

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -50,6 +50,7 @@ def setup_db():
                     ScoreEvent.__table__,
                 ],
             )
+            await conn.exec_driver_sql("DROP TABLE IF EXISTS match_participant")
             await conn.exec_driver_sql(
                 """
                 CREATE TABLE match_participant (


### PR DESCRIPTION
## Summary
- ensure test DB schema is rebuilt whenever `db.engine` or `AsyncSessionLocal` changes
- reset global engine/session between modules with optional `@pytest.mark.preserve_db`

## Testing
- `pytest backend/tests/test_auth_me.py::test_get_and_update_me backend/tests/test_auth.py::test_signup_login_and_protected_access -q`
- `pytest backend/tests/test_comments.py::test_comment_crud backend/tests/test_players.py::test_list_players_pagination -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57f2531908323a4c4eb092f06d798