### PR TITLE
Add player self endpoints and location update tests

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -56,6 +56,29 @@ class PlayerCreate(BaseModel):
         )
         return model
 
+
+class PlayerLocationUpdate(BaseModel):
+    location: Optional[str] = None
+    country_code: Optional[str] = None
+    region_code: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _normalize_location(
+        cls, model: "PlayerLocationUpdate"
+    ) -> "PlayerLocationUpdate":
+        (
+            model.location,
+            model.country_code,
+            model.region_code,
+        ) = normalize_location_fields(
+            model.location,
+            model.country_code,
+            model.region_code,
+            raise_on_invalid=True,
+        )
+        return model
+
+
 class PlayerOut(BaseModel):
     id: str
     name: str


### PR DESCRIPTION
## Summary
- add a PlayerLocationUpdate schema that normalizes location updates
- expose /players/me and /players/me/location endpoints for authenticated players
- cover the new endpoints with success, validation, clearing, and error tests

## Testing
- pytest backend/tests/test_players.py

------
https://chatgpt.com/codex/tasks/task_e_68d0fe58f4e88323a0387ba59c85f59d