### PR TITLE
Normalize player photo URLs across frontend

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { apiFetch, isAdmin } from "../../../lib/api";
+import { apiFetch, isAdmin, withAbsolutePhotoUrl } from "../../../lib/api";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
 
 type MatchRow = {
@@ -69,7 +69,7 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
         if (p.id) {
           remaining.delete(p.id);
           if (p.name) {
-            idToPlayer.set(p.id, p);
+            idToPlayer.set(p.id, withAbsolutePhotoUrl(p));
           } else {
             missing.push(p.id);
             idToPlayer.set(p.id, { id: p.id, name: "Unknown" });

--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -3,15 +3,20 @@ import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 import { execSync } from "child_process";
 
-vi.mock("../../../lib/api", () => ({
-  apiFetch: vi.fn(),
-  apiUrl: (p: string) => p,
-}));
+const apiFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../lib/api")>(
+    "../../../lib/api"
+  );
+  return {
+    ...actual,
+    apiFetch: apiFetchMock,
+    apiUrl: (p: string) => p,
+  };
+});
 
 import MatchDetailPage from "./page";
-import { apiFetch } from "../../../lib/api";
-
-const apiFetchMock = apiFetch as unknown as ReturnType<typeof vi.fn>;
 
 describe("MatchDetailPage", () => {
   afterEach(() => {

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { apiFetch } from "../../../lib/api";
+import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary, { type SummaryData } from "./live-summary";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
 
@@ -53,7 +53,7 @@ async function fetchPlayers(ids: string[]): Promise<Map<string, PlayerInfo>> {
     if (p.id) {
       remaining.delete(p.id);
       if (p.name) {
-        map.set(p.id, p);
+        map.set(p.id, withAbsolutePhotoUrl(p));
       } else {
         missing.push(p.id);
         map.set(p.id, { id: p.id, name: "Unknown" });

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { apiFetch } from "../../lib/api";
+import { apiFetch, withAbsolutePhotoUrl } from "../../lib/api";
 import Pager from "./pager";
 import PlayerName, { PlayerInfo } from "../../components/PlayerName";
 
@@ -76,7 +76,12 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
         if (p.id) {
           remaining.delete(p.id);
           if (p.name) {
-            idToPlayer.set(p.id, p as PlayerInfo);
+            const info: PlayerInfo = {
+              id: p.id,
+              name: p.name,
+              photo_url: p.photo_url ?? null,
+            };
+            idToPlayer.set(p.id, withAbsolutePhotoUrl(info));
           } else {
             missing.push(p.id);
             idToPlayer.set(p.id, { id: p.id, name: "Unknown" });

--- a/apps/web/src/app/players/[id]/PhotoUpload.tsx
+++ b/apps/web/src/app/players/[id]/PhotoUpload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { apiFetch } from '../../../lib/api';
+import { apiFetch, ensureAbsoluteApiUrl } from '../../../lib/api';
 
 interface Props {
   playerId: string;
@@ -24,7 +24,11 @@ export default function PhotoUpload({ playerId, initialUrl }: Props) {
     });
     if (r.ok) {
       const data = (await r.json()) as { photo_url?: string };
-      setUrl(data.photo_url ?? null);
+      setUrl(
+        typeof data.photo_url === 'string' && data.photo_url
+          ? ensureAbsoluteApiUrl(data.photo_url)
+          : null
+      );
     }
     setUploading(false);
   };

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { apiFetch, fetchClubs } from "../../../lib/api";
+import { apiFetch, fetchClubs, withAbsolutePhotoUrl } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
@@ -86,7 +86,8 @@ async function getPlayer(id: string): Promise<Player> {
     cache: "no-store",
   } as RequestInit);
   if (!res.ok) throw new Error("player");
-  return (await res.json()) as Player;
+  const data = (await res.json()) as Player;
+  return withAbsolutePhotoUrl(data);
 }
 
 async function getMatches(
@@ -134,7 +135,7 @@ async function getMatches(
         if (p.id) {
           remaining.delete(p.id);
           if (p.name) {
-            idToPlayer.set(p.id, p);
+            idToPlayer.set(p.id, withAbsolutePhotoUrl(p));
           } else {
             missing.push(p.id);
             idToPlayer.set(p.id, { id: p.id, name: "Unknown" });

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { apiFetch, isAdmin, updatePlayerLocation } from "../../lib/api";
+import {
+  apiFetch,
+  isAdmin,
+  updatePlayerLocation,
+  withAbsolutePhotoUrl,
+} from "../../lib/api";
 import { COUNTRY_OPTIONS } from "../../lib/countries";
 import PlayerName, { PlayerInfo } from "../../components/PlayerName";
 
@@ -54,7 +59,10 @@ export default function PlayersPage() {
       });
       if (res.ok) {
         const data = await res.json();
-        setPlayers(data.players as Player[]);
+        const normalized = ((data.players as Player[]) ?? []).map((p) =>
+          withAbsolutePhotoUrl(p)
+        );
+        setPlayers(normalized);
       } else {
         setError("Failed to load players.");
       }

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -13,6 +13,7 @@ import {
   updateMySocialLink,
   deleteMySocialLink,
   type PlayerSocialLink,
+  ensureAbsoluteApiUrl,
 } from "../../lib/api";
 import type { PlayerLocationPayload } from "../../lib/api";
 import ClubSelect from "../../components/ClubSelect";
@@ -86,7 +87,11 @@ export default function ProfilePage() {
         const me = await fetchMe();
         if (!active) return;
         setUsername(me.username);
-        setPhotoUrl(me.photo_url ?? null);
+        setPhotoUrl(
+          typeof me.photo_url === "string" && me.photo_url
+            ? ensureAbsoluteApiUrl(me.photo_url)
+            : null
+        );
         try {
           const player = await fetchMyPlayer();
           if (!active) return;
@@ -151,7 +156,11 @@ export default function ProfilePage() {
         body: form,
       });
       const data = (await res.json()) as { photo_url?: string };
-      setPhotoUrl(data.photo_url ?? null);
+      setPhotoUrl(
+        typeof data.photo_url === "string" && data.photo_url
+          ? ensureAbsoluteApiUrl(data.photo_url)
+          : null
+      );
       setMessage("Profile photo updated");
     } catch {
       setError("Photo upload failed");

--- a/apps/web/src/components/PlayerName.tsx
+++ b/apps/web/src/components/PlayerName.tsx
@@ -1,3 +1,5 @@
+import { ensureAbsoluteApiUrl } from '../lib/api';
+
 export type PlayerInfo = {
   id: string;
   name: string;
@@ -5,12 +7,16 @@ export type PlayerInfo = {
 };
 
 export default function PlayerName({ player }: { player: PlayerInfo }) {
+  const photoUrl =
+    typeof player.photo_url === 'string' && player.photo_url
+      ? ensureAbsoluteApiUrl(player.photo_url)
+      : null;
   return (
     <span className="player-name" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-      {player.photo_url && (
+      {photoUrl && (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={player.photo_url}
+          src={photoUrl}
           alt={player.name}
           width={24}
           height={24}

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -25,7 +25,7 @@ export type EnrichedMatch = MatchRow & {
   players: Record<string, PlayerInfo[]>;
 };
 
-import { apiFetch } from './api';
+import { apiFetch, withAbsolutePhotoUrl } from './api';
 
 export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   const details = await Promise.all(
@@ -57,7 +57,7 @@ export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> 
         if (p.id) {
           remaining.delete(p.id);
           if (p.name) {
-            idToPlayer.set(p.id, p);
+            idToPlayer.set(p.id, withAbsolutePhotoUrl(p));
           } else {
             missing.push(p.id);
             idToPlayer.set(p.id, { id: p.id, name: 'Unknown' });


### PR DESCRIPTION
## Summary
- add helpers to convert API-relative paths to absolute URLs and apply them to player-facing API responses
- normalize player photos when enriching matches and player lists so UI components receive absolute URLs
- update photo rendering components and profile tests to verify relative paths resolve correctly

## Testing
- pnpm test run

------
https://chatgpt.com/codex/tasks/task_e_68d28fb3d97883239f3a2127bbaa9abb