### PR TITLE
Add seeded padel test players for recording matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 alembic upgrade head
-python seed.py  # adds default sports, rulesets, demo club/player
+python seed.py  # adds default sports, rulesets, demo club & test players
 
 ### Web
 cd ../apps/web

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -91,6 +91,36 @@ async def main():
         }
         players = [
             Player(id="demo-player", name="demo player", club_id="demo-club"),
+            Player(
+                id="padel-alex-ruiz",
+                name="Alex Ruiz",
+                club_id="demo-club",
+            ),
+            Player(
+                id="padel-bella-fernandez",
+                name="Bella Fernandez",
+                club_id="demo-club",
+            ),
+            Player(
+                id="padel-carlos-mendez",
+                name="Carlos Mendez",
+                club_id="demo-club",
+            ),
+            Player(
+                id="padel-diana-soto",
+                name="Diana Soto",
+                club_id="demo-club",
+            ),
+            Player(
+                id="padel-eli-vasquez",
+                name="Eli Vasquez",
+                club_id="demo-club",
+            ),
+            Player(
+                id="padel-fiona-castro",
+                name="Fiona Castro",
+                club_id="demo-club",
+            ),
         ]
         for p in players:
             if p.id not in existing_players:


### PR DESCRIPTION
## Summary
- add additional padel-focused demo players to the database seed script so matches can be recorded in the UI
- document that the seed script now provisions test players alongside the default demo club

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9249c7b548323ac7dd3a1093fc103