### PR TITLE
Handle padel record validation without locking Save

### DIFF
--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -84,6 +84,7 @@ export default function RecordPadelPage() {
     const filtered = idValues.filter((v) => v);
     if (new Set(filtered).size !== filtered.length) {
       setError("Please select unique players.");
+      setSaving(false);
       return;
     }
 
@@ -91,6 +92,7 @@ export default function RecordPadelPage() {
     const sideB = [ids.b1, ids.b2].filter(Boolean);
     if (!sideA.length || !sideB.length) {
       setError("Select at least one player for each side");
+      setSaving(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Re-enable the Save button when padel match submission fails validation
- Test padel record form resubmission after empty sides or duplicate players

## Testing
- `npx vitest run src/app/record/padel/page.test.tsx`
- `npm test -- --run` *(fails: RecordSportPage > clears partner ids when toggling back to singles; RecordSportPage > submits numeric scores)*

------
https://chatgpt.com/codex/tasks/task_e_68c57792a540832399562fa59c8f2a37