### PR TITLE
Enforce participant uniqueness during match creation

### DIFF
--- a/backend/tests/test_matches_disc_golf_events.py
+++ b/backend/tests/test_matches_disc_golf_events.py
@@ -78,8 +78,8 @@ def test_create_and_append_event_hole(client_and_session):
         json={
             "sport": "disc_golf",
             "participants": [
-                {"side": "A", "playerIds": []},
-                {"side": "B", "playerIds": []},
+                {"side": "A", "playerIds": ["p1"]},
+                {"side": "B", "playerIds": ["p2"]},
             ],
         },
     )


### PR DESCRIPTION
## Summary
- normalize match participant sides while enforcing uniqueness and non-empty player lists for both MatchCreate schemas
- add unit coverage for success, duplicate side, and empty participant scenarios

## Testing
- pytest backend/tests/test_matches.py

------
https://chatgpt.com/codex/tasks/task_e_68d0997287c08323aebd02d49b9ff5ca