### PR TITLE
Add player social links

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -148,6 +148,7 @@ export interface PlayerMe {
   region_code: string | null;
   club_id?: string | null;
   photo_url?: string | null;
+  social_links?: PlayerSocialLink[];
 }
 
 export type PlayerLocationPayload = {
@@ -156,6 +157,20 @@ export type PlayerLocationPayload = {
   region_code?: string | null;
   club_id?: string | null;
 };
+
+export interface PlayerSocialLink {
+  id: string;
+  label: string;
+  url: string;
+  created_at: string;
+}
+
+export type PlayerSocialLinkCreatePayload = {
+  label: string;
+  url: string;
+};
+
+export type PlayerSocialLinkUpdatePayload = Partial<PlayerSocialLinkCreatePayload>;
 
 export async function fetchMyPlayer(): Promise<PlayerMe> {
   const res = await apiFetch("/v0/players/me");
@@ -175,6 +190,40 @@ export async function updateMyPlayerLocation(
     body: JSON.stringify(body),
   });
   return res.json();
+}
+
+export async function listMySocialLinks(): Promise<PlayerSocialLink[]> {
+  const res = await apiFetch("/v0/players/me/social-links");
+  return res.json();
+}
+
+export async function createMySocialLink(
+  data: PlayerSocialLinkCreatePayload
+): Promise<PlayerSocialLink> {
+  const res = await apiFetch("/v0/players/me/social-links", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+export async function updateMySocialLink(
+  linkId: string,
+  data: PlayerSocialLinkUpdatePayload
+): Promise<PlayerSocialLink> {
+  const res = await apiFetch(`/v0/players/me/social-links/${linkId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+export async function deleteMySocialLink(linkId: string): Promise<void> {
+  await apiFetch(`/v0/players/me/social-links/${linkId}`, {
+    method: "DELETE",
+  });
 }
 
 export async function updatePlayerLocation(

--- a/backend/alembic/versions/0020_player_social_links.py
+++ b/backend/alembic/versions/0020_player_social_links.py
@@ -1,0 +1,39 @@
+"""add player social links table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0020_player_social_links"
+down_revision = "0019_glicko_ratings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "player_social_link",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.String(), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["player_id"], ["player.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_player_social_link_player_id",
+        "player_social_link",
+        ["player_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_player_social_link_player_id", table_name="player_social_link")
+    op.drop_table("player_social_link")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -46,6 +46,13 @@ class Player(Base):
     ranking = Column(Integer, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 
+    social_links = relationship(
+        "PlayerSocialLink",
+        cascade="all, delete-orphan",
+        order_by="PlayerSocialLink.created_at",
+        back_populates="player",
+    )
+
     __table_args__ = (
         Index("uq_player_name_lower", func.lower(name), unique=True),
     )
@@ -127,6 +134,18 @@ class Rating(Base):
     player_id = Column(String, ForeignKey("player.id"), nullable=False)
     sport_id = Column(String, ForeignKey("sport.id"), nullable=False)
     value = Column(Float, nullable=False, default=1000)
+
+
+class PlayerSocialLink(Base):
+    __tablename__ = "player_social_link"
+
+    id = Column(String, primary_key=True)
+    player_id = Column(String, ForeignKey("player.id", ondelete="CASCADE"), nullable=False)
+    label = Column(String(100), nullable=False)
+    url = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    player = relationship("Player", back_populates="social_links")
 
 
 class GlickoRating(Base):


### PR DESCRIPTION
## Summary
- add a dedicated `player_social_link` table plus ORM and schema types for storing labelled URLs
- expose CRUD APIs for players to manage their own links and cover them with backend tests
- surface social links through the web app profile editor and public profile views

## Testing
- pytest backend/tests/test_players.py
- npm --prefix apps/web run lint

------
https://chatgpt.com/codex/tasks/task_e_68d21b9a41cc83238e0813a1d8bdab49