### PR TITLE
Update backend quickstart uvicorn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/crosssport
 export JWT_SECRET=local-dev-secret-local-dev-secret
 export ALLOWED_ORIGINS=http://localhost:3000
 
-uvicorn backend.app.main:app --reload --port 8000
+uvicorn app.main:app --reload --port 8000
 ```
 
 **Terminal 2 - Web**


### PR DESCRIPTION
## Summary
- adjust the backend quickstart uvicorn command so it works when run from within the backend directory

## Testing
- python -m markdown README.md > /tmp/readme.html

------
https://chatgpt.com/codex/tasks/task_e_68d00c066a748323927d7e4b5aaf8953