### PR TITLE
Handle empty matches state

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -95,4 +95,20 @@ describe("MatchesPage", () => {
     expect(prev).toBeDisabled();
     expect(next).toBeDisabled();
   });
+
+  it("renders an empty state when there are no matches", async () => {
+    const fetchMock = vi
+      .fn()
+      // list matches
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    global.fetch = fetchMock as typeof fetch;
+
+    const page = await MatchesPage({ searchParams: {} });
+    render(page);
+
+    expect(await screen.findByText("No matches yet.")).toBeInTheDocument();
+    expect(screen.queryByText("Next")).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -144,45 +144,55 @@ export default async function MatchesPage(
     const disablePrev = offset <= 0;
     const disableNext = rows.length < limit;
 
+    const hasMatches = matches.length > 0;
+
     return (
       <main className="container">
         <h1 className="heading">Matches</h1>
-        <ul className="match-list">
-          {matches.map((m) => (
-            <li key={m.id} className="card match-item">
-              <div style={{ fontWeight: 500 }}>
-                {m.participants.map((side, i) => (
-                  <span key={i}>
-                    {side.map((pl, j) => (
-                      <span key={pl.id}>
-                        <PlayerName player={pl} />
-                        {j < side.length - 1 ? " & " : ""}
+        {hasMatches ? (
+          <>
+            <ul className="match-list">
+              {matches.map((m) => (
+                <li key={m.id} className="card match-item">
+                  <div style={{ fontWeight: 500 }}>
+                    {m.participants.map((side, i) => (
+                      <span key={i}>
+                        {side.map((pl, j) => (
+                          <span key={pl.id}>
+                            <PlayerName player={pl} />
+                            {j < side.length - 1 ? " & " : ""}
+                          </span>
+                        ))}
+                        {i < m.participants.length - 1 ? " vs " : ""}
                       </span>
                     ))}
-                    {i < m.participants.length - 1 ? " vs " : ""}
-                  </span>
-                ))}
-              </div>
-              <div className="match-meta">
-                {formatSummary(m.summary)}
-                {m.summary ? " · " : ""}
-                {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-                {m.playedAt ? new Date(m.playedAt).toLocaleDateString() : "—"} ·{" "}
-                {m.location ?? "—"}
-              </div>
-              <div>
-                <Link href={`/matches/${m.id}`}>More info</Link>
-              </div>
-            </li>
-          ))}
-        </ul>
-        <Pager
-          limit={limit}
-          prevOffset={prevOffset}
-          nextOffset={nextOffset}
-          disablePrev={disablePrev}
-          disableNext={disableNext}
-        />
+                  </div>
+                  <div className="match-meta">
+                    {formatSummary(m.summary)}
+                    {m.summary ? " · " : ""}
+                    {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
+                    {m.playedAt
+                      ? new Date(m.playedAt).toLocaleDateString()
+                      : "—"} ·{" "}
+                    {m.location ?? "—"}
+                  </div>
+                  <div>
+                    <Link href={`/matches/${m.id}`}>More info</Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <Pager
+              limit={limit}
+              prevOffset={prevOffset}
+              nextOffset={nextOffset}
+              disablePrev={disablePrev}
+              disableNext={disableNext}
+            />
+          </>
+        ) : (
+          <p className="empty-state">No matches yet.</p>
+        )}
       </main>
     );
   } catch {


### PR DESCRIPTION
## Summary
- render a friendly empty state on the matches page and only show the pager when matches exist
- add coverage for the empty matches scenario in the matches page tests

## Testing
- npm test -- --run src/app/matches/page.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d228d39a988323bb7c0bcea9254ab0