### PR TITLE
Handle missing table rollbacks in player stats

### DIFF
--- a/backend/app/routes/player.py
+++ b/backend/app/routes/player.py
@@ -24,7 +24,6 @@ async def player_profile(
     if not player or player.deleted_at is not None:
         raise HTTPException(status_code=404, detail="Player not found")
 
-    stats = await player_stats(player_id, session=session)
     player_out = PlayerOut(
         id=player.id,
         name=player.name,
@@ -35,6 +34,8 @@ async def player_profile(
         region_code=player.region_code,
         ranking=player.ranking,
     )
+
+    stats = await player_stats(player_id, session=session)
     return templates.TemplateResponse(
         "player/profile.html",
         {"request": request, "player": player_out, "stats": stats},


### PR DESCRIPTION
## Summary
- add a helper that rolls back the current async session if a transaction is active
- use the helper when loading player social links and during optional rating lookups so missing tables leave the session usable
- build the player profile response data before computing stats to avoid accessing expired ORM objects after a rollback

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2730d8448832399c5b2574a8957fc