### PR TITLE
Handle RFC7807 errors in apiFetch

### DIFF
--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,4 +1,5 @@
-import { isAdmin } from './api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch, isAdmin } from './api';
 
 function buildToken(payload: Record<string, unknown>): string {
   const json = JSON.stringify(payload);
@@ -27,5 +28,68 @@ describe('isAdmin', () => {
   it('returns false for malformed token', () => {
     window.localStorage.setItem('token', 'bad.token');
     expect(isAdmin()).toBe(false);
+  });
+});
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it('uses problem detail messages for RFC 7807 responses', async () => {
+    const response = new Response(
+      JSON.stringify({
+        type: 'about:blank',
+        title: 'Bad Request',
+        detail: 'Validation failed',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/problem+json' },
+      }
+    );
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(apiFetch('/error')).rejects.toMatchObject({
+      message: 'HTTP 400: Validation failed',
+      status: 400,
+    });
+  });
+
+  it('falls back to plain text responses when JSON parsing fails', async () => {
+    const response = new Response('Server exploded', { status: 500 });
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(apiFetch('/error')).rejects.toMatchObject({
+      message: 'HTTP 500: Server exploded',
+      status: 500,
+    });
+  });
+
+  it('logs out when the token has expired', async () => {
+    window.localStorage.setItem('token', 'abc');
+    const response = new Response(
+      JSON.stringify({ detail: 'token expired' }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/problem+json' },
+      }
+    );
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(apiFetch('/error')).rejects.toMatchObject({
+      message: 'HTTP 401: token expired',
+      status: 401,
+    });
+    expect(window.localStorage.getItem('token')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- parse RFC 7807 error payloads in `apiFetch`, falling back to response text and keeping the expired-token logout
- add tests covering problem detail JSON, plain-text failures, and unauthorized responses

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d00fd9611c8323a8349fe9db14b026