### PR TITLE
Harden structured player location migration and add admin tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,30 @@ POST /api/v0/matches
   "location": "Local Club"
 }
 
+### Player location data hygiene
+
+The legacy `player.location` column accepts arbitrary free-form text. To assess
+the existing values before running the structured location migration, use the
+helper script to dump the distinct strings and their frequencies:
+
+```bash
+DATABASE_URL=postgresql://... \
+  python backend/scripts/survey_player_locations.py
+```
+
+After the migration, an administrator can backfill or correct individual rows
+with normalized ISO country codes and optional subdivision codes using:
+
+```bash
+DATABASE_URL=postgresql://... \
+  python backend/scripts/set_player_location.py <player-id> \
+    --country-code US --region-code CA --location "US-CA"
+```
+
+Run with `--dry-run` to preview the changes before committing them. Leaving a
+flag empty (for example `--region-code ''`) clears that field while keeping the
+three columns synchronized via the shared normalization helpers.
+
 Append events
 
 POST /api/v0/matches/m_123/events

--- a/backend/alembic/versions/0016_structured_player_location.py
+++ b/backend/alembic/versions/0016_structured_player_location.py
@@ -38,12 +38,15 @@ def upgrade() -> None:
             and region_code is None
         ):
             continue
-        values = {
-            "country_code": country_code,
-            "region_code": region_code,
-        }
+        values = {}
         if normalized_location != location:
             values["location"] = normalized_location
+        if country_code is not None:
+            values["country_code"] = country_code
+        if region_code is not None:
+            values["region_code"] = region_code
+        if not values:
+            continue
         connection.execute(
             player_table.update()
             .where(player_table.c.id == player_id)

--- a/backend/app/location_data.py
+++ b/backend/app/location_data.py
@@ -1,0 +1,26 @@
+"""Static datasets for location normalization."""
+
+ISO3166_ALPHA2_CODES = {
+    "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU",
+    "AW", "AX", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL",
+    "BM", "BN", "BO", "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CC",
+    "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CR", "CU", "CV",
+    "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG",
+    "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR", "GA", "GB", "GD",
+    "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT",
+    "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM",
+    "IN", "IO", "IQ", "IR", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH",
+    "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK",
+    "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH",
+    "MK", "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW",
+    "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR",
+    "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM", "PN", "PR",
+    "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC",
+    "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS",
+    "ST", "SV", "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL",
+    "TM", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY",
+    "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU", "WF", "WS", "YE", "YT", "ZA",
+    "ZM", "ZW",
+}
+
+__all__ = ["ISO3166_ALPHA2_CODES"]

--- a/backend/app/location_utils.py
+++ b/backend/app/location_utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Optional, Tuple
 
+from .location_data import ISO3166_ALPHA2_CODES
+
 COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
 REGION_CODE_RE = re.compile(r"^[A-Z0-9]{1,3}$")
 STRUCTURED_LOCATION_RE = re.compile(
@@ -25,10 +27,10 @@ def normalize_country_code(
     normalized = value.strip().upper()
     if not normalized:
         return None
-    if COUNTRY_CODE_RE.fullmatch(normalized):
+    if COUNTRY_CODE_RE.fullmatch(normalized) and normalized in ISO3166_ALPHA2_CODES:
         return normalized
     if raise_on_invalid:
-        raise ValueError("country_code must be a 2-letter ISO-3166 alpha-2 code")
+        raise ValueError("country_code must be a valid ISO-3166 alpha-2 code")
     return None
 
 
@@ -120,7 +122,7 @@ def normalize_location_fields(
 
     if normalized_location:
         loc_country, loc_region = parse_location_string(normalized_location)
-        if loc_country:
+        if loc_country and loc_country in ISO3166_ALPHA2_CODES:
             if normalized_country is None:
                 normalized_country = loc_country
             if normalized_region is None:
@@ -129,6 +131,9 @@ def normalize_location_fields(
                 normalized_country,
                 normalized_region if normalized_region is not None else loc_region,
             )
+        else:
+            loc_country = None
+            loc_region = None
 
     if not normalized_location and normalized_country:
         normalized_location = compose_location_string(

--- a/backend/scripts/set_player_location.py
+++ b/backend/scripts/set_player_location.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Admin helper to update structured player location fields."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.location_utils import normalize_location_fields
+
+
+@dataclass
+class PlayerLocation:
+    id: str
+    name: str
+    location: Optional[str]
+    country_code: Optional[str]
+    region_code: Optional[str]
+
+    @classmethod
+    def from_row(cls, row: Any) -> "PlayerLocation":
+        return cls(
+            id=row.id,
+            name=row.name,
+            location=row.location,
+            country_code=row.country_code,
+            region_code=row.region_code,
+        )
+
+
+async def _get_engine() -> AsyncEngine:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+    return create_async_engine(database_url, echo=False, pool_pre_ping=True)
+
+
+async def _load_player(session: AsyncSession, player_id: str) -> PlayerLocation:
+    result = await session.execute(
+        text(
+            """
+            SELECT id, name, location, country_code, region_code
+            FROM player
+            WHERE id = :player_id
+            """
+        ),
+        {"player_id": player_id},
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise RuntimeError(f"Player '{player_id}' not found")
+    return PlayerLocation.from_row(row)
+
+
+def _normalize_inputs(
+    existing: PlayerLocation,
+    *,
+    location: Optional[str],
+    country_code: Optional[str],
+    region_code: Optional[str],
+) -> PlayerLocation:
+    target_location = existing.location if location is None else location
+    target_country = existing.country_code if country_code is None else country_code
+    target_region = existing.region_code if region_code is None else region_code
+
+    normalized_location, normalized_country, normalized_region = normalize_location_fields(
+        target_location,
+        target_country,
+        target_region,
+        raise_on_invalid=True,
+    )
+
+    return PlayerLocation(
+        id=existing.id,
+        name=existing.name,
+        location=normalized_location,
+        country_code=normalized_country,
+        region_code=normalized_region,
+    )
+
+
+def _detect_changes(
+    before: PlayerLocation, after: PlayerLocation
+) -> Dict[str, Optional[str]]:
+    updates: Dict[str, Optional[str]] = {}
+    if before.location != after.location:
+        updates["location"] = after.location
+    if before.country_code != after.country_code:
+        updates["country_code"] = after.country_code
+    if before.region_code != after.region_code:
+        updates["region_code"] = after.region_code
+    return updates
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Update the structured location fields for a player while keeping the "
+            "free-form location string in sync."
+        )
+    )
+    parser.add_argument("player_id", help="Identifier of the player to update")
+    parser.add_argument(
+        "--location",
+        help="Free-form location text. Provide an empty string to clear the value.",
+    )
+    parser.add_argument(
+        "--country-code",
+        help="ISO-3166 alpha-2 country code. Provide an empty string to clear the value.",
+    )
+    parser.add_argument(
+        "--region-code",
+        help="Optional region/subdivision code. Provide an empty string to clear the value.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the proposed changes without writing them to the database.",
+    )
+
+    args = parser.parse_args()
+
+    if (
+        args.location is None
+        and args.country_code is None
+        and args.region_code is None
+    ):
+        parser.error("At least one of --location, --country-code, or --region-code is required")
+
+    engine = await _get_engine()
+    Session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        async with Session() as session:
+            before = await _load_player(session, args.player_id)
+            after = _normalize_inputs(
+                before,
+                location=args.location,
+                country_code=args.country_code,
+                region_code=args.region_code,
+            )
+            updates = _detect_changes(before, after)
+
+            print("Before:")
+            print(json.dumps(asdict(before), indent=2, sort_keys=True))
+            print("After:")
+            print(json.dumps(asdict(after), indent=2, sort_keys=True))
+
+            if not updates:
+                print("No changes detected; nothing to do.")
+                return
+
+            if args.dry_run:
+                print("Dry run; no updates written.")
+                return
+
+            await session.execute(
+                text(
+                    """
+                    UPDATE player
+                    SET location = :location,
+                        country_code = :country_code,
+                        region_code = :region_code
+                    WHERE id = :player_id
+                    """
+                ),
+                {
+                    "player_id": before.id,
+                    "location": updates.get("location", before.location),
+                    "country_code": updates.get("country_code", before.country_code),
+                    "region_code": updates.get("region_code", before.region_code),
+                },
+            )
+            await session.commit()
+            print("Update applied.")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/survey_player_locations.py
+++ b/backend/scripts/survey_player_locations.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Helper script to survey distinct player.location values.
+
+Run with DATABASE_URL pointing at the production database::
+
+    DATABASE_URL=postgresql://... python backend/scripts/survey_player_locations.py
+
+The script prints a JSON document containing the distinct location strings,
+counts, and whether the current normalization helpers consider them structured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from app.location_utils import parse_location_string, normalize_location_string
+
+
+@dataclass
+class LocationSample:
+    location: str
+    count: int
+    normalized: Optional[str]
+    structured_country: Optional[str]
+    structured_region: Optional[str]
+
+
+async def _gather_samples(engine: AsyncEngine) -> list[LocationSample]:
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT location, COUNT(*) AS count
+                FROM player
+                WHERE location IS NOT NULL
+                  AND TRIM(location) <> ''
+                GROUP BY location
+                ORDER BY COUNT(*) DESC, location
+                """
+            )
+        )
+        rows = result.fetchall()
+
+    samples: list[LocationSample] = []
+    for raw_location, count in rows:
+        normalized = normalize_location_string(raw_location)
+        if normalized is None:
+            normalized = raw_location
+        country, region = parse_location_string(normalized)
+        samples.append(
+            LocationSample(
+                location=raw_location,
+                count=count,
+                normalized=normalized,
+                structured_country=country,
+                structured_region=region,
+            )
+        )
+    return samples
+
+
+async def main() -> None:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+
+    engine = create_async_engine(database_url, echo=False, pool_pre_ping=True)
+    try:
+        samples = await _gather_samples(engine)
+    finally:
+        await engine.dispose()
+
+    print(json.dumps([asdict(sample) for sample in samples], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add ISO-3166 alpha-2 country dataset and tighten location normalization to ignore unrecognized codes
- only backfill structured location columns during the migration when normalized values are available
- document and ship helper scripts for surveying legacy player locations and manually updating structured fields

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cbf812e5448323a0f915fa51f0508d