### PR TITLE
Add player biography support

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -9,6 +9,7 @@ export const dynamic = "force-dynamic";
 
 interface Player extends PlayerInfo {
   club_id?: string | null;
+  bio?: string | null;
   badges: Badge[];
   social_links?: PlayerSocialLink[];
 }
@@ -359,8 +360,28 @@ export default async function PlayerPage({
           <h1 className="heading">
             <PlayerName player={player} />
           </h1>
+          {player.bio ? (
+            <p
+              style={{
+                marginTop: "0.75rem",
+                marginBottom: player.club_id ? "0.5rem" : "1rem",
+                whiteSpace: "pre-wrap",
+                color: "#444",
+                lineHeight: 1.5,
+              }}
+            >
+              {player.bio}
+            </p>
+          ) : null}
           {player.club_id ? (
-            <p>Club: {clubName ?? player.club_id}</p>
+            <p
+              style={{
+                marginTop: player.bio ? "0" : "0.75rem",
+                marginBottom: "0.75rem",
+              }}
+            >
+              Club: {clubName ?? player.club_id}
+            </p>
           ) : null}
           {player.social_links && player.social_links.length ? (
             <div

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -51,8 +51,10 @@ export default function ProfilePage() {
   const [uploading, setUploading] = useState(false);
   const [countryCode, setCountryCode] = useState("");
   const [clubId, setClubId] = useState("");
+  const [bio, setBio] = useState("");
   const [initialCountryCode, setInitialCountryCode] = useState("");
   const [initialClubId, setInitialClubId] = useState("");
+  const [initialBio, setInitialBio] = useState("");
   const [saving, setSaving] = useState(false);
   const [socialLinks, setSocialLinks] = useState<PlayerSocialLink[]>([]);
   const [linkDrafts, setLinkDrafts] = useState<
@@ -90,11 +92,14 @@ export default function ProfilePage() {
           if (!active) return;
           const nextCountry = player.country_code ?? "";
           const nextClub = player.club_id ?? "";
+          const nextBio = player.bio ?? "";
           const nextLinks = player.social_links ?? [];
           setCountryCode(nextCountry);
           setClubId(nextClub);
+          setBio(nextBio);
           setInitialCountryCode(nextCountry);
           setInitialClubId(nextClub);
+          setInitialBio(nextBio);
           resetSocialLinkState(nextLinks);
         } catch (playerErr) {
           if (!active) return;
@@ -108,6 +113,8 @@ export default function ProfilePage() {
             setInitialCountryCode("");
             setClubId("");
             setInitialClubId("");
+            setBio("");
+            setInitialBio("");
             resetSocialLinkState([]);
           } else {
             console.error("Failed to load player profile", playerErr);
@@ -183,6 +190,8 @@ export default function ProfilePage() {
     const continentCode = normalizedCountry
       ? getContinentForCountry(normalizedCountry)
       : undefined;
+    const trimmedBio = bio.trim();
+    const initialBioTrimmed = initialBio.trim();
 
     setUsername(trimmedUsername);
     setCountryCode(normalizedCountry);
@@ -190,6 +199,7 @@ export default function ProfilePage() {
 
     const countryChanged = normalizedCountry !== initialCountryCode;
     const clubChanged = trimmedClubId !== initialClubId;
+    const bioChanged = trimmedBio !== initialBioTrimmed;
 
     const payload: PlayerLocationPayload = {};
 
@@ -205,6 +215,10 @@ export default function ProfilePage() {
       payload.club_id = trimmedClubId ? trimmedClubId : null;
     }
 
+    if (bioChanged) {
+      payload.bio = trimmedBio ? trimmedBio : null;
+    }
+
     setSaving(true);
     try {
       if (Object.keys(payload).length > 0) {
@@ -212,10 +226,13 @@ export default function ProfilePage() {
           const updatedPlayer = await updateMyPlayerLocation(payload);
           const nextCountry = updatedPlayer.country_code ?? "";
           const nextClub = updatedPlayer.club_id ?? "";
+          const nextBioValue = updatedPlayer.bio ?? "";
           setCountryCode(nextCountry);
           setClubId(nextClub);
+          setBio(nextBioValue);
           setInitialCountryCode(nextCountry);
           setInitialClubId(nextClub);
+          setInitialBio(nextBioValue);
           resetSocialLinkState(updatedPlayer.social_links ?? []);
         } catch (err) {
           const status = (err as Error & { status?: number }).status;
@@ -230,6 +247,8 @@ export default function ProfilePage() {
       } else {
         setInitialCountryCode(normalizedCountry);
         setInitialClubId(trimmedClubId);
+        setBio(trimmedBio);
+        setInitialBio(trimmedBio);
       }
 
       const body: { username: string; password?: string } = {
@@ -331,6 +350,29 @@ export default function ProfilePage() {
           ariaLabel="Favorite club"
           name="club_id"
         />
+        <label
+          style={{ display: "grid", gap: "0.5rem", width: "100%" }}
+          htmlFor="profile-bio"
+        >
+          <span>Biography</span>
+          <textarea
+            id="profile-bio"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            rows={4}
+            maxLength={2000}
+            placeholder="Tell other players about yourself"
+            style={{
+              width: "100%",
+              minHeight: "6rem",
+              padding: "0.5rem",
+              fontFamily: "inherit",
+              fontSize: "1rem",
+              lineHeight: 1.4,
+              resize: "vertical",
+            }}
+          />
+        </label>
         <button type="submit" disabled={saving}>
           Save
         </button>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -148,6 +148,7 @@ export interface PlayerMe {
   region_code: string | null;
   club_id?: string | null;
   photo_url?: string | null;
+  bio?: string | null;
   social_links?: PlayerSocialLink[];
 }
 
@@ -156,6 +157,7 @@ export type PlayerLocationPayload = {
   country_code?: string | null;
   region_code?: string | null;
   club_id?: string | null;
+  bio?: string | null;
 };
 
 export interface PlayerSocialLink {

--- a/backend/alembic/versions/0021_player_bio.py
+++ b/backend/alembic/versions/0021_player_bio.py
@@ -1,0 +1,21 @@
+"""Add bio column to player"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0021_player_bio"
+down_revision = "0020_player_social_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("player", sa.Column("bio", sa.Text(), nullable=True))
+    op.execute(sa.text("UPDATE player SET bio = '' WHERE bio IS NULL"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("UPDATE player SET bio = NULL"))
+    op.drop_column("player", "bio")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,6 +40,7 @@ class Player(Base):
     name = Column(String, nullable=False)
     club_id = Column(String, ForeignKey("club.id"), nullable=True)
     photo_url = Column(String, nullable=True)
+    bio = Column(Text, nullable=True)
     location = Column(String, nullable=True)
     country_code = Column(String(2), nullable=True)
     region_code = Column(String(3), nullable=True)

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -100,6 +100,7 @@ async def create_player(
         name=normalized_name,
         club_id=body.club_id,
         photo_url=body.photo_url,
+        bio=body.bio,
         location=body.location,
         country_code=body.country_code,
         region_code=body.region_code,
@@ -113,6 +114,7 @@ async def create_player(
         name=p.name,
         club_id=p.club_id,
         photo_url=p.photo_url,
+        bio=p.bio,
         location=p.location,
         country_code=p.country_code,
         region_code=p.region_code,
@@ -144,6 +146,7 @@ async def list_players(
             name=p.name,
             club_id=p.club_id,
             photo_url=p.photo_url,
+            bio=p.bio,
             location=p.location,
             country_code=p.country_code,
             region_code=p.region_code,
@@ -335,6 +338,7 @@ async def _apply_player_location_update(
     country_value = player.country_code
     region_value = player.region_code
     club_value = player.club_id
+    bio_value = player.bio
 
     if "location" in fields_set:
         location_value = body.location
@@ -359,6 +363,9 @@ async def _apply_player_location_update(
             if exists is None:
                 raise HTTPException(status_code=422, detail="unknown club id")
 
+    if "bio" in fields_set:
+        bio_value = body.bio
+
     location_value, country_value, region_value = normalize_location_fields(
         location_value,
         country_value,
@@ -379,6 +386,9 @@ async def _apply_player_location_update(
 
     if "club_id" in fields_set:
         player.club_id = club_value
+
+    if "bio" in fields_set:
+        player.bio = bio_value
 
     await session.commit()
     return True
@@ -446,6 +456,7 @@ async def get_player(player_id: str, session: AsyncSession = Depends(get_session
         name=p.name,
         club_id=p.club_id,
         photo_url=p.photo_url,
+        bio=p.bio,
         location=p.location,
         country_code=p.country_code,
         region_code=p.region_code,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -126,10 +126,21 @@ class PlayerCreate(BaseModel):
     )
     club_id: Optional[str] = None
     photo_url: Optional[str] = None
+    bio: Optional[str] = Field(default=None, max_length=2000)
     location: Optional[str] = None
     ranking: Optional[int] = None
     country_code: Optional[str] = None
     region_code: Optional[str] = None
+
+    @field_validator("bio", mode="before")
+    @classmethod
+    def _normalize_bio(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("bio must be a string")
+        trimmed = value.strip()
+        return trimmed or None
 
     @model_validator(mode="after")
     def _normalize_location(cls, model: "PlayerCreate") -> "PlayerCreate":
@@ -157,6 +168,7 @@ class PlayerLocationUpdate(BaseModel):
     country_code: Optional[str] = None
     region_code: Optional[str] = None
     club_id: Optional[str] = None
+    bio: Optional[str] = Field(default=None, max_length=2000)
 
     @field_validator("club_id", mode="after")
     @classmethod
@@ -167,6 +179,16 @@ class PlayerLocationUpdate(BaseModel):
             trimmed = value.strip()
             return trimmed or None
         raise TypeError("club_id must be a string")
+
+    @field_validator("bio", mode="before")
+    @classmethod
+    def _normalize_bio(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("bio must be a string")
+        trimmed = value.strip()
+        return trimmed or None
 
     @model_validator(mode="after")
     def _normalize_location(
@@ -196,6 +218,7 @@ class PlayerOut(BaseModel):
     name: str
     club_id: Optional[str] = None
     photo_url: Optional[str] = None
+    bio: Optional[str] = None
     location: Optional[str] = None
     ranking: Optional[int] = None
     country_code: Optional[str] = None


### PR DESCRIPTION
## Summary
- add an Alembic migration to introduce a nullable `bio` column on players
- expose and persist player biographies across the backend models, schemas, and handlers
- surface the biography field in the web app for editing the profile and viewing public player pages

## Testing
- pytest backend/tests/test_players.py

------
https://chatgpt.com/codex/tasks/task_e_68d2202cda4c83238542b04f8eed0e84