### PR TITLE
Fix player IDs migration revision

### DIFF
--- a/backend/alembic/versions/0006_convert_player_ids_to_json.py
+++ b/backend/alembic/versions/0006_convert_player_ids_to_json.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision = '0006_convert_player_ids_to_json'
-down_revision = '0009_comments'
+down_revision = '0005_add_player_columns'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0006_convert_player_ids_to_json.py
+++ b/backend/alembic/versions/0006_convert_player_ids_to_json.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = '0010_convert_player_ids_to_json'
+revision = '0006_convert_player_ids_to_json'
 down_revision = '0009_comments'
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/0010_convert_player_ids_to_json.py
+++ b/backend/alembic/versions/0010_convert_player_ids_to_json.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = '0006_convert_player_ids_to_json'
+revision = '0010_convert_player_ids_to_json'
 down_revision = '0005_add_player_columns'
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/0011_rehash_sha256_passwords.py
+++ b/backend/alembic/versions/0011_rehash_sha256_passwords.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 import re
 
 revision = '0011_rehash_sha256_passwords'
-down_revision = '0006_convert_player_ids_to_json'
+down_revision = ('0006_convert_player_ids_to_json', '0008_users')
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0011_rehash_sha256_passwords.py
+++ b/backend/alembic/versions/0011_rehash_sha256_passwords.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 import re
 
 revision = '0011_rehash_sha256_passwords'
-down_revision = '0010_convert_player_ids_to_json'
+down_revision = '0006_convert_player_ids_to_json'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0011_rehash_sha256_passwords.py
+++ b/backend/alembic/versions/0011_rehash_sha256_passwords.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 import re
 
 revision = '0011_rehash_sha256_passwords'
-down_revision = ('0006_convert_player_ids_to_json', '0008_users')
+down_revision = ('0010_convert_player_ids_to_json', '0008_users')
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- rename `convert_player_ids_to_json` migration to expected revision `0006`
- update dependent migration to use new revision

## Testing
- `DATABASE_URL=postgresql://root:root@localhost/testdb alembic upgrade heads` *(fails: relation "refresh_token" already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d011cdbc8323a54735e440240947