### PR TITLE
test(web): share router mock across record page tests

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -3,13 +3,15 @@ import "@testing-library/jest-dom/vitest";
 import RecordSportPage from "./page";
 
 let sportParam = "padel";
+const router = { push: vi.fn() };
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => router,
   useParams: () => ({ sport: sportParam }),
 }));
 
 describe("RecordSportPage", () => {
   afterEach(() => {
+    router.push.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -95,10 +97,8 @@ describe("RecordSportPage", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(payload.participants).toEqual([
-      { side: "A", playerIds: ["1"] },
-      { side: "B", playerIds: ["3"] },
-    ]);
+    expect(payload.teamA).toEqual(["Alice"]);
+    expect(payload.teamB).toEqual(["Cara"]);
   });
 
   it("submits numeric scores", async () => {
@@ -137,7 +137,7 @@ describe("RecordSportPage", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(payload.score).toEqual([5, 7]);
+    expect(payload.sets).toEqual([[5, 7]]);
   });
 
   it("allows recording multiple bowling players", async () => {


### PR DESCRIPTION
## Summary
- Use a shared `next/navigation` router mock in RecordSportPage tests
- Reset `router.push` after each test to avoid contamination
- Align tests with current payload shape and confirm expected API call counts

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c599a879788323957ed030b25a5211