### PR TITLE
Ensure singles toggle clears partner ids synchronously

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -92,6 +92,7 @@ describe("RecordSportPage", () => {
 
     // switch back to singles
     fireEvent.click(toggle);
+    await waitFor(() => expect(toggle).not.toBeChecked());
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useState, type FormEvent } from "react";
+import { flushSync } from "react-dom";
 import { useRouter, useParams } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 
@@ -69,10 +70,12 @@ export default function RecordSportPage() {
   };
 
   const handleToggle = (checked: boolean) => {
-    setDoubles(checked);
-    if (!checked) {
-      setIds((prev) => ({ ...prev, a2: "", b2: "" }));
-    }
+    flushSync(() => {
+      setDoubles(checked);
+      if (!checked) {
+        setIds((prev) => ({ ...prev, a2: "", b2: "" }));
+      }
+    });
   };
 
   const handleSubmit = async (e: FormEvent) => {


### PR DESCRIPTION
## Summary
- use `flushSync` to synchronously update doubles toggle and reset partner ids
- wait for toggle state to finish updating in record page test

## Testing
- `cd apps/web && npx vitest src/app/record/[sport]/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6a026bf648323bb6067e5e517cd8f