### PR TITLE
feat: add leaderboard regional filters

### DIFF
--- a/apps/web/src/app/leaderboard/[sport]/page.tsx
+++ b/apps/web/src/app/leaderboard/[sport]/page.tsx
@@ -1,5 +1,21 @@
 import Leaderboard from "../leaderboard";
 
-export default function LeaderboardSportPage({ params }: { params: { sport: string } }) {
-  return <Leaderboard sport={params.sport} />;
+type LeaderboardSearchParams = {
+  country?: string | string[];
+  clubId?: string | string[];
+};
+
+const toSingleValue = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value;
+
+export default function LeaderboardSportPage({
+  params,
+  searchParams,
+}: {
+  params: { sport: string };
+  searchParams?: LeaderboardSearchParams;
+}) {
+  const country = toSingleValue(searchParams?.country);
+  const clubId = toSingleValue(searchParams?.clubId);
+  return <Leaderboard sport={params.sport} country={country} clubId={clubId} />;
 }

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -2,13 +2,30 @@ import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import Leaderboard from "./leaderboard";
 
+const replaceMock = vi.fn();
+let mockPathname = "/leaderboard";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  usePathname: () => mockPathname,
+}));
+
 describe("Leaderboard", () => {
+  beforeEach(() => {
+    mockPathname = "/leaderboard";
+    replaceMock.mockReset();
+  });
+
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    // @ts-expect-error - cleanup mocked fetch between tests
+    global.fetch = undefined;
   });
 
   it("fetches disc_golf when showing all sports", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
 
     render(<Leaderboard sport="all" />);
@@ -16,5 +33,50 @@ describe("Leaderboard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain("/api/v0/leaderboards?sport=disc_golf");
+  });
+
+  it("includes the country filter when provided", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+    mockPathname = "/leaderboard/padel";
+
+    render(<Leaderboard sport="padel" country="SE" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v0/leaderboards?sport=padel&country=SE"
+    );
+  });
+
+  it("includes the club filter when provided", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+    mockPathname = "/leaderboard/padel";
+
+    render(<Leaderboard sport="padel" clubId="club-a" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v0/leaderboards?sport=padel&clubId=club-a"
+    );
+  });
+
+  it("passes region filters to each sport when viewing the combined board", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="all" country="SE" clubId="club-a" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain(
+      "/api/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a"
+    );
   });
 });

--- a/apps/web/src/app/leaderboard/master/page.tsx
+++ b/apps/web/src/app/leaderboard/master/page.tsx
@@ -1,6 +1,20 @@
 import Leaderboard from "../leaderboard";
 
-export default function MasterLeaderboardPage() {
-  return <Leaderboard sport="master" />;
+type LeaderboardSearchParams = {
+  country?: string | string[];
+  clubId?: string | string[];
+};
+
+const toSingleValue = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value;
+
+export default function MasterLeaderboardPage({
+  searchParams,
+}: {
+  searchParams?: LeaderboardSearchParams;
+}) {
+  const country = toSingleValue(searchParams?.country);
+  const clubId = toSingleValue(searchParams?.clubId);
+  return <Leaderboard sport="master" country={country} clubId={clubId} />;
 }
 

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,5 +1,19 @@
 import Leaderboard from "./leaderboard";
 
-export default function LeaderboardIndexPage() {
-  return <Leaderboard sport="all" />;
+type LeaderboardSearchParams = {
+  country?: string | string[];
+  clubId?: string | string[];
+};
+
+const toSingleValue = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value;
+
+export default function LeaderboardIndexPage({
+  searchParams,
+}: {
+  searchParams?: LeaderboardSearchParams;
+}) {
+  const country = toSingleValue(searchParams?.country);
+  const clubId = toSingleValue(searchParams?.clubId);
+  return <Leaderboard sport="all" country={country} clubId={clubId} />;
 }


### PR DESCRIPTION
## Summary
- add UI and request plumbing in the leaderboard client to apply optional country/club filters and surface the active region
- update leaderboard routes to pass through search params so selections persist between pages
- extend leaderboard tests to cover the new filters and API URLs

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cbf4daca748323a325ca5a504a8dc3