### PR TITLE
Use async file writing for player photo uploads

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.27,<1.0
 sqlalchemy[asyncio]>=2.0,<3.0
 asyncpg>=0.29,<1.0
 aiosqlite>=0.20,<1.0
+aiofiles>=23.1,<24.0
 alembic>=1.12,<2.0
 pydantic>=2.4,<3.0
 pydantic-settings>=2.2,<3.0


### PR DESCRIPTION
## Summary
- switch the player photo upload handler to stream writes with aiofiles and clean up on failure
- add the aiofiles dependency for the backend and expose an async httpx client fixture for player tests
- extend the photo upload tests to exercise chunked async writes and verify the persisted bytes

## Testing
- pytest backend/tests/test_players.py

------
https://chatgpt.com/codex/tasks/task_e_68cf7c66400c8323876ccaee7e445948