### PR TITLE
Fix player profile stats session usage

### DIFF
--- a/backend/app/routes/player.py
+++ b/backend/app/routes/player.py
@@ -24,7 +24,7 @@ async def player_profile(
     if not player or player.deleted_at is not None:
         raise HTTPException(status_code=404, detail="Player not found")
 
-    stats = await player_stats(player_id, session)
+    stats = await player_stats(player_id, session=session)
     player_out = PlayerOut(
         id=player.id,
         name=player.name,

--- a/backend/tests/test_player_profile_route.py
+++ b/backend/tests/test_player_profile_route.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import asyncio
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+
+from backend.app.db import get_session
+from backend.app.models import Player, Match, MatchParticipant, Sport
+from backend.app.routes import player as player_pages
+from backend.app.routers import players
+
+
+@pytest.fixture()
+def player_profile_client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    # Use SQLite JSON type for compatibility with MatchParticipant.player_ids
+    MatchParticipant.__table__.c.player_ids.type = SQLiteJSON()
+
+    async def init_models():
+        async with engine.begin() as conn:
+            await conn.run_sync(Sport.__table__.create)
+            await conn.run_sync(Player.__table__.create)
+            await conn.run_sync(Match.__table__.create)
+            await conn.run_sync(MatchParticipant.__table__.create)
+
+    asyncio.run(init_models())
+
+    async def override_get_session():
+        async with async_session_maker() as session:
+            yield session
+
+    app = FastAPI()
+    app.include_router(player_pages.router)
+    app.dependency_overrides[get_session] = override_get_session
+
+    asyncio.run(players.player_stats_cache.clear())
+    with TestClient(app) as client:
+        yield client, async_session_maker
+    asyncio.run(players.player_stats_cache.clear())
+
+
+def seed_basic_match(session_maker):
+    async def _seed():
+        async with session_maker() as session:
+            session.add(Sport(id="padel", name="Padel"))
+            session.add_all(
+                [
+                    Player(id="p1", name="Alice"),
+                    Player(id="p2", name="Bob"),
+                    Player(id="p3", name="Cara"),
+                    Player(id="p4", name="Dan"),
+                ]
+            )
+            session.add(
+                Match(
+                    id="m1",
+                    sport_id="padel",
+                    details={"sets": {"A": 2, "B": 0}},
+                )
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp1",
+                    match_id="m1",
+                    side="A",
+                    player_ids=["p1", "p2"],
+                )
+            )
+            session.add(
+                MatchParticipant(
+                    id="mp2",
+                    match_id="m1",
+                    side="B",
+                    player_ids=["p3", "p4"],
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_seed())
+
+
+def test_player_profile_includes_stats(player_profile_client):
+    client, session_maker = player_profile_client
+    seed_basic_match(session_maker)
+
+    response = client.get("/players/p1")
+    assert response.status_code == 200
+
+    stats = response.context["stats"]
+    assert stats.playerId == "p1"
+    assert stats.matchSummary.wins == 1
+    assert stats.matchSummary.total == 1


### PR DESCRIPTION
## Summary
- ensure the player profile route passes the database session to `player_stats` via keyword arguments
- add a FastAPI TestClient-based test that seeds sample data and verifies `/players/{id}` responds with populated stats

## Testing
- pytest backend/tests/test_player_profile_route.py

------
https://chatgpt.com/codex/tasks/task_e_68d218535b448323a4acb337b8d752b3