### PR TITLE
Handle set scores when creating matches

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -119,7 +119,10 @@ async def create_match(
         )
         session.add(mp)
 
-    if body.score:
+    if body.sets:
+        totals = [sum(s) for s in body.sets]
+        match.details = {"score": {chr(65 + i): t for i, t in enumerate(totals)}}
+    elif body.score:
         match.details = {"score": {chr(65 + i): s for i, s in enumerate(body.score)}}
 
     await session.commit()
@@ -168,6 +171,7 @@ async def create_match_by_name(
         bestOf=body.bestOf,
         playedAt=body.playedAt,
         location=body.location,
+        sets=body.sets,
     )
     return await create_match(mc, session, user)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -85,6 +85,7 @@ class MatchCreate(BaseModel):
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
     score: Optional[List[int]] = None
+    sets: Optional[List[List[int]]] = None
 
     @field_validator("playedAt")
     def _normalize_played_at(cls, v: datetime | None) -> datetime | None:
@@ -103,6 +104,7 @@ class MatchCreateByName(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    sets: Optional[List[Tuple[int, int]]] = None
 
     @field_validator("playedAt")
     def _normalize_played_at(cls, v: datetime | None) -> datetime | None:

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -117,7 +117,7 @@ async def test_create_match_by_name_is_case_insensitive(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_create_match_with_scores(tmp_path):
+async def test_create_match_with_sets(tmp_path):
   os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Sport, User
@@ -140,7 +140,7 @@ async def test_create_match_with_scores(tmp_path):
             Participant(side="A", playerIds=["p1"]),
             Participant(side="B", playerIds=["p2"]),
         ],
-        score=[120, 100],
+        sets=[[120], [100]],
     )
     admin = User(id="u1", username="admin", password_hash="", is_admin=True)
     resp = await create_match(body, session, user=admin)


### PR DESCRIPTION
## Summary
- accept set arrays in match creation schemas
- persist set totals as scores and forward through by-name endpoint
- adjust tests to verify bowling match scores via sets

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b37431c88323bf3db242d9ffe604