### PR TITLE
Add admin-only player badge removal endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ GET  /api/v0/rulesets?sport=padel
 POST /api/v0/players
 GET  /api/v0/players?q=name
 DELETE /api/v0/players/{id}  # admin, soft delete
+POST /api/v0/players/{id}/badges/{badge_id}  # admin, award badge
+DELETE /api/v0/players/{id}/badges/{badge_id}  # admin, remove badge
 POST /api/v0/matches
 POST /api/v0/matches/by-name
 GET  /api/v0/matches/{id}


### PR DESCRIPTION
## Summary
- require admin privileges when awarding player badges and add a matching removal route
- delete player badge assignments via DELETE /players/{player_id}/badges/{badge_id} and return 404 when missing
- cover the new behavior in backend tests and document the badge management endpoints

## Testing
- pytest backend/tests/test_players.py

------
https://chatgpt.com/codex/tasks/task_e_68cffc92d9608323b46be58c1af3fa79