### PR TITLE
Add admin player location editing support

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -164,3 +164,19 @@ export async function updateMyPlayerLocation(
   });
   return res.json();
 }
+
+export async function updatePlayerLocation(
+  playerId: string,
+  data: PlayerLocationPayload
+): Promise<PlayerMe> {
+  const payloadEntries = Object.entries(data).filter(
+    (entry): entry is [string, string | null] => entry[1] !== undefined
+  );
+  const body = Object.fromEntries(payloadEntries);
+  const res = await apiFetch(`/v0/players/${playerId}/location`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- extract the shared location update logic into a helper and add an admin-only endpoint for updating any player's location
- expose a web API helper plus admin UI controls to edit player countries
- expand backend and frontend tests to cover the new admin location update flow

## Testing
- pytest backend/tests/test_players.py
- pnpm vitest run src/app/players/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d171402bac83239149b0c6dbef78a2