### PR TITLE
Fix backend script imports

### DIFF
--- a/backend/scripts/set_player_location.py
+++ b/backend/scripts/set_player_location.py
@@ -7,14 +7,20 @@ import argparse
 import asyncio
 import json
 import os
+import sys
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.location_utils import normalize_location_fields
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from backend.app.location_utils import normalize_location_fields
 
 
 @dataclass

--- a/backend/scripts/survey_player_locations.py
+++ b/backend/scripts/survey_player_locations.py
@@ -14,13 +14,22 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-from dataclasses import dataclass, asdict
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from app.location_utils import parse_location_string, normalize_location_string
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from backend.app.location_utils import (
+    parse_location_string,
+    normalize_location_string,
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- ensure the location helper scripts can find the backend package when executed directly
- update both scripts to import helpers from backend.app and prepend the project root to sys.path

## Testing
- DATABASE_URL=postgresql://localhost:1/test python backend/scripts/survey_player_locations.py *(fails with connection error because Postgres is not running, but confirms imports succeed)*
- DATABASE_URL=postgresql://localhost:1/test python backend/scripts/set_player_location.py player123 --dry-run --location "Test" *(fails with connection error because Postgres is not running, but confirms imports succeed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc178339488323b85f2000ce45c01d