### PR TITLE
Allow displaying Albert players

### DIFF
--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -117,7 +117,7 @@ describe("PlayersPage", () => {
     vi.useRealTimers();
   });
 
-  it("filters out Albert accounts", async () => {
+  it("renders players even when named Albert", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -129,6 +129,14 @@ describe("PlayersPage", () => {
           ],
         }),
       })
+      .mockResolvedValueOnce(
+        mockStatsResponse({
+          playerId: "1",
+          wins: 5,
+          losses: 2,
+          winPct: 0.7142857143,
+        })
+      )
       .mockResolvedValueOnce(
         mockStatsResponse({
           playerId: "2",
@@ -143,8 +151,10 @@ describe("PlayersPage", () => {
       render(<PlayersPage />);
     });
 
-    expect(screen.queryByText("Albert")).toBeNull();
-    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(await screen.findByText("Albert")).toBeTruthy();
+    expect(await screen.findByText("Bob")).toBeTruthy();
+    expect(await screen.findByText("5-2 (71%)")).toBeTruthy();
+    expect(await screen.findByText("4-1 (80%)")).toBeTruthy();
   });
 
   it("shows a message when no players match the search", async () => {

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -54,10 +54,7 @@ export default function PlayersPage() {
       });
       if (res.ok) {
         const data = await res.json();
-        const filtered = (data.players as Player[]).filter(
-          (p) => !p.name.toLowerCase().startsWith("albert")
-        );
-        setPlayers(filtered);
+        setPlayers(data.players as Player[]);
       } else {
         setError("Failed to load players.");
       }


### PR DESCRIPTION
## Summary
- remove the hard-coded filter that dropped players whose names start with Albert
- update the players page test to expect Albert to render with his stats

## Testing
- pnpm vitest run src/app/players/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d228d3ac608323b6665c899cad124d