### PR TITLE
test: assert numeric sets

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -138,6 +138,8 @@ describe("RecordSportPage", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(payload.sets).toEqual([[5, 7]]);
+    expect(typeof payload.sets[0][0]).toBe("number");
+    expect(typeof payload.sets[0][1]).toBe("number");
   });
 
   it("allows recording multiple bowling players", async () => {


### PR DESCRIPTION
## Summary
- ensure `RecordSportPage` numeric scores are validated as numbers by checking `payload.sets`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c6a0268a08832381dc9a3d6f4ec127