### PR TITLE
Handle missing disc golf match id

### DIFF
--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -8,13 +8,14 @@ const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 function DiscGolfForm() {
   const params = useSearchParams();
   const mid = params.get("mid") || "";
+  const hasMatchId = Boolean(mid);
   const [hole, setHole] = useState(1);
   const [a, setA] = useState("");
   const [b, setB] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const submit = async () => {
-    if (!mid) return;
+    if (!hasMatchId) return;
     setError(null);
     const events = [
       { type: "HOLE", side: "A", hole, strokes: Number(a) },
@@ -39,6 +40,12 @@ function DiscGolfForm() {
   return (
     <main className="container">
       <h1 className="heading">Record Disc Golf</h1>
+      {!hasMatchId && (
+        <p>
+          Select a match before recording scores. Open this page from a match
+          scoreboard or include a match id in the link.
+        </p>
+      )}
       <p>Hole {hole}</p>
       <div className="scores">
         <input
@@ -46,15 +53,19 @@ function DiscGolfForm() {
           placeholder="A"
           value={a}
           onChange={(e) => setA(e.target.value)}
+          disabled={!hasMatchId}
         />
         <input
           type="number"
           placeholder="B"
           value={b}
           onChange={(e) => setB(e.target.value)}
+          disabled={!hasMatchId}
         />
       </div>
-      <button onClick={submit}>Record Hole</button>
+      <button onClick={submit} disabled={!hasMatchId}>
+        Record Hole
+      </button>
       {error && <p>{error}</p>}
     </main>
   );


### PR DESCRIPTION
## Summary
- show guidance when the disc golf recorder page is opened without a match id and disable the inputs/button
- keep submissions gated on a match id before posting hole events
- extend the disc golf recorder tests to cover the missing match id state

## Testing
- npx vitest run src/app/record/disc-golf/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d22b80c6c48323a91db905975024e3