### PR TITLE
Add admin badges management page with tests

### DIFF
--- a/apps/web/src/app/__tests__/admin-badges.page.test.tsx
+++ b/apps/web/src/app/__tests__/admin-badges.page.test.tsx
@@ -1,0 +1,183 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AdminBadgesPage from '../admin/badges/page';
+import { apiFetch, isAdmin } from '../../lib/api';
+
+vi.mock('../../lib/api', () => ({
+  apiFetch: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedIsAdmin = vi.mocked(isAdmin);
+
+const jsonResponse = (data: unknown): Response =>
+  ({
+    ok: true,
+    json: async () => data,
+  } as Response);
+
+const emptyResponse = (): Response =>
+  ({
+    ok: true,
+    json: async () => ({}),
+  } as Response);
+
+describe('AdminBadgesPage', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedIsAdmin.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects non-admins to login', async () => {
+    let href = 'http://localhost/';
+    const locationMock = {
+      assign: vi.fn((value: string) => {
+        href = value;
+      }),
+      replace: vi.fn(),
+      reload: vi.fn(),
+    } as Partial<Location>;
+    Object.defineProperty(locationMock, 'href', {
+      configurable: true,
+      get: () => href,
+      set: (value: string) => {
+        href = value;
+      },
+    });
+    vi.stubGlobal('location', locationMock);
+
+    mockedIsAdmin.mockReturnValue(false);
+
+    render(<AdminBadgesPage />);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('/login');
+    });
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('renders badges returned from the API', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 'b1', name: 'Alpha', icon: null },
+        { id: 'b2', name: 'Beta', icon: '🔥' },
+      ])
+    );
+
+    render(<AdminBadgesPage />);
+
+    expect(await screen.findByDisplayValue('Alpha')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('🔥')).toBeInTheDocument();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      '/v0/badges',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  it('creates a new badge', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(emptyResponse())
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'b2', name: 'Legend', icon: '🏆' }])
+      );
+
+    render(<AdminBadgesPage />);
+
+    const form = screen.getByRole('form', { name: /create badge/i });
+    const nameInput = within(form).getByLabelText('Name');
+    const iconInput = within(form).getByLabelText('Icon');
+
+    fireEvent.change(nameInput, { target: { value: 'Legend' } });
+    fireEvent.change(iconInput, { target: { value: '🏆' } });
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    });
+    const postCall = mockedApiFetch.mock.calls[1];
+    expect(postCall[0]).toBe('/v0/badges');
+    expect(postCall[1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(postCall[1]?.body as string)).toEqual({
+      name: 'Legend',
+      icon: '🏆',
+    });
+    expect(await screen.findByText('Badge created.')).toBeInTheDocument();
+  });
+
+  it('updates an existing badge', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'b1', name: 'Starter', icon: null }])
+      )
+      .mockResolvedValueOnce(emptyResponse())
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'b1', name: 'Starter Updated', icon: '🔥' }])
+      );
+
+    render(<AdminBadgesPage />);
+
+    const nameInput = await screen.findByDisplayValue('Starter');
+    const row = nameInput.closest('li');
+    if (!row) throw new Error('Expected badge row');
+    const iconInput = within(row).getByLabelText('Icon');
+    const saveButton = within(row).getByRole('button', { name: 'Save' });
+
+    fireEvent.change(nameInput, { target: { value: 'Starter Updated' } });
+    fireEvent.change(iconInput, { target: { value: '🔥' } });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    });
+    const patchCall = mockedApiFetch.mock.calls[1];
+    expect(patchCall[0]).toBe('/v0/badges/b1');
+    expect(patchCall[1]).toMatchObject({ method: 'PATCH' });
+    expect(JSON.parse(patchCall[1]?.body as string)).toEqual({
+      name: 'Starter Updated',
+      icon: '🔥',
+    });
+    expect(await screen.findByText('Badge updated.')).toBeInTheDocument();
+  });
+
+  it('deletes a badge', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'b1', name: 'Starter', icon: null }])
+      )
+      .mockResolvedValueOnce(emptyResponse())
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    render(<AdminBadgesPage />);
+
+    const nameInput = await screen.findByDisplayValue('Starter');
+    const row = nameInput.closest('li');
+    if (!row) throw new Error('Expected badge row');
+    const deleteButton = within(row).getByRole('button', { name: 'Delete' });
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    });
+    const deleteCall = mockedApiFetch.mock.calls[1];
+    expect(deleteCall[0]).toBe('/v0/badges/b1');
+    expect(deleteCall[1]).toMatchObject({ method: 'DELETE' });
+    expect(await screen.findByText('Badge deleted.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/badges/page.tsx
+++ b/apps/web/src/app/admin/badges/page.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { apiFetch, isAdmin } from '../../../lib/api';
+
+type BadgeApi = {
+  id: string;
+  name: string;
+  icon?: string | null;
+};
+
+type BadgeRow = {
+  id: string;
+  name: string;
+  icon: string;
+};
+
+function normalizeBadge(badge: BadgeApi): BadgeRow {
+  return {
+    id: badge.id,
+    name: badge.name,
+    icon: badge.icon ?? '',
+  };
+}
+
+export default function AdminBadgesPage() {
+  const [badges, setBadges] = useState<BadgeRow[]>([]);
+  const [newBadgeName, setNewBadgeName] = useState('');
+  const [newBadgeIcon, setNewBadgeIcon] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [deleting, setDeleting] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const loadBadges = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/v0/badges', { cache: 'no-store' });
+      const data = (await res.json()) as BadgeApi[];
+      const normalized = data
+        .map(normalizeBadge)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      setBadges(normalized);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to load badges.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin()) {
+      window.location.href = '/login';
+      return;
+    }
+    loadBadges();
+  }, [loadBadges]);
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newBadgeName.trim()) {
+      setError('Badge name is required.');
+      setSuccess(null);
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload = {
+        name: newBadgeName.trim(),
+        icon: newBadgeIcon.trim() ? newBadgeIcon.trim() : null,
+      };
+      await apiFetch('/v0/badges', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      setNewBadgeName('');
+      setNewBadgeIcon('');
+      await loadBadges();
+      setSuccess('Badge created.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create badge.';
+      setError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const updateBadgeField = (id: string, field: 'name' | 'icon', value: string) => {
+    setBadges((prev) =>
+      prev.map((badge) =>
+        badge.id === id
+          ? {
+              ...badge,
+              [field]: value,
+            }
+          : badge
+      )
+    );
+  };
+
+  const handleUpdate = async (id: string) => {
+    const badge = badges.find((b) => b.id === id);
+    if (!badge) return;
+    if (!badge.name.trim()) {
+      setError('Badge name is required.');
+      setSuccess(null);
+      return;
+    }
+
+    setSaving((prev) => ({ ...prev, [id]: true }));
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const payload = {
+        name: badge.name.trim(),
+        icon: badge.icon.trim() ? badge.icon.trim() : null,
+      };
+      await apiFetch(`/v0/badges/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      await loadBadges();
+      setSuccess('Badge updated.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update badge.';
+      setError(message);
+    } finally {
+      setSaving((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeleting((prev) => ({ ...prev, [id]: true }));
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await apiFetch(`/v0/badges/${id}`, { method: 'DELETE' });
+      await loadBadges();
+      setSuccess('Badge deleted.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete badge.';
+      setError(message);
+    } finally {
+      setDeleting((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    }
+  };
+
+  return (
+    <main className="container">
+      <h1 className="heading">Admin Badges</h1>
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="success" role="status">
+          {success}
+        </p>
+      )}
+      {loading && <p>Loading badges...</p>}
+
+      <section className="card" style={{ marginBottom: 24 }}>
+        <h2>Create new badge</h2>
+        <form
+          aria-label="Create badge"
+          onSubmit={handleCreate}
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}
+        >
+          <label htmlFor="new-badge-name" style={{ flex: '1 1 200px' }}>
+            Name
+            <input
+              id="new-badge-name"
+              value={newBadgeName}
+              onChange={(event) => setNewBadgeName(event.target.value)}
+              required
+              disabled={creating}
+            />
+          </label>
+          <label htmlFor="new-badge-icon" style={{ flex: '1 1 200px' }}>
+            Icon
+            <input
+              id="new-badge-icon"
+              value={newBadgeIcon}
+              onChange={(event) => setNewBadgeIcon(event.target.value)}
+              disabled={creating}
+            />
+          </label>
+          <button type="submit" disabled={creating} style={{ alignSelf: 'flex-end' }}>
+            {creating ? 'Creating…' : 'Create badge'}
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Existing badges</h2>
+        {badges.length === 0 ? (
+          <p>No badges yet.</p>
+        ) : (
+          <ul className="match-list">
+            {badges.map((badge) => {
+              const savingBadge = saving[badge.id];
+              const deletingBadge = deleting[badge.id];
+              return (
+                <li
+                  key={badge.id}
+                  className="card"
+                  style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'flex-end' }}
+                >
+                  <label htmlFor={`badge-name-${badge.id}`} style={{ flex: '1 1 200px' }}>
+                    Name
+                    <input
+                      id={`badge-name-${badge.id}`}
+                      value={badge.name}
+                      onChange={(event) =>
+                        updateBadgeField(badge.id, 'name', event.target.value)
+                      }
+                    />
+                  </label>
+                  <label htmlFor={`badge-icon-${badge.id}`} style={{ flex: '1 1 200px' }}>
+                    Icon
+                    <input
+                      id={`badge-icon-${badge.id}`}
+                      value={badge.icon}
+                      onChange={(event) =>
+                        updateBadgeField(badge.id, 'icon', event.target.value)
+                      }
+                    />
+                  </label>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button
+                      type="button"
+                      onClick={() => handleUpdate(badge.id)}
+                      disabled={savingBadge || deletingBadge}
+                    >
+                      {savingBadge ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(badge.id)}
+                      disabled={savingBadge || deletingBadge}
+                    >
+                      {deletingBadge ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -73,11 +73,18 @@ export default function Header() {
             </Link>
           </li>
           {admin && (
-            <li>
-              <Link href="/admin/matches" onClick={() => setOpen(false)}>
-                Admin
-              </Link>
-            </li>
+            <>
+              <li>
+                <Link href="/admin/matches" onClick={() => setOpen(false)}>
+                  Admin Matches
+                </Link>
+              </li>
+              <li>
+                <Link href="/admin/badges" onClick={() => setOpen(false)}>
+                  Admin Badges
+                </Link>
+              </li>
+            </>
           )}
           {user ? (
             <>


### PR DESCRIPTION
## Summary
- add an admin badges page that enforces admin access, lists badges, and supports create/update/delete flows with status messaging
- update the site header so admins can reach both the matches and badges admin pages
- add vitest coverage for the admin badges page including creation, editing, deletion, and non-admin redirect behaviours

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d9ee80588323ac90caf3e045df59