### PR TITLE
Add player biography support

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -9,6 +9,7 @@ export const dynamic = "force-dynamic";
 
 interface Player extends PlayerInfo {
   club_id?: string | null;
+  bio?: string | null;
   badges: Badge[];
 }
 
@@ -311,6 +312,9 @@ export default async function PlayerPage({
           <h1 className="heading">
             <PlayerName player={player} />
           </h1>
+          {player.bio ? (
+            <p className="mt-2 text-gray-700 whitespace-pre-line">{player.bio}</p>
+          ) : null}
           {player.club_id && <p>Club: {player.club_id}</p>}
 
           <nav className="mt-4 mb-4 space-x-4">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -46,8 +46,10 @@ export default function ProfilePage() {
   const [uploading, setUploading] = useState(false);
   const [countryCode, setCountryCode] = useState("");
   const [clubId, setClubId] = useState("");
+  const [bio, setBio] = useState("");
   const [initialCountryCode, setInitialCountryCode] = useState("");
   const [initialClubId, setInitialClubId] = useState("");
+  const [initialBio, setInitialBio] = useState("");
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -67,10 +69,13 @@ export default function ProfilePage() {
           if (!active) return;
           const nextCountry = player.country_code ?? "";
           const nextClub = player.club_id ?? "";
+          const nextBio = player.bio ?? "";
           setCountryCode(nextCountry);
           setClubId(nextClub);
+          setBio(nextBio);
           setInitialCountryCode(nextCountry);
           setInitialClubId(nextClub);
+          setInitialBio(nextBio);
         } catch (playerErr) {
           if (!active) return;
           const status = (playerErr as Error & { status?: number }).status;
@@ -83,6 +88,8 @@ export default function ProfilePage() {
             setInitialCountryCode("");
             setClubId("");
             setInitialClubId("");
+            setBio("");
+            setInitialBio("");
           } else {
             console.error("Failed to load player profile", playerErr);
             setError("Failed to load profile");
@@ -145,6 +152,8 @@ export default function ProfilePage() {
     }
     const normalizedCountry = countryCode.trim().toUpperCase();
     const trimmedClubId = clubId.trim();
+    const normalizedBio = bio.trim();
+    const bioChanged = bio !== initialBio;
 
     const hasValidCountry =
       !normalizedCountry ||
@@ -179,6 +188,10 @@ export default function ProfilePage() {
       payload.club_id = trimmedClubId ? trimmedClubId : null;
     }
 
+    if (bioChanged) {
+      payload.bio = normalizedBio ? normalizedBio : null;
+    }
+
     setSaving(true);
     try {
       if (Object.keys(payload).length > 0) {
@@ -186,10 +199,13 @@ export default function ProfilePage() {
           const updatedPlayer = await updateMyPlayerLocation(payload);
           const nextCountry = updatedPlayer.country_code ?? "";
           const nextClub = updatedPlayer.club_id ?? "";
+          const nextBio = updatedPlayer.bio ?? "";
           setCountryCode(nextCountry);
           setClubId(nextClub);
+          setBio(nextBio);
           setInitialCountryCode(nextCountry);
           setInitialClubId(nextClub);
+          setInitialBio(nextBio);
         } catch (err) {
           const status = (err as Error & { status?: number }).status;
           if (status === 422) {
@@ -281,6 +297,13 @@ export default function ProfilePage() {
           placeholder="New password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+        />
+        <textarea
+          aria-label="Bio"
+          placeholder="Tell us about yourself"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          rows={4}
         />
         <select
           aria-label="Country"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -136,6 +136,7 @@ export interface PlayerMe {
   region_code: string | null;
   club_id?: string | null;
   photo_url?: string | null;
+  bio?: string | null;
 }
 
 export type PlayerLocationPayload = {
@@ -143,6 +144,7 @@ export type PlayerLocationPayload = {
   country_code?: string | null;
   region_code?: string | null;
   club_id?: string | null;
+  bio?: string | null;
 };
 
 export async function fetchMyPlayer(): Promise<PlayerMe> {

--- a/backend/alembic/versions/0020_player_bio.py
+++ b/backend/alembic/versions/0020_player_bio.py
@@ -1,0 +1,27 @@
+"""add player biography column"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0020_player_bio"
+down_revision = "0019_glicko_ratings"
+branch_labels = None
+depends_on = None
+
+player_table = sa.table(
+    "player",
+    sa.column("id", sa.String()),
+    sa.column("bio", sa.Text()),
+)
+
+
+def upgrade() -> None:
+    op.add_column("player", sa.Column("bio", sa.Text(), nullable=True))
+
+    connection = op.get_bind()
+    connection.execute(player_table.update().values(bio=None))
+
+
+def downgrade() -> None:
+    op.drop_column("player", "bio")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,6 +40,7 @@ class Player(Base):
     name = Column(String, nullable=False)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
     photo_url = Column(String, nullable=True)
+    bio = Column(Text, nullable=True)
     location = Column(String, nullable=True)
     country_code = Column(String(2), nullable=True)
     region_code = Column(String(3), nullable=True)

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -96,6 +96,7 @@ async def create_player(
         name=normalized_name,
         club_id=body.club_id,
         photo_url=body.photo_url,
+        bio=(body.bio.strip() or None) if body.bio is not None else None,
         location=body.location,
         country_code=body.country_code,
         region_code=body.region_code,
@@ -109,6 +110,7 @@ async def create_player(
         name=p.name,
         club_id=p.club_id,
         photo_url=p.photo_url,
+        bio=p.bio,
         location=p.location,
         country_code=p.country_code,
         region_code=p.region_code,
@@ -139,6 +141,7 @@ async def list_players(
             name=p.name,
             club_id=p.club_id,
             photo_url=p.photo_url,
+            bio=p.bio,
             location=p.location,
             country_code=p.country_code,
             region_code=p.region_code,
@@ -192,6 +195,7 @@ async def _apply_player_location_update(
     country_value = player.country_code
     region_value = player.region_code
     club_value = player.club_id
+    bio_value = player.bio
 
     if "location" in fields_set:
         location_value = body.location
@@ -216,6 +220,14 @@ async def _apply_player_location_update(
             if exists is None:
                 raise HTTPException(status_code=422, detail="unknown club id")
 
+    if "bio" in fields_set:
+        raw_bio = body.bio
+        if raw_bio is None:
+            bio_value = None
+        else:
+            trimmed = raw_bio.strip()
+            bio_value = trimmed or None
+
     location_value, country_value, region_value = normalize_location_fields(
         location_value,
         country_value,
@@ -236,6 +248,9 @@ async def _apply_player_location_update(
 
     if "club_id" in fields_set:
         player.club_id = club_value
+
+    if "bio" in fields_set:
+        player.bio = bio_value
 
     await session.commit()
     return True
@@ -308,6 +323,7 @@ async def get_player(player_id: str, session: AsyncSession = Depends(get_session
         name=p.name,
         club_id=p.club_id,
         photo_url=p.photo_url,
+        bio=p.bio,
         location=p.location,
         country_code=p.country_code,
         region_code=p.region_code,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -37,6 +37,7 @@ class PlayerCreate(BaseModel):
     )
     club_id: Optional[str] = None
     photo_url: Optional[str] = None
+    bio: Optional[str] = None
     location: Optional[str] = None
     ranking: Optional[int] = None
     country_code: Optional[str] = None
@@ -68,6 +69,7 @@ class PlayerLocationUpdate(BaseModel):
     country_code: Optional[str] = None
     region_code: Optional[str] = None
     club_id: Optional[str] = None
+    bio: Optional[str] = None
 
     @field_validator("club_id", mode="after")
     @classmethod
@@ -107,6 +109,7 @@ class PlayerOut(BaseModel):
     name: str
     club_id: Optional[str] = None
     photo_url: Optional[str] = None
+    bio: Optional[str] = None
     location: Optional[str] = None
     ranking: Optional[int] = None
     country_code: Optional[str] = None


### PR DESCRIPTION
## Summary
- add a nullable biography column for players via Alembic migration and ORM/schema updates
- expose the bio through player endpoints, including self-update handling
- surface the biography field in the web app profile editor and public player view

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d214f0f8488323afd6d98d8be106c5