### PR TITLE
fix(web): add react-dom types for build

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/react": "^16.3.0",
         "@types/node": "20.11.30",
         "@types/react": "18.3.3",
+        "@types/react-dom": "18.3.3",
         "@typescript-eslint/eslint-plugin": "8.42.0",
         "@typescript-eslint/parser": "8.42.0",
         "eslint": "^8.57.1",
@@ -1421,6 +1422,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.3.tgz",
+      "integrity": "sha512-uTYkxTLkYp41nq/ULXyXMtkNT1vu5fXJoqad6uTNCOGat5t9cLgF4vMNLBXsTOXpdOI44XzKPY1M5RRm0bQHuw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.3",
     "@typescript-eslint/eslint-plugin": "8.42.0",
     "@typescript-eslint/parser": "8.42.0",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- add `@types/react-dom` so Next.js can resolve React DOM typings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7a277cd5483239f0be33ee40b54bc