### PR TITLE
fix: resolve lint errors in web app

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -159,7 +159,7 @@ describe("RecordPadelPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    fetchMock.mock.calls.forEach(([_, init]) => {
+    fetchMock.mock.calls.forEach(([, init]) => {
       const headers = init?.headers as Headers;
       expect(headers.get("Authorization")).toBe("Bearer tkn");
     });

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -48,15 +48,16 @@ export default function RecordPadelPage() {
         const res = await apiFetch(`/v0/players`);
         const data = (await res.json()) as { players: Player[] };
         setPlayers(data.players || []);
-      } catch (err: any) {
+      } catch (err: unknown) {
         setError("Failed to load players");
-        if (err?.status === 401) {
+        const status = (err as { status?: number }).status;
+        if (status === 401) {
           router.push("/login");
         }
       }
     }
     loadPlayers();
-  }, []);
+  }, [router]);
 
   const handleIdChange = (key: keyof IdMap, value: string) => {
     setIds((prev) => ({ ...prev, [key]: value }));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -26,8 +26,10 @@ export async function apiFetch(path: string, init?: RequestInit) {
       if (res.status === 401 && text.includes("token expired")) {
         logout();
       }
-      const err = new Error(`HTTP ${res.status}: ${text}`);
-      (err as any).status = res.status;
+      const err: Error & { status?: number } = new Error(
+        `HTTP ${res.status}: ${text}`
+      );
+      err.status = res.status;
       throw err;
     }
     return res;

--- a/apps/web/src/lib/matches.test.ts
+++ b/apps/web/src/lib/matches.test.ts
@@ -23,7 +23,7 @@ describe('enrichMatches', () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => detail })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: '1', name: 'Alice' }, { id: '2' }] });
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- remove unused variable in Padel page tests
- replace `any` with typed error handling and include router dependency
- cast mocked fetch without `any` and type error helper

## Testing
- `npm run lint`
- `npm test` *(fails: expected "spy" to be called 3 times, but got 17 times)*

------
https://chatgpt.com/codex/tasks/task_e_68c5777ce4c48323ab8f4ba1993c46d3