### PR TITLE
tests: centralize in-memory database config

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,12 +12,31 @@ from app import db
 # A sufficiently long JWT secret for tests
 TEST_JWT_SECRET = "x" * 32
 os.environ.setdefault("JWT_SECRET", TEST_JWT_SECRET)
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
 @pytest.fixture(autouse=True)
 def jwt_secret(monkeypatch):
     """Ensure a strong JWT secret is present for all tests."""
     monkeypatch.setenv("JWT_SECRET", TEST_JWT_SECRET)
     yield
+
+
+@pytest.fixture(autouse=True, scope="module")
+def ensure_database():
+    """Ensure a usable test database is configured.
+
+    If ``DATABASE_URL`` is unset, default to an in-memory SQLite database and
+    reset the global engine/session so each module starts with a clean slate.
+    """
+
+    mp = pytest.MonkeyPatch()
+    if not os.getenv("DATABASE_URL"):
+        mp.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    yield
+    mp.undo()
 
 
 async def _create_schema(engine) -> None:
@@ -28,7 +47,7 @@ async def _create_schema(engine) -> None:
 
 
 @pytest.fixture(autouse=True, scope="module")
-def ensure_schema(request):
+def ensure_schema(request, ensure_database):
     """Rebuild database schema if the engine/session have been reset.
 
     This fixture checks whether ``db.engine`` or ``db.AsyncSessionLocal`` have

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -10,7 +10,6 @@ from sqlalchemy import select
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth.db"
 # Use a sufficiently long JWT secret for tests
 os.environ["JWT_SECRET"] = "x" * 32
 os.environ["ADMIN_SECRET"] = "admintest"

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -23,7 +23,6 @@ app.include_router(auth.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_auth_me.db"
         if os.path.exists("./test_auth_me.db"):
             os.remove("./test_auth_me.db")
         db.engine = None

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -37,7 +37,6 @@ app.include_router(players.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_comments.db"
         if os.path.exists("./test_comments.db"):
             os.remove("./test_comments.db")
         db.engine = None

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -12,7 +12,6 @@ from sqlalchemy.dialects.sqlite import JSON
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Configure database for tests
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_leaderboards.db"
 
 from app import db  # noqa: E402
 from app.models import (

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -17,7 +17,6 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Player, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -48,7 +47,6 @@ async def test_create_match_by_name_rejects_duplicate_players(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_rejects_duplicate_players(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Sport, User
   from app.schemas import MatchCreate, Participant
@@ -80,7 +78,6 @@ async def test_create_match_rejects_duplicate_players(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_by_name_is_case_insensitive(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Player, Sport, Match, MatchParticipant, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -118,7 +115,6 @@ async def test_create_match_by_name_is_case_insensitive(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_with_sets(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Sport, User
   from app.schemas import MatchCreate, Participant
@@ -150,7 +146,6 @@ async def test_create_match_with_sets(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_by_name_with_sets(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Player, Sport, User
   from app.schemas import MatchCreateByName, ParticipantByName
@@ -188,7 +183,6 @@ async def test_create_match_by_name_with_sets(tmp_path):
 
 @pytest.mark.anyio
 async def test_create_match_normalizes_timezone(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -238,7 +232,6 @@ async def test_create_match_normalizes_timezone(tmp_path):
 
 @pytest.mark.anyio
 async def test_list_matches_returns_most_recent_first(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -281,7 +274,6 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
 
 @pytest.mark.anyio
 async def test_list_matches_upcoming_filter(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -319,7 +311,6 @@ async def test_list_matches_upcoming_filter(tmp_path):
 
 @pytest.mark.skip(reason="SQLite lacks ARRAY support for MatchParticipant")
 def test_list_matches_filters_by_player(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -390,7 +381,6 @@ def test_list_matches_filters_by_player(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -471,7 +461,6 @@ async def test_delete_match_requires_secret_and_marks_deleted(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_missing_returns_404(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   os.environ["ADMIN_SECRET"] = "admintest"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
@@ -511,8 +500,6 @@ async def test_delete_match_missing_returns_404(tmp_path):
 
 @pytest.mark.anyio
 async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
-  prev_db = os.environ.get("DATABASE_URL")
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from sqlalchemy.dialects.sqlite import JSON
   from app import db
   from app.models import (
@@ -616,15 +603,9 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
     assert ratings["p1"] == pytest.approx(1000.0)
     assert ratings["p2"] > ratings["p1"] > ratings["p3"]
 
-  if prev_db is None:
-    del os.environ["DATABASE_URL"]
-  else:
-    os.environ["DATABASE_URL"] = prev_db
-
 
 @pytest.mark.anyio
 async def test_create_match_preserves_naive_date(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from fastapi import FastAPI
   from fastapi.testclient import TestClient
   from app import db
@@ -668,7 +649,6 @@ async def test_create_match_preserves_naive_date(tmp_path):
 
 @pytest.mark.anyio
 async def test_user_with_multiple_player_records_can_modify_match(tmp_path):
-  os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
   from app import db
   from app.models import Match, MatchParticipant, Player, ScoreEvent, User
   from app.schemas import EventIn

--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_player_profile_metrics.py
+++ b/backend/tests/test_player_profile_metrics.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -3,7 +3,6 @@ from typing import Tuple
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -43,7 +43,6 @@ app.include_router(badges.router)
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
     async def init_models():
-        os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_players.db"
         if os.path.exists("./test_players.db"):
             os.remove("./test_players.db")
         db.engine = None

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -4,7 +4,6 @@ from typing import Tuple
 # Ensure the app package is importable and the DB URL is set for module import
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 
 import pytest
 from fastapi import FastAPI

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -16,7 +16,6 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_tournament_crud(tmp_path):
-    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     from app import db
     from app.models import Sport, Tournament, Stage
     from app.routers import tournaments
@@ -52,7 +51,6 @@ async def test_tournament_crud(tmp_path):
 
 @pytest.mark.anyio
 async def test_stage_crud(tmp_path):
-    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     from app import db
     from app.models import Sport, Tournament, Stage
     from app.routers import tournaments


### PR DESCRIPTION
## Summary
- add session-wide DB fixture to reset engine and default to in-memory SQLite
- drop per-test `DATABASE_URL` environment setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c9d48d248323adc2be2f80ec9628