### PR TITLE
fix(web): prevent player fetch loop in padel recorder

### DIFF
--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -57,7 +57,8 @@ export default function RecordPadelPage() {
       }
     }
     loadPlayers();
-  }, [router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleIdChange = (key: keyof IdMap, value: string) => {
     setIds((prev) => ({ ...prev, [key]: value }));


### PR DESCRIPTION
## Summary
- load padel players once on mount instead of on router changes

## Testing
- `npm test` *(fails: RecordSportPage tests - expected payload values undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c594bf64fc83238453def0eb9e7e27