### PR TITLE
Use api helper for leaderboard requests

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import Leaderboard from "./leaderboard";
+import { apiUrl } from "../../lib/api";
 
 const replaceMock = vi.fn();
 let mockPathname = "/leaderboard";
@@ -32,7 +33,7 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
-    expect(urls).toContain("/api/v0/leaderboards?sport=disc_golf");
+    expect(urls).toContain(apiUrl("/v0/leaderboards?sport=disc_golf"));
   });
 
   it("includes the country filter when provided", async () => {
@@ -46,7 +47,7 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/v0/leaderboards?sport=padel&country=SE"
+      apiUrl("/v0/leaderboards?sport=padel&country=SE")
     );
   });
 
@@ -61,7 +62,7 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/v0/leaderboards?sport=padel&clubId=club-a"
+      apiUrl("/v0/leaderboards?sport=padel&clubId=club-a")
     );
   });
 
@@ -76,7 +77,7 @@ describe("Leaderboard", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain(
-      "/api/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a"
+      apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")
     );
   });
 });

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { apiUrl } from "../../lib/api";
 
 // Identifier type for players
 export type ID = string | number;
@@ -83,7 +84,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     const params = new URLSearchParams({ sport: sportId });
     if (appliedCountry) params.set("country", appliedCountry);
     if (appliedClubId) params.set("clubId", appliedClubId);
-    return `/api/v0/leaderboards?${params.toString()}`;
+    return apiUrl(`/v0/leaderboards?${params.toString()}`);
   };
 
   const supportsFilters = sport !== "master";
@@ -167,7 +168,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             .map((l, i) => ({ ...l, rank: i + 1 }));
           if (!cancelled) setLeaders(combined);
         } else if (sport === "master") {
-          const res = await fetch(`/api/v0/leaderboards/master`);
+          const res = await fetch(apiUrl(`/v0/leaderboards/master`));
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
           const data = await res.json();
           const arr = Array.isArray(data) ? data : data.leaders ?? [];


### PR DESCRIPTION
## Summary
- resolve leaderboard API calls with the shared apiUrl helper so they respect configured base URLs
- update leaderboard tests to assert against helper-generated request URLs

## Testing
- npm test -- --run --reporter=basic (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68ce39a2a0f48323b1c5727e5c9a2648