### PR TITLE
chore: preserve module mocks in RecordSportPage tests

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/navigation", () => ({
 
 describe("RecordSportPage", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("rejects duplicate player selections", async () => {


### PR DESCRIPTION
## Summary
- keep `next/navigation` mock intact across tests by clearing Vitest mocks instead of restoring them

## Testing
- `npm --prefix apps/web test -- --run 'src/app/record/[[]sport[]]/page.test.tsx'` *(fails: expected undefined to deeply equal ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5777b508c8323b58fc59ac942f723