### PR TITLE
Handle paginated player comments response

### DIFF
--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -12,6 +12,13 @@ interface Comment {
   createdAt: string;
 }
 
+interface PaginatedComments {
+  items: Comment[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export default function PlayerComments({ playerId }: { playerId: string }) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [content, setContent] = useState("");
@@ -21,7 +28,8 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
   const load = useCallback(async () => {
     const resp = await apiFetch(`/v0/players/${playerId}/comments`);
     if (resp.ok) {
-      setComments((await resp.json()) as Comment[]);
+      const data = (await resp.json()) as PaginatedComments;
+      setComments(data.items ?? []);
     }
   }, [playerId]);
 


### PR DESCRIPTION
## Summary
- parse the paginated comments payload from the player comments endpoint
- continue storing only the comment items so the UI can render the comment list

## Testing
- npm run lint (warns about existing missing dependency warning in leaderboard page)


------
https://chatgpt.com/codex/tasks/task_e_68d0dcb7699c8323b521da32c72359b4