### PR TITLE
Use clearAllMocks in record page tests

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -12,7 +12,7 @@ vi.mock("next/navigation", () => ({
 describe("RecordSportPage", () => {
   afterEach(() => {
     router.push.mockReset();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("rejects duplicate player selections", async () => {


### PR DESCRIPTION
## Summary
- Use `vi.clearAllMocks` in record page tests to reset call counts while preserving module mocks

## Testing
- `npm --prefix apps/web test -- --run 'src/app/record/[sport]/page.test.tsx'`


------
https://chatgpt.com/codex/tasks/task_e_68c6629656ec83238367d06620b58ac5