### PR TITLE
Paginate player comments endpoint

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -313,6 +313,15 @@ class CommentOut(BaseModel):
     content: str
     createdAt: datetime
 
+
+class CommentListOut(BaseModel):
+    """Paginated list of comments returned from the comments endpoint."""
+
+    items: List[CommentOut]
+    total: int
+    limit: int
+    offset: int
+
 class VersusRecord(BaseModel):
     """Win/loss record versus or with another player."""
     playerId: str


### PR DESCRIPTION
## Summary
- add pagination parameters and total counting to the player comments endpoint
- introduce a paginated response schema for comment listings
- expand comment tests to cover pagination defaults, overrides, and validation

## Testing
- pytest backend/tests/test_comments.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c70499b08323a9187f2cad6b74cc