### PR TITLE
Add player social links backend and UI support

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { apiUrl } from "../../lib/api";
 
 // Identifier type for players
@@ -80,12 +80,15 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const appliedCountry = filters.country;
   const appliedClubId = filters.clubId;
 
-  const buildUrl = (sportId: string) => {
-    const params = new URLSearchParams({ sport: sportId });
-    if (appliedCountry) params.set("country", appliedCountry);
-    if (appliedClubId) params.set("clubId", appliedClubId);
-    return apiUrl(`/v0/leaderboards?${params.toString()}`);
-  };
+  const buildUrl = useCallback(
+    (sportId: string) => {
+      const params = new URLSearchParams({ sport: sportId });
+      if (appliedCountry) params.set("country", appliedCountry);
+      if (appliedClubId) params.set("clubId", appliedClubId);
+      return apiUrl(`/v0/leaderboards?${params.toString()}`);
+    },
+    [appliedCountry, appliedClubId]
+  );
 
   const supportsFilters = sport !== "master";
 
@@ -197,7 +200,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [sport, appliedCountry, appliedClubId]);
+  }, [sport, appliedCountry, appliedClubId, buildUrl]);
 
   const TableHeader = () => (
     <thead>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -136,6 +136,7 @@ export interface PlayerMe {
   region_code: string | null;
   club_id?: string | null;
   photo_url?: string | null;
+  social_links?: PlayerSocialLink[];
 }
 
 export type PlayerLocationPayload = {
@@ -143,6 +144,25 @@ export type PlayerLocationPayload = {
   country_code?: string | null;
   region_code?: string | null;
   club_id?: string | null;
+};
+
+export type PlayerSocialLink = {
+  id: string;
+  label: string;
+  url: string;
+  position: number;
+};
+
+export type PlayerSocialLinkPayload = {
+  label: string;
+  url: string;
+  position?: number;
+};
+
+export type PlayerSocialLinkUpdatePayload = {
+  label?: string;
+  url?: string;
+  position?: number;
 };
 
 export async function fetchMyPlayer(): Promise<PlayerMe> {
@@ -179,4 +199,38 @@ export async function updatePlayerLocation(
     body: JSON.stringify(body),
   });
   return res.json();
+}
+
+export async function createMySocialLink(
+  data: PlayerSocialLinkPayload
+): Promise<PlayerSocialLink> {
+  const res = await apiFetch("/v0/players/me/social-links", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+export async function updateMySocialLink(
+  id: string,
+  data: PlayerSocialLinkUpdatePayload
+): Promise<PlayerSocialLink> {
+  const payloadEntries = Object.entries(data).filter(
+    (entry): entry is [string, PlayerSocialLinkUpdatePayload[keyof PlayerSocialLinkUpdatePayload]] =>
+      entry[1] !== undefined
+  );
+  const body = Object.fromEntries(payloadEntries);
+  const res = await apiFetch(`/v0/players/me/social-links/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+export async function deleteMySocialLink(id: string): Promise<void> {
+  await apiFetch(`/v0/players/me/social-links/${id}`, {
+    method: "DELETE",
+  });
 }

--- a/backend/alembic/versions/0020_player_social_links.py
+++ b/backend/alembic/versions/0020_player_social_links.py
@@ -1,0 +1,56 @@
+"""Add player social links table
+
+"""Add player social links table
+
+Revision ID: 0020_player_social_links
+Revises: 0019_glicko_ratings
+Create Date: 2024-09-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0020_player_social_links"
+down_revision = "0019_glicko_ratings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "player_social_link",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.String(), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column(
+            "position",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["player_id"],
+            ["player.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_player_social_link_player_id_position",
+        "player_social_link",
+        ["player_id", "position"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_player_social_link_player_id_position", table_name="player_social_link")
+    op.drop_table("player_social_link")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -46,6 +46,13 @@ class Player(Base):
     ranking = Column(Integer, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 
+    social_links = relationship(
+        "PlayerSocialLink",
+        order_by="PlayerSocialLink.position",
+        cascade="all, delete-orphan",
+        back_populates="player",
+    )
+
     __table_args__ = (
         Index("uq_player_name_lower", func.lower(name), unique=True),
     )
@@ -71,6 +78,23 @@ class PlayerBadge(Base):
             name="uq_player_badge_player_id_badge_id",
         ),
     )
+
+
+class PlayerSocialLink(Base):
+    __tablename__ = "player_social_link"
+
+    id = Column(String, primary_key=True)
+    player_id = Column(
+        String,
+        ForeignKey("player.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label = Column(String, nullable=False)
+    url = Column(String, nullable=False)
+    position = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    player = relationship("Player", back_populates="social_links")
 
 class Team(Base):
     __tablename__ = "team"


### PR DESCRIPTION
## Summary
- add an alembic migration and SQLAlchemy models to store player social links with ordering
- expose social link data through PlayerOut plus new authenticated CRUD endpoints
- extend the web client to manage social links in the profile editor and render them on player pages

## Testing
- pytest tests/test_players.py
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2150ae7fc8323a34bd6ede6dc2b23