### PR TITLE
Handle padel save errors gracefully

### DIFF
--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -138,9 +138,11 @@ export default function RecordPadelPage() {
       }
       setSuccess(true);
       router.push(`/matches`);
-    } catch {
+    } catch (err) {
+      console.error("Failed to save padel match", err);
       setSaving(false);
-      // ignore network errors
+      setSuccess(false);
+      setError("Failed to save match. Please try again.");
     }
   };
 


### PR DESCRIPTION
## Summary
- show a friendly error and reset UI state when saving a padel match fails
- add a regression test that covers failing POST requests on the padel record page

## Testing
- pnpm --dir apps/web test src/app/record/padel/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d228ccfe4883239b87ab6b485d79ac