### PR TITLE
Add clubs API endpoint and club selector UI

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { apiFetch } from "../../../lib/api";
+import { apiFetch, fetchClubs } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
@@ -268,6 +268,16 @@ export default async function PlayerPage({
       getStats(params.id),
       getUpcomingMatches(params.id),
     ]);
+    let clubName: string | null = null;
+    if (player.club_id) {
+      try {
+        const clubs = await fetchClubs({ cache: "no-store" });
+        const match = clubs.find((club) => club.id === player.club_id);
+        clubName = match?.name ?? null;
+      } catch (err) {
+        console.warn("Failed to resolve club name", err);
+      }
+    }
     const matches = allMatches.filter(
       (m) => m.playedAt && new Date(m.playedAt) <= new Date()
     );
@@ -311,7 +321,9 @@ export default async function PlayerPage({
           <h1 className="heading">
             <PlayerName player={player} />
           </h1>
-          {player.club_id && <p>Club: {player.club_id}</p>}
+          {player.club_id ? (
+            <p>Club: {clubName ?? player.club_id}</p>
+          ) : null}
 
           <nav className="mt-4 mb-4 space-x-4">
             <Link

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -11,6 +11,7 @@ import {
   updateMyPlayerLocation,
 } from "../../lib/api";
 import type { PlayerLocationPayload } from "../../lib/api";
+import ClubSelect from "../../components/ClubSelect";
 import {
   COUNTRY_OPTIONS,
   getContinentForCountry,
@@ -89,7 +90,7 @@ export default function ProfilePage() {
             setMessage(null);
           }
         }
-      } catch (err) {
+      } catch {
         if (!active) return;
         router.push("/login");
         return;
@@ -297,12 +298,12 @@ export default function ProfilePage() {
         <div style={{ fontSize: "0.9rem", color: "#555" }}>
           Continent: {continentLabel ?? "—"}
         </div>
-        <input
-          type="text"
-          aria-label="Favorite club"
-          placeholder="Favorite club"
+        <ClubSelect
           value={clubId}
-          onChange={(e) => setClubId(e.target.value)}
+          onChange={setClubId}
+          placeholder="Favorite club"
+          ariaLabel="Favorite club"
+          name="club_id"
         />
         <button type="submit" disabled={saving}>
           Save

--- a/apps/web/src/components/ClubSelect.tsx
+++ b/apps/web/src/components/ClubSelect.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+} from "react";
+
+import { fetchClubs, type ClubSummary } from "../lib/api";
+
+interface ClubSelectProps {
+  value: string;
+  onChange: (clubId: string) => void;
+  placeholder?: string;
+  name?: string;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+export default function ClubSelect({
+  value,
+  onChange,
+  placeholder = "Select a club",
+  name,
+  disabled = false,
+  className,
+  ariaLabel,
+}: ClubSelectProps) {
+  const [options, setOptions] = useState<ClubSummary[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [dirtySearch, setDirtySearch] = useState(false);
+
+  const loadOptions = useCallback(async () => {
+    if (status === "loading" || status === "loaded") {
+      return;
+    }
+    setStatus("loading");
+    try {
+      const clubs = await fetchClubs();
+      const sorted = [...clubs].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+      );
+      setOptions(sorted);
+      setStatus("loaded");
+    } catch (err) {
+      console.error("Failed to load clubs", err);
+      setStatus("error");
+    }
+  }, [status]);
+
+  const handleFocus = useCallback(
+    (event: FocusEvent<HTMLInputElement | HTMLSelectElement>) => {
+      if (disabled) {
+        return;
+      }
+      void loadOptions();
+      if (!dirtySearch && value && event.currentTarget instanceof HTMLInputElement) {
+        const selected = options.find((club) => club.id === value);
+        if (selected) {
+          setSearchTerm(selected.name);
+        }
+      }
+    },
+    [disabled, dirtySearch, loadOptions, options, value]
+  );
+
+  const handleSearchChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setDirtySearch(true);
+      setSearchTerm(event.target.value);
+    },
+    []
+  );
+
+  const optionList = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    let filtered = options;
+    if (query) {
+      filtered = options.filter((club) => {
+        const name = club.name.toLowerCase();
+        const id = club.id.toLowerCase();
+        return name.includes(query) || id.includes(query);
+      });
+    }
+    if (value) {
+      const selected = options.find((club) => club.id === value);
+      if (selected) {
+        filtered = [selected, ...filtered];
+      } else if (!filtered.some((club) => club.id === value)) {
+        filtered = [{ id: value, name: value }, ...filtered];
+      }
+    }
+    const seen = new Set<string>();
+    return filtered.filter((club) => {
+      if (seen.has(club.id)) return false;
+      seen.add(club.id);
+      return true;
+    });
+  }, [options, searchTerm, value]);
+
+  useEffect(() => {
+    if (dirtySearch) {
+      return;
+    }
+    if (!value) {
+      setSearchTerm((prev) => (prev ? "" : prev));
+      return;
+    }
+    const selected = options.find((club) => club.id === value);
+    const next = selected ? selected.name : value;
+    setSearchTerm((prev) => (prev === next ? prev : next));
+  }, [dirtySearch, options, value]);
+
+  const handleSelectChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextValue = event.target.value.trim();
+      setDirtySearch(false);
+      onChange(nextValue);
+    },
+    [onChange]
+  );
+
+  const clearSelection = useCallback(() => {
+    if (disabled) return;
+    setDirtySearch(false);
+    onChange("");
+  }, [disabled, onChange]);
+
+  return (
+    <div className={className} style={{ display: "grid", gap: "0.5rem" }}>
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={handleSearchChange}
+          onFocus={handleFocus}
+          placeholder={placeholder}
+          aria-label={ariaLabel ?? "Club search"}
+          disabled={disabled}
+          autoComplete="off"
+          style={{ flex: 1 }}
+        />
+        <button
+          type="button"
+          onClick={clearSelection}
+          disabled={disabled || (!value && !searchTerm)}
+        >
+          Clear
+        </button>
+      </div>
+      <select
+        value={value}
+        onChange={handleSelectChange}
+        onFocus={handleFocus}
+        disabled={disabled}
+        style={{ width: "100%" }}
+        aria-label={ariaLabel ?? "Select club"}
+      >
+        <option value="">No club selected</option>
+        {optionList.length ? (
+          optionList.map((club) => (
+            <option key={club.id} value={club.id}>
+              {club.name}
+            </option>
+          ))
+        ) : (
+          <option value="" disabled>
+            {status === "loading" ? "Loading clubs…" : "No clubs found"}
+          </option>
+        )}
+      </select>
+      {status === "loading" ? (
+        <span style={{ fontSize: "0.85rem", color: "#555" }}>
+          Loading clubs…
+        </span>
+      ) : null}
+      {status === "error" ? (
+        <span style={{ fontSize: "0.85rem", color: "#b91c1c" }}>
+          Failed to load clubs. Focus the field to try again.
+        </span>
+      ) : null}
+      {name ? <input type="hidden" name={name} value={value} /> : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -128,6 +128,18 @@ export async function updateMe(data: {
   return res.json();
 }
 
+export interface ClubSummary {
+  id: string;
+  name: string;
+}
+
+export async function fetchClubs(
+  init?: RequestInit
+): Promise<ClubSummary[]> {
+  const res = await apiFetch("/v0/clubs", init);
+  return res.json();
+}
+
 export interface PlayerMe {
   id: string;
   name: string;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .routers import (
     tournaments,
     auth,
     badges,
+    clubs,
 )
 from .routes import player as player_pages
 from .exceptions import DomainException, ProblemDetail
@@ -121,4 +122,5 @@ app.include_router(streams.router,      prefix=f"{API_PREFIX}/v0")
 app.include_router(tournaments.router,  prefix=f"{API_PREFIX}/v0")
 app.include_router(auth.router,         prefix=f"{API_PREFIX}/v0")
 app.include_router(badges.router,       prefix=f"{API_PREFIX}/v0")
+app.include_router(clubs.router,        prefix=f"{API_PREFIX}/v0")
 app.include_router(player_pages.router)

--- a/backend/app/routers/clubs.py
+++ b/backend/app/routers/clubs.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..models import Club
+from ..schemas import ClubOut
+
+router = APIRouter(prefix="/clubs", tags=["clubs"])
+
+
+@router.get("", response_model=list[ClubOut])
+async def list_clubs(session: AsyncSession = Depends(get_session)) -> list[ClubOut]:
+    rows = (await session.execute(select(Club).order_by(Club.name))).scalars().all()
+    return [ClubOut(id=club.id, name=club.name) for club in rows]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,6 +18,11 @@ class RuleSetOut(BaseModel):
     name: str
     config: dict
 
+
+class ClubOut(BaseModel):
+    id: str
+    name: str
+
 class BadgeCreate(BaseModel):
     name: str
     icon: Optional[str] = None


### PR DESCRIPTION
## Summary
- add a FastAPI router that exposes `/v0/clubs` and wire it into the main app
- introduce shared API helper and client-side ClubSelect component for loading and filtering clubs
- integrate the selector into the profile form and show human-readable club names on player pages

## Testing
- pytest
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d214f8651c83239cd9b3ba6b69210c