### PR TITLE
test: share router mock in padel tests

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -2,9 +2,8 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import RecordPadelPage from "./page";
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
-}));
+const router = { push: vi.fn() };
+vi.mock("next/navigation", () => ({ useRouter: () => router }));
 
 describe("RecordPadelPage", () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
- use a shared router mock for padel record page tests

## Testing
- `npm test`
- `npm test -- --run src/app/record/padel/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c594ae12648323ba8c858374fa16ab