### PR TITLE
Handle missing player_metric table

### DIFF
--- a/backend/app/db_errors.py
+++ b/backend/app/db_errors.py
@@ -1,0 +1,25 @@
+"""Helpers for working with database/SQLAlchemy errors."""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import SQLAlchemyError
+
+_MISSING_TABLE_SQLSTATES = {"42P01"}
+
+
+def is_missing_table_error(exc: SQLAlchemyError, table_name: str) -> bool:
+    """Return ``True`` if ``exc`` indicates that ``table_name`` is missing."""
+
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+
+    sqlstate = getattr(orig, "sqlstate", None)
+    if sqlstate in _MISSING_TABLE_SQLSTATES:
+        return True
+
+    message = str(orig).lower()
+    if table_name.lower() not in message:
+        return False
+
+    return "no such table" in message or "does not exist" in message

--- a/backend/tests/test_player_metrics_table_missing.py
+++ b/backend/tests/test_player_metrics_table_missing.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import uuid
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import db
+from app.models import Player, PlayerMetric
+from app.routers import players
+from app.services.metrics import update_player_metrics
+
+app = FastAPI()
+app.include_router(players.router)
+
+
+async def _drop_player_metric_table() -> None:
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: PlayerMetric.__table__.drop(
+                sync_conn, checkfirst=True
+            )
+        )
+
+
+async def _create_player_metric_table() -> None:
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: PlayerMetric.__table__.create(
+                sync_conn, checkfirst=True
+            )
+        )
+
+
+def test_update_player_metrics_handles_missing_table() -> None:
+    asyncio.run(_drop_player_metric_table())
+    try:
+        async def run_update() -> None:
+            async with db.AsyncSessionLocal() as session:
+                await update_player_metrics(
+                    session,
+                    sport_id="padel",
+                    winners=["winner"],
+                    losers=["loser"],
+                )
+
+        asyncio.run(run_update())
+    finally:
+        asyncio.run(_create_player_metric_table())
+
+
+def test_get_player_handles_missing_metrics_table() -> None:
+    player_id = uuid.uuid4().hex
+    player_name = f"player-{player_id}"
+
+    async def insert_player() -> None:
+        async with db.AsyncSessionLocal() as session:
+            session.add(Player(id=player_id, name=player_name))
+            await session.commit()
+
+    asyncio.run(insert_player())
+    asyncio.run(_drop_player_metric_table())
+
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get(f"/players/{player_id}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["id"] == player_id
+            assert body["name"] == player_name
+            assert body["metrics"] is None
+            assert body["milestones"] is None
+    finally:
+        asyncio.run(_create_player_metric_table())


### PR DESCRIPTION
## Summary
- add a shared helper to detect missing database tables
- guard player metric updates and retrievals so requests succeed even if the player_metric table has not been created yet
- add regression tests that simulate a missing player_metric table to verify the new safeguards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92e38f6d8832385ec4e8198cb53c8