### PR TITLE
Ensure badge update/delete endpoints serialize consistently

### DIFF
--- a/backend/app/routers/badges.py
+++ b/backend/app/routers/badges.py
@@ -5,12 +5,16 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
+from ..exceptions import ProblemDetail
 from ..models import Badge, PlayerBadge, User
 from ..schemas import BadgeCreate, BadgeOut, BadgeUpdate
-from ..exceptions import ProblemDetail
 from .admin import require_admin
 
 router = APIRouter(prefix="/badges", tags=["badges"], responses={404: {"model": ProblemDetail}})
+
+
+def _to_badge_out(badge: Badge) -> BadgeOut:
+    return BadgeOut(id=badge.id, name=badge.name, icon=badge.icon)
 
 
 @router.post("", response_model=BadgeOut)
@@ -19,21 +23,20 @@ async def create_badge(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(require_admin),
 ):
-    bid = uuid.uuid4().hex
-    b = Badge(id=bid, name=body.name, icon=body.icon)
-    session.add(b)
+    badge = Badge(id=uuid.uuid4().hex, name=body.name, icon=body.icon)
+    session.add(badge)
     try:
         await session.commit()
     except IntegrityError:
         await session.rollback()
         raise HTTPException(status_code=409, detail="badge name exists")
-    return BadgeOut(id=bid, name=b.name, icon=b.icon)
+    return _to_badge_out(badge)
 
 
 @router.get("", response_model=list[BadgeOut])
 async def list_badges(session: AsyncSession = Depends(get_session)):
     rows = (await session.execute(select(Badge))).scalars().all()
-    return [BadgeOut(id=b.id, name=b.name, icon=b.icon) for b in rows]
+    return [_to_badge_out(badge) for badge in rows]
 
 
 @router.patch("/{badge_id}", response_model=BadgeOut)
@@ -48,10 +51,8 @@ async def update_badge(
         raise HTTPException(status_code=404, detail="badge not found")
 
     updates = body.model_dump(exclude_unset=True)
-    if "name" in updates:
-        badge.name = updates["name"]
-    if "icon" in updates:
-        badge.icon = updates["icon"]
+    for field, value in updates.items():
+        setattr(badge, field, value)
 
     try:
         await session.commit()
@@ -59,7 +60,7 @@ async def update_badge(
         await session.rollback()
         raise HTTPException(status_code=409, detail="badge name exists")
 
-    return BadgeOut(id=badge.id, name=badge.name, icon=badge.icon)
+    return _to_badge_out(badge)
 
 
 @router.delete("/{badge_id}", status_code=204)


### PR DESCRIPTION
## Summary
- add a helper to convert `Badge` ORM entities into `BadgeOut` responses
- reuse the helper across badge creation, listing, and mutation handlers while simplifying update field assignment

## Testing
- pytest backend/tests/test_badges.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ff8276708323ad6a091822c988f9