### PR TITLE
Fix chunk error listener capture

### DIFF
--- a/apps/web/src/components/ChunkErrorReload.tsx
+++ b/apps/web/src/components/ChunkErrorReload.tsx
@@ -67,11 +67,13 @@ export default function ChunkErrorReload() {
       }
     };
 
-    window.addEventListener("error", handleError);
+    const captureOptions = { capture: true } as const;
+
+    window.addEventListener("error", handleError, captureOptions);
     window.addEventListener("unhandledrejection", handleRejection);
 
     return () => {
-      window.removeEventListener("error", handleError);
+      window.removeEventListener("error", handleError, captureOptions);
       window.removeEventListener("unhandledrejection", handleRejection);
     };
   }, []);


### PR DESCRIPTION
## Summary
- ensure the chunk load error listener is attached in the capture phase so script load failures are detected
- reuse the same capture options when removing the error listener to prevent leaks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce4078a4d88323be064d05a08dacec