### PR TITLE
Handle stats fetch errors

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -193,12 +193,16 @@ async function getUpcomingMatches(playerId: string): Promise<EnrichedMatch[]> {
 }
 
 async function getStats(playerId: string): Promise<PlayerStats | null> {
-  const r = await apiFetch(
-    `/v0/players/${encodeURIComponent(playerId)}/stats`,
-    { cache: "no-store" } as RequestInit
-  );
-  if (!r.ok) return null;
-  return (await r.json()) as PlayerStats;
+  try {
+    const r = await apiFetch(
+      `/v0/players/${encodeURIComponent(playerId)}/stats`,
+      { cache: "no-store" } as RequestInit
+    );
+    if (!r.ok) return null;
+    return (await r.json()) as PlayerStats;
+  } catch {
+    return null;
+  }
 }
 
 function formatMatchSummary(summary: MatchSummary): string {


### PR DESCRIPTION
## Summary
- return null from `getStats` when the stats request fails so the fallback message can render

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d28b22282883239ea2acc6d0a5cbe7