### PR TITLE
Keep matches pager accessible when page empty

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -145,53 +145,56 @@ export default async function MatchesPage(
     const disableNext = rows.length < limit;
 
     const hasMatches = matches.length > 0;
+    const showPager = hasMatches || offset > 0;
 
     return (
       <main className="container">
         <h1 className="heading">Matches</h1>
         {hasMatches ? (
-          <>
-            <ul className="match-list">
-              {matches.map((m) => (
-                <li key={m.id} className="card match-item">
-                  <div style={{ fontWeight: 500 }}>
-                    {m.participants.map((side, i) => (
-                      <span key={i}>
-                        {side.map((pl, j) => (
-                          <span key={pl.id}>
-                            <PlayerName player={pl} />
-                            {j < side.length - 1 ? " & " : ""}
-                          </span>
-                        ))}
-                        {i < m.participants.length - 1 ? " vs " : ""}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="match-meta">
-                    {formatSummary(m.summary)}
-                    {m.summary ? " · " : ""}
-                    {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-                    {m.playedAt
-                      ? new Date(m.playedAt).toLocaleDateString()
-                      : "—"} ·{" "}
-                    {m.location ?? "—"}
-                  </div>
-                  <div>
-                    <Link href={`/matches/${m.id}`}>More info</Link>
-                  </div>
-                </li>
-              ))}
-            </ul>
-            <Pager
-              limit={limit}
-              prevOffset={prevOffset}
-              nextOffset={nextOffset}
-              disablePrev={disablePrev}
-              disableNext={disableNext}
-            />
-          </>
+          <ul className="match-list">
+            {matches.map((m) => (
+              <li key={m.id} className="card match-item">
+                <div style={{ fontWeight: 500 }}>
+                  {m.participants.map((side, i) => (
+                    <span key={i}>
+                      {side.map((pl, j) => (
+                        <span key={pl.id}>
+                          <PlayerName player={pl} />
+                          {j < side.length - 1 ? " & " : ""}
+                        </span>
+                      ))}
+                      {i < m.participants.length - 1 ? " vs " : ""}
+                    </span>
+                  ))}
+                </div>
+                <div className="match-meta">
+                  {formatSummary(m.summary)}
+                  {m.summary ? " · " : ""}
+                  {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
+                  {m.playedAt
+                    ? new Date(m.playedAt).toLocaleDateString()
+                    : "—"} ·{" "}
+                  {m.location ?? "—"}
+                </div>
+                <div>
+                  <Link href={`/matches/${m.id}`}>More info</Link>
+                </div>
+              </li>
+            ))}
+          </ul>
         ) : (
-          <p className="empty-state">No matches yet.</p>
+          <p className="empty-state">
+            {offset > 0 ? "No matches on this page." : "No matches yet."}
+          </p>
+        )}
+        {showPager && (
+          <Pager
+            limit={limit}
+            prevOffset={prevOffset}
+            nextOffset={nextOffset}
+            disablePrev={disablePrev}
+            disableNext={disableNext}
+          />
         )}
       </main>
     );


### PR DESCRIPTION
## Summary
- keep rendering the matches pager when navigating to empty result pages
- clarify the empty state copy for empty datasets versus empty pages

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68d22af9ac488323876a99d112f3bc14