### PR TITLE
chore: isolate fetch mocks in record page tests

### DIFF
--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -6,9 +6,17 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams("mid=m1"),
 }));
 
+const originalFetch = global.fetch;
+
 describe("RecordDiscGolfPage", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (global as any).fetch;
+    }
   });
 
   it("posts hole events", async () => {

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -5,9 +5,17 @@ import RecordPadelPage from "./page";
 const router = { push: vi.fn() };
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
 
+const originalFetch = global.fetch;
+
 describe("RecordPadelPage", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (global as any).fetch;
+    }
     window.localStorage.clear();
   });
 


### PR DESCRIPTION
## Summary
- replace `vi.restoreAllMocks` with `vi.clearAllMocks` in disc golf and padel record page tests
- restore the original `fetch` after each test to avoid cross-test leakage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c782711c2c83238f275059ff0163e1