### PR TITLE
Handle padel tiebreak simulation and add coverage

### DIFF
--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -88,6 +88,14 @@ def test_record_sets():
     assert len(events) == (6 + 4 + 6 + 2) * 4
 
 
+def test_padel_record_sets_tiebreak():
+    events, state = padel.record_sets([(7, 6)])
+    summary = padel.summary(state)
+    assert summary["sets"] == {"A": 1, "B": 0}
+    tiebreak_to = summary["config"].get("tiebreakTo", 7)
+    assert len(events) == (12 * 4) + tiebreak_to
+
+
 def test_tennis_record_sets_tiebreak():
     events, state = tennis.record_sets([(7, 6)])
     assert state["sets"] == {"A": 1, "B": 0}


### PR DESCRIPTION
## Summary
- update the padel record_sets helper to alternate games and emit tiebreak points when sets reach 7–6
- add unit coverage confirming padel.record_sets includes the tiebreak summary and point count
- extend the record sets API integration test to seed players, post a 7–6 set, and verify the stored summary and rating changes favour the winner

## Testing
- `pytest backend/tests/test_scoring.py backend/tests/test_record_sets.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc1eee772c8323b38f163d67178c09