### PR TITLE
Fix padel form saving reset on validation errors

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -127,6 +127,47 @@ describe("RecordPadelPage", () => {
       ),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled(),
+    );
+  });
+
+  it("re-enables save button when duplicate players selected", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "p1", name: "A" },
+            { id: "p2", name: "B" },
+          ],
+        }),
+      });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordPadelPage />);
+
+    await waitFor(() => screen.getByLabelText("Player A1"));
+
+    fireEvent.change(screen.getByLabelText("Player A1"), {
+      target: { value: "p1" },
+    });
+    fireEvent.change(screen.getByLabelText("Player B1"), {
+      target: { value: "p1" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /please select unique players/i,
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled(),
+    );
   });
 
   it("includes auth token in API requests", async () => {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -84,6 +84,7 @@ export default function RecordPadelPage() {
     const filtered = idValues.filter((v) => v);
     if (new Set(filtered).size !== filtered.length) {
       setError("Please select unique players.");
+      setSaving(false);
       return;
     }
 
@@ -91,6 +92,7 @@ export default function RecordPadelPage() {
     const sideB = [ids.b1, ids.b2].filter(Boolean);
     if (!sideA.length || !sideB.length) {
       setError("Select at least one player for each side");
+      setSaving(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Ensure save button re-enables when padel form exits early by resetting `saving`
- Test that duplicate or missing player validation resets button state

## Testing
- `npm test` *(fails: RecordSportPage > clears partner ids when toggling back to singles; RecordSportPage > submits numeric scores)*
- `npm test -- src/app/record/padel/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5775644b88323890619c81a986fb6