### PR TITLE
Fix migration revision mismatch for player_ids conversion

### DIFF
--- a/backend/alembic/versions/0006_convert_player_ids_to_json.py
+++ b/backend/alembic/versions/0006_convert_player_ids_to_json.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = '0010_convert_player_ids_to_json'
+revision = '0006_convert_player_ids_to_json'
 down_revision = '0005_add_player_columns'
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/0011_rehash_sha256_passwords.py
+++ b/backend/alembic/versions/0011_rehash_sha256_passwords.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 import re
 
 revision = '0011_rehash_sha256_passwords'
-down_revision = ('0010_convert_player_ids_to_json', '0008_users')
+down_revision = ('0006_convert_player_ids_to_json', '0008_users')
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Add missing Alembic revision `0006_convert_player_ids_to_json` and update merge dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7d952ada483239f5db023f3c3a7b2