### PR TITLE
test: update padel score assertion

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -137,7 +137,7 @@ describe("RecordSportPage", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(payload.score).toEqual([5, 7]);
+    expect(payload.sets).toEqual([[5, 7]]);
   });
 
   it("allows recording multiple bowling players", async () => {


### PR DESCRIPTION
## Summary
- update padel record test to expect `sets` payload instead of `score`

## Testing
- `npm test -- --run` *(fails: AssertionError)*
- `npx vitest run src/app/record/[sport]/page.test.tsx -t "submits numeric scores"`


------
https://chatgpt.com/codex/tasks/task_e_68c594aca16883239199dcc5e5776f9a