### PR TITLE
Add structured player location fields

### DIFF
--- a/backend/alembic/versions/0016_structured_player_location.py
+++ b/backend/alembic/versions/0016_structured_player_location.py
@@ -1,0 +1,56 @@
+"""add structured location fields to player"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.location_utils import normalize_location_fields
+
+revision = "0016_structured_player_location"
+down_revision = "0015_case_insensitive_player_name"
+branch_labels = None
+depends_on = None
+
+player_table = sa.table(
+    "player",
+    sa.column("id", sa.String()),
+    sa.column("location", sa.String()),
+    sa.column("country_code", sa.String(length=2)),
+    sa.column("region_code", sa.String(length=3)),
+)
+
+
+def upgrade() -> None:
+    op.add_column("player", sa.Column("country_code", sa.String(length=2), nullable=True))
+    op.add_column("player", sa.Column("region_code", sa.String(length=3), nullable=True))
+
+    connection = op.get_bind()
+    results = connection.execute(
+        sa.select(player_table.c.id, player_table.c.location)
+    ).all()
+
+    for player_id, location in results:
+        normalized_location, country_code, region_code = normalize_location_fields(
+            location, None, None
+        )
+        if (
+            normalized_location == location
+            and country_code is None
+            and region_code is None
+        ):
+            continue
+        values = {
+            "country_code": country_code,
+            "region_code": region_code,
+        }
+        if normalized_location != location:
+            values["location"] = normalized_location
+        connection.execute(
+            player_table.update()
+            .where(player_table.c.id == player_id)
+            .values(**values)
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("player", "region_code")
+    op.drop_column("player", "country_code")

--- a/backend/app/location_utils.py
+++ b/backend/app/location_utils.py
@@ -1,0 +1,151 @@
+"""Helpers for normalizing structured location fields."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
+REGION_CODE_RE = re.compile(r"^[A-Z0-9]{1,3}$")
+STRUCTURED_LOCATION_RE = re.compile(
+    r"^(?P<country>[A-Z]{2})(?:[-_/:](?P<region>[A-Z0-9]{1,3}))?$"
+)
+
+
+def normalize_country_code(
+    value: Optional[str], *, raise_on_invalid: bool = False
+) -> Optional[str]:
+    """Normalize a country code to uppercase ISO-3166 alpha-2."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        if raise_on_invalid:
+            raise ValueError("country_code must be a string")
+        return None
+    normalized = value.strip().upper()
+    if not normalized:
+        return None
+    if COUNTRY_CODE_RE.fullmatch(normalized):
+        return normalized
+    if raise_on_invalid:
+        raise ValueError("country_code must be a 2-letter ISO-3166 alpha-2 code")
+    return None
+
+
+def _strip_region_prefix(raw: str) -> str:
+    for sep in ("-", "_", "/", ":"):
+        if sep in raw:
+            prefix, remainder = raw.split(sep, 1)
+            if COUNTRY_CODE_RE.fullmatch(prefix):
+                return remainder
+    return raw
+
+
+def normalize_region_code(
+    value: Optional[str],
+    *,
+    country_code: Optional[str] = None,
+    raise_on_invalid: bool = False,
+) -> Optional[str]:
+    """Normalize a region/subdivision code to uppercase alphanumeric."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        if raise_on_invalid:
+            raise ValueError("region_code must be a string")
+        return None
+    normalized = value.strip().upper()
+    if not normalized:
+        return None
+    if country_code:
+        prefix = f"{country_code}-"
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+    normalized = _strip_region_prefix(normalized)
+    if REGION_CODE_RE.fullmatch(normalized):
+        return normalized
+    if raise_on_invalid:
+        raise ValueError("region_code must be 1-3 alphanumeric characters")
+    return None
+
+
+def parse_location_string(location: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Parse a structured location string into country/region codes."""
+    if location is None or not isinstance(location, str):
+        return None, None
+    trimmed = location.strip()
+    if not trimmed:
+        return None, None
+    match = STRUCTURED_LOCATION_RE.fullmatch(trimmed.upper())
+    if match:
+        return match.group("country"), match.group("region")
+    return None, None
+
+
+def compose_location_string(
+    country_code: Optional[str], region_code: Optional[str]
+) -> Optional[str]:
+    """Compose a structured location string from normalized codes."""
+    if not country_code:
+        return None
+    if region_code:
+        return f"{country_code}-{region_code}"
+    return country_code
+
+
+def normalize_location_string(location: Optional[str]) -> Optional[str]:
+    if location is None or not isinstance(location, str):
+        return None
+    trimmed = location.strip()
+    return trimmed or None
+
+
+def normalize_location_fields(
+    location: Optional[str],
+    country_code: Optional[str],
+    region_code: Optional[str],
+    *,
+    raise_on_invalid: bool = False,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Normalize a trio of location fields and keep them in sync."""
+    normalized_location = normalize_location_string(location)
+    normalized_country = normalize_country_code(
+        country_code, raise_on_invalid=raise_on_invalid
+    )
+    normalized_region = normalize_region_code(
+        region_code,
+        country_code=normalized_country,
+        raise_on_invalid=raise_on_invalid,
+    )
+
+    if normalized_location:
+        loc_country, loc_region = parse_location_string(normalized_location)
+        if loc_country:
+            if normalized_country is None:
+                normalized_country = loc_country
+            if normalized_region is None:
+                normalized_region = loc_region
+            normalized_location = compose_location_string(
+                normalized_country,
+                normalized_region if normalized_region is not None else loc_region,
+            )
+
+    if not normalized_location and normalized_country:
+        normalized_location = compose_location_string(
+            normalized_country, normalized_region
+        )
+
+    if raise_on_invalid and normalized_region and not normalized_country:
+        raise ValueError("region_code requires country_code")
+
+    return normalized_location, normalized_country, normalized_region
+
+
+__all__ = [
+    "compose_location_string",
+    "normalize_country_code",
+    "normalize_location_fields",
+    "normalize_location_string",
+    "normalize_region_code",
+    "parse_location_string",
+]

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,6 +40,8 @@ class Player(Base):
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
     photo_url = Column(String, nullable=True)
     location = Column(String, nullable=True)
+    country_code = Column(String(2), nullable=True)
+    region_code = Column(String(3), nullable=True)
     ranking = Column(Integer, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -74,6 +74,8 @@ async def create_player(
         club_id=body.club_id,
         photo_url=body.photo_url,
         location=body.location,
+        country_code=body.country_code,
+        region_code=body.region_code,
         ranking=body.ranking,
     )
     session.add(p)
@@ -84,6 +86,8 @@ async def create_player(
         club_id=p.club_id,
         photo_url=p.photo_url,
         location=p.location,
+        country_code=p.country_code,
+        region_code=p.region_code,
         ranking=p.ranking,
         badges=[],
     )
@@ -112,6 +116,8 @@ async def list_players(
             club_id=p.club_id,
             photo_url=p.photo_url,
             location=p.location,
+            country_code=p.country_code,
+            region_code=p.region_code,
             ranking=p.ranking,
             badges=[],
         )
@@ -165,6 +171,8 @@ async def get_player(player_id: str, session: AsyncSession = Depends(get_session
         club_id=p.club_id,
         photo_url=p.photo_url,
         location=p.location,
+        country_code=p.country_code,
+        region_code=p.region_code,
         ranking=p.ranking,
         metrics=metrics or None,
         milestones=milestones or None,

--- a/backend/app/routes/player.py
+++ b/backend/app/routes/player.py
@@ -31,6 +31,8 @@ async def player_profile(
         club_id=player.club_id,
         photo_url=player.photo_url,
         location=player.location,
+        country_code=player.country_code,
+        region_code=player.region_code,
         ranking=player.ranking,
     )
     return templates.TemplateResponse(


### PR DESCRIPTION
## Summary
- add `country_code`/`region_code` columns to players with shared normalization utilities
- update player schemas and API handlers to accept structured location data while retaining the legacy `location` value
- add an Alembic migration that backfills existing players and normalizes stored location strings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbddd9706c8323855a40e99bd289c0