### PR TITLE
Fix missing Alembic revision reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Runtime: Python 3.12, Node 20, Postgres 16
 
 IDs & pagination: ULID strings, cursor-based pagination
 
-Auth: Credentials (username/password) for $0 email costs; magic-link later. JWT tokens require a high-entropy `JWT_SECRET` env var. Only bcrypt password hashes are supported; run migration `0011_rehash_sha256_passwords` and reset any flagged accounts before upgrading.
+Auth: Credentials (username/password) for $0 email costs; magic-link later. JWT tokens require a high-entropy `JWT_SECRET` env var. Only bcrypt password hashes are supported; run migration `0007_rehash_sha256_passwords` and reset any flagged accounts before upgrading.
 
 Multi-tenancy: Club-scoped (club_id on entities)
 

--- a/backend/alembic/versions/0007_rehash_sha256_passwords.py
+++ b/backend/alembic/versions/0007_rehash_sha256_passwords.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 import re
 
-revision = '0011_rehash_sha256_passwords'
+revision = '0007_rehash_sha256_passwords'
 down_revision = ('0006_convert_player_ids_to_json', '0008_users')
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/0008_player_metric.py
+++ b/backend/alembic/versions/0008_player_metric.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0008_player_metric'
-down_revision = '0011_rehash_sha256_passwords'
+down_revision = '0007_rehash_sha256_passwords'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0012_refresh_token_table.py
+++ b/backend/alembic/versions/0012_refresh_token_table.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0012_refresh_token_table'
-down_revision = '0011_rehash_sha256_passwords'
+down_revision = '0007_rehash_sha256_passwords'
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0012_refresh_tokens.py
+++ b/backend/alembic/versions/0012_refresh_tokens.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0012_refresh_tokens'
-down_revision = '0011_rehash_sha256_passwords'
+down_revision = '0007_rehash_sha256_passwords'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- add missing `0007_rehash_sha256_passwords` migration and update dependent revisions
- point documentation to the correct migration identifier

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68c7dcb9ff1083239a9dbaa4bec28d73