### PR TITLE
Add Glicko ratings and extend player performance stats

### DIFF
--- a/backend/alembic/versions/0019_glicko_ratings.py
+++ b/backend/alembic/versions/0019_glicko_ratings.py
@@ -1,0 +1,41 @@
+"""create glicko rating table
+
+Revision ID: 0019_glicko_ratings
+Revises: 0018_user_profile_photos
+Create Date: 2024-05-08 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0019_glicko_ratings"
+down_revision = "0018_user_profile_photos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "glicko_rating",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.String(), nullable=False),
+        sa.Column("sport_id", sa.String(), nullable=False),
+        sa.Column("rating", sa.Float(), nullable=False, server_default=sa.text("1500.0")),
+        sa.Column("rd", sa.Float(), nullable=False, server_default=sa.text("350.0")),
+        sa.Column(
+            "last_updated",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "player_id", "sport_id", name="uq_glicko_rating_player_id_sport_id"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("glicko_rating")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -129,6 +129,25 @@ class Rating(Base):
     value = Column(Float, nullable=False, default=1000)
 
 
+class GlickoRating(Base):
+    """Current Glicko rating snapshot for a player in a given sport."""
+
+    __tablename__ = "glicko_rating"
+
+    id = Column(String, primary_key=True)
+    player_id = Column(String, ForeignKey("player.id"), nullable=False)
+    sport_id = Column(String, ForeignKey("sport.id"), nullable=False)
+    rating = Column(Float, nullable=False, default=1500.0)
+    rd = Column(Float, nullable=False, default=350.0)
+    last_updated = Column(DateTime, nullable=True, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint(
+            "player_id", "sport_id", name="uq_glicko_rating_player_id_sport_id"
+        ),
+    )
+
+
 class MasterRating(Base):
     """Aggregated rating across all sports for a player."""
 

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -92,6 +92,11 @@ async def leaderboard(
         payload = ev.payload or {}
         pid = payload.get("playerId")
         rating = payload.get("rating")
+        systems = payload.get("systems") if isinstance(payload, dict) else None
+        if rating is None and isinstance(systems, dict):
+            elo_info = systems.get("elo")
+            if isinstance(elo_info, dict):
+                rating = elo_info.get("rating")
         if pid is not None and rating is not None:
             histories[pid].append(rating)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -386,6 +386,8 @@ class VersusRecord(BaseModel):
     wins: int
     losses: int
     winPct: float
+    total: Optional[int] = None
+    chemistry: Optional[float] = None
 
 class SportFormatStats(BaseModel):
     """Aggregated stats for a particular sport and team size."""
@@ -401,6 +403,50 @@ class StreakSummary(BaseModel):
     longestWin: int
     longestLoss: int
 
+
+class RatingSystemSnapshot(BaseModel):
+    """Rating information for a specific rating system."""
+
+    value: Optional[float] = None
+    delta30: float = 0.0
+    sparkline: List[float] = Field(default_factory=list)
+    deviation: Optional[float] = None
+    lastUpdated: Optional[datetime] = None
+
+
+class SportRatingSummary(BaseModel):
+    """Ratings for a player within a given sport."""
+
+    sport: str
+    elo: Optional[RatingSystemSnapshot] = None
+    glicko: Optional[RatingSystemSnapshot] = None
+
+
+class MatchSummary(BaseModel):
+    """Aggregate match record for a player."""
+
+    total: int = 0
+    wins: int = 0
+    losses: int = 0
+    draws: int = 0
+    winPct: float = 0.0
+
+
+class SetSummary(BaseModel):
+    """Aggregate set performance for a player."""
+
+    won: int = 0
+    lost: int = 0
+    differential: int = 0
+
+
+class RecentFormSummary(BaseModel):
+    """Recent form indicators for a player."""
+
+    lastFive: List[str] = Field(default_factory=list)
+    currentStreak: str = ""
+
+
 class PlayerStatsOut(BaseModel):
     """Statistics summary returned by the player stats endpoint."""
     playerId: str
@@ -412,6 +458,12 @@ class PlayerStatsOut(BaseModel):
     sportFormatStats: List[SportFormatStats] = Field(default_factory=list)
     withRecords: List[VersusRecord] = Field(default_factory=list)
     streaks: Optional[StreakSummary] = None
+    matchSummary: MatchSummary = Field(default_factory=MatchSummary)
+    setSummary: SetSummary = Field(default_factory=SetSummary)
+    recentForm: RecentFormSummary = Field(default_factory=RecentFormSummary)
+    topPartners: List[VersusRecord] = Field(default_factory=list)
+    headToHeadRecords: List[VersusRecord] = Field(default_factory=list)
+    ratings: List[SportRatingSummary] = Field(default_factory=list)
 
 
 class MatchIdOut(BaseModel):

--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -1,11 +1,72 @@
+import math
 import uuid
+from datetime import datetime
 from typing import Sequence
+
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..models import Rating, MatchParticipant, Match, ScoreEvent
+from ..db_errors import is_missing_table_error
+from ..models import GlickoRating, Match, MatchParticipant, Rating, ScoreEvent
 
 K_FACTOR = 32.0
+GLICKO_DEFAULT_RATING = 1500.0
+GLICKO_DEFAULT_RD = 350.0
+GLICKO_MIN_RD = 30.0
+GLICKO_MAX_RD = 350.0
+GLICKO_SCALE = 173.7178
+
+
+def _glicko_update(
+    rating: float, rd: float, outcomes: Sequence[tuple[float, float, float]]
+) -> tuple[float, float]:
+    """Return updated Glicko rating and rating deviation.
+
+    Args:
+        rating: Current rating value.
+        rd: Current rating deviation.
+        outcomes: Sequence of tuples ``(opponent_rating, opponent_rd, score)`` where
+            ``score`` is ``1`` for a win, ``0`` for a loss, and ``0.5`` for a draw.
+    """
+
+    if not outcomes:
+        # No new information – let the RD drift slightly upward to express uncertainty.
+        new_rd = min(GLICKO_MAX_RD, math.sqrt(rd**2 + (GLICKO_MIN_RD / 2) ** 2))
+        return rating, new_rd
+
+    mu = (rating - GLICKO_DEFAULT_RATING) / GLICKO_SCALE
+    phi = max(rd / GLICKO_SCALE, 1e-6)
+
+    denom = 0.0
+    delta_sum = 0.0
+    for opp_rating, opp_rd, score in outcomes:
+        mu_j = (opp_rating - GLICKO_DEFAULT_RATING) / GLICKO_SCALE
+        phi_j = max(opp_rd / GLICKO_SCALE, 1e-6)
+        g = 1 / math.sqrt(1 + 3 * (phi_j**2) / (math.pi**2))
+        e = 1 / (1 + math.exp(-g * (mu - mu_j)))
+        denom += (g**2) * e * (1 - e)
+        delta_sum += g * (score - e)
+
+    if denom <= 0:
+        return rating, max(GLICKO_MIN_RD, min(GLICKO_MAX_RD, rd))
+
+    v = 1 / denom
+    phi_star = phi  # assume instantaneous rating periods
+    phi_prime = 1 / math.sqrt((1 / (phi_star**2)) + (1 / v))
+    mu_prime = mu + (phi_prime**2) * delta_sum
+
+    new_rating = (mu_prime * GLICKO_SCALE) + GLICKO_DEFAULT_RATING
+    new_rd = max(GLICKO_MIN_RD, min(GLICKO_MAX_RD, phi_prime * GLICKO_SCALE))
+    return new_rating, new_rd
+
+
+def _average_glicko(opponents: Sequence[GlickoRating]) -> tuple[float, float]:
+    if not opponents:
+        return GLICKO_DEFAULT_RATING, GLICKO_DEFAULT_RD
+    rating = sum(o.rating for o in opponents) / len(opponents)
+    rd = sum(o.rd for o in opponents) / len(opponents)
+    return rating, rd
 
 async def update_ratings(
     session: AsyncSession,
@@ -40,6 +101,37 @@ async def update_ratings(
             session.add(r)
             rating_map[pid] = r
 
+    glicko_map: dict[str, GlickoRating] = {}
+    glicko_disabled = False
+    try:
+        glicko_rows = (
+            await session.execute(
+                select(GlickoRating).where(
+                    GlickoRating.player_id.in_(ids), GlickoRating.sport_id == sport_id
+                )
+            )
+        ).scalars().all()
+    except SQLAlchemyError as exc:  # pragma: no cover - optional table
+        if not is_missing_table_error(exc, GlickoRating.__tablename__):
+            raise
+        glicko_disabled = True
+    else:
+        glicko_map = {r.player_id: r for r in glicko_rows}
+
+    if not glicko_disabled:
+        for pid in ids:
+            if pid not in glicko_map:
+                glicko = GlickoRating(
+                    id=uuid.uuid4().hex,
+                    player_id=pid,
+                    sport_id=sport_id,
+                    rating=GLICKO_DEFAULT_RATING,
+                    rd=GLICKO_DEFAULT_RD,
+                    last_updated=datetime.utcnow(),
+                )
+                session.add(glicko)
+                glicko_map[pid] = glicko
+
     avg_win = sum(rating_map[pid].value for pid in winners) / len(winners)
     avg_lose = sum(rating_map[pid].value for pid in losers) / len(losers)
 
@@ -72,13 +164,78 @@ async def update_ratings(
     for pid in losers:
         rating_map[pid].value += k_map[pid] * (lose_score - (1 - expected_win))
 
+    glicko_payload: dict[str, tuple[float, float]] = {}
+    if not glicko_disabled:
+        winner_set = set(winners)
+        loser_set = set(losers)
+        draw_set = set(draws)
+
+        def opponent_ids(pid: str) -> list[str]:
+            if pid in winner_set:
+                opponents = list(loser_set)
+                if not opponents and draw_set:
+                    opponents = [d for d in draw_set if d != pid]
+                return opponents
+            if pid in loser_set:
+                opponents = list(winner_set)
+                if not opponents and draw_set:
+                    opponents = [d for d in draw_set if d != pid]
+                return opponents
+            # draws only (no win/lose info)
+            return [p for p in (winner_set | loser_set | draw_set) if p != pid]
+
+        score_map: dict[str, float] = {}
+        for pid in ids:
+            if pid in winner_set:
+                score_map[pid] = win_score
+            elif pid in loser_set:
+                score_map[pid] = lose_score
+            else:
+                score_map[pid] = 0.5
+
+        for pid in ids:
+            opponents = opponent_ids(pid)
+            if not opponents:
+                current = glicko_map.get(pid)
+                if current is not None:
+                    glicko_payload[pid] = (current.rating, current.rd)
+                continue
+            opponent_rows = [glicko_map[o] for o in opponents if o in glicko_map]
+            if not opponent_rows:
+                current = glicko_map.get(pid)
+                if current is not None:
+                    glicko_payload[pid] = (current.rating, current.rd)
+                continue
+            opp_rating, opp_rd = _average_glicko(opponent_rows)
+            current = glicko_map[pid]
+            new_rating, new_rd = _glicko_update(current.rating, current.rd, [(opp_rating, opp_rd, score_map[pid])])
+            current.rating = new_rating
+            current.rd = new_rd
+            current.last_updated = datetime.utcnow()
+            glicko_payload[pid] = (new_rating, new_rd)
+
+        for pid in ids:
+            if pid not in glicko_payload and pid in glicko_map:
+                current = glicko_map[pid]
+                glicko_payload[pid] = (current.rating, current.rd)
+
     if match_id:
         for pid in ids:
+            payload: dict[str, object] = {
+                "playerId": pid,
+                "rating": rating_map[pid].value,
+                "systems": {
+                    "elo": {"rating": rating_map[pid].value},
+                },
+            }
+            if not glicko_disabled and pid in glicko_payload:
+                rating_value, rd_value = glicko_payload[pid]
+                payload["systems"]["glicko"] = {"rating": rating_value, "rd": rd_value}
             session.add(
                 ScoreEvent(
                     id=uuid.uuid4().hex,
                     match_id=match_id,
                     type="RATING",
-                    payload={"playerId": pid, "rating": rating_map[pid].value},
+                    payload=payload,
                 )
             )

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -592,6 +592,7 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
   from app.models import (
       Player,
       Rating,
+      GlickoRating,
       Sport,
       Match,
       MatchParticipant,
@@ -617,6 +618,7 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
             Sport.__table__,
             Player.__table__,
             Rating.__table__,
+            GlickoRating.__table__,
             Match.__table__,
             ScoreEvent.__table__,
         ],

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -227,11 +227,29 @@ def test_player_stats(client_and_session):
     assert data["worstAgainst"]["losses"] == 1
     assert data["worstWith"]["losses"] == 1
 
+    assert data["matchSummary"] == {
+        "total": 2,
+        "wins": 1,
+        "losses": 1,
+        "draws": 0,
+        "winPct": pytest.approx(0.5),
+    }
+    assert data["setSummary"] == {
+        "won": 2,
+        "lost": 2,
+        "differential": 0,
+    }
+    assert data["recentForm"] == {"lastFive": ["W", "L"], "currentStreak": "L1"}
+
     records = {r["playerId"]: r for r in data["withRecords"]}
     assert records["p2"]["wins"] == 1
     assert records["p2"]["losses"] == 0
+    assert records["p2"]["total"] == 1
+    assert records["p2"]["chemistry"] == pytest.approx(1.0)
     assert records["p3"]["wins"] == 0
     assert records["p3"]["losses"] == 1
+    assert records["p3"]["total"] == 1
+    assert records["p3"]["chemistry"] == pytest.approx(0.0)
 
     # Rolling win percentage for the two matches
     assert data["rollingWinPct"] == [1.0, 0.5]
@@ -245,6 +263,14 @@ def test_player_stats(client_and_session):
     assert data["streaks"]["current"] == -1
     assert data["streaks"]["longestWin"] == 1
     assert data["streaks"]["longestLoss"] == 1
+    assert data["topPartners"][0]["playerId"] == "p2"
+    assert data["topPartners"][1]["playerId"] == "p3"
+
+    h2h = {r["playerId"]: r for r in data["headToHeadRecords"]}
+    assert h2h["p3"]["wins"] == 1 and h2h["p3"]["losses"] == 0
+    assert h2h["p4"]["wins"] == 1 and h2h["p4"]["losses"] == 1
+    assert h2h["p2"]["wins"] == 0 and h2h["p2"]["losses"] == 1
+    assert data["ratings"] == []
 
 
 def test_player_stats_with_singles(client_and_session):

--- a/backend/tests/test_record_sets.py
+++ b/backend/tests/test_record_sets.py
@@ -21,6 +21,7 @@ from backend.app.models import (
     MatchParticipant,
     Player,
     Rating,
+    GlickoRating,
     User,
 )
 from backend.app.routers import matches
@@ -49,6 +50,7 @@ def client_and_session():
             await conn.run_sync(ScoreEvent.__table__.create)
             await conn.run_sync(Player.__table__.create)
             await conn.run_sync(Rating.__table__.create)
+            await conn.run_sync(GlickoRating.__table__.create)
 
     asyncio.run(init_models())
 


### PR DESCRIPTION
## Summary
- add persistent Glicko rating support alongside existing Elo ratings and record both systems in match score events
- enrich the player stats endpoint with match totals, set performance, recent form, partner chemistry, head-to-head tables, and rating history/sparklines
- update schemas, utilities, and tests (including a migration) to cover the new data structures and ensure optional tables are handled gracefully

## Testing
- pytest backend/tests/test_rating_service.py backend/tests/test_player_stats.py backend/tests/test_record_sets.py backend/tests/test_matches.py


------
https://chatgpt.com/codex/tasks/task_e_68d15589f1d48323908c2d87546cc228