### PR TITLE
feat(web): send bowling scores as sets

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -182,6 +182,6 @@ describe("RecordSportPage", () => {
       { side: "B", playerIds: ["2"] },
       { side: "C", playerIds: ["3"] },
     ]);
-    expect(payload.score).toEqual([100, 120, 90]);
+    expect(payload.sets).toEqual([[100], [120], [90]]);
   });
 });

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -142,7 +142,7 @@ export default function RecordSportPage() {
         const payload = {
           sport,
           participants,
-          score: entries.map((e) => Number(e.score)),
+          sets: entries.map((e) => [Number(e.score)]),
           ...(playedAt ? { playedAt } : {}),
           ...(location ? { location } : {}),
         };


### PR DESCRIPTION
## Summary
- send bowling scores as `sets`
- update record page test to expect `payload.sets`

## Testing
- `cd apps/web && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0a651e883238722bcfc159b4967