### PR TITLE
Fix set recording payload parsing

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -409,6 +409,7 @@ async def record_sets_endpoint(
             else:
                 normalized_sets.append({"A": getattr(s, "A", None), "B": getattr(s, "B", None)})
         validate_set_scores(normalized_sets)
+        set_tuples = [(int(s["A"]), int(s["B"])) for s in normalized_sets]
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
@@ -422,7 +423,7 @@ async def record_sets_endpoint(
     for old in existing:
         state = engine.apply(old.payload, state)
 
-    new_events, state = engine.record_sets(body.sets, state)
+    new_events, state = engine.record_sets(set_tuples, state)
 
     for ev in new_events:
         e = ScoreEvent(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -112,8 +112,24 @@ class MatchCreateByName(BaseModel):
             return v.astimezone(timezone.utc).replace(tzinfo=None)
         return v
 
+class SetScore(BaseModel):
+    A: int
+    B: int
+
+    @model_validator(mode="before")
+    def _coerce(cls, value: Any) -> Dict[str, int]:
+        """Allow incoming set scores to be provided as tuples or objects."""
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            return {"A": value[0], "B": value[1]}
+        if hasattr(value, "A") or hasattr(value, "B"):
+            return {"A": getattr(value, "A", None), "B": getattr(value, "B", None)}
+        raise TypeError("Set scores must be a mapping or 2-item tuple/list.")
+
+
 class SetsIn(BaseModel):
-    sets: List[Tuple[int, int]]
+    sets: List[SetScore]
 
 class EventIn(BaseModel):
     type: Literal["POINT", "ROLL", "UNDO", "HOLE"]


### PR DESCRIPTION
## Summary
- accept incoming set scores as mapping or tuple when recording sets
- normalize validated scores before handing them to the scoring engines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c926ffb4988323b897ff8d4115ebbb