### PR TITLE
test: update payload assertions

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -95,10 +95,8 @@ describe("RecordSportPage", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(payload.participants).toEqual([
-      { side: "A", playerIds: ["1"] },
-      { side: "B", playerIds: ["3"] },
-    ]);
+    expect(payload.teamA).toEqual(["Alice"]);
+    expect(payload.teamB).toEqual(["Cara"]);
   });
 
   it("submits numeric scores", async () => {
@@ -137,7 +135,7 @@ describe("RecordSportPage", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(payload.score).toEqual([5, 7]);
+    expect(payload.sets).toEqual([[5, 7]]);
   });
 
   it("allows recording multiple bowling players", async () => {


### PR DESCRIPTION
## Summary
- adjust single-player payload assertions for teamA and teamB
- update numeric score test to expect sets array

## Testing
- `npm test src/app/record/[sport]/page.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c594ad14e08323a7c0368cd788083c