### PR TITLE
Fix profile fetchMe typing for auth/me response

### DIFF
--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -53,7 +53,12 @@ describe("ProfilePage", () => {
     apiMocks.updateMySocialLink.mockReset();
     apiMocks.deleteMySocialLink.mockReset();
     apiMocks.isLoggedIn.mockReturnValue(true);
-    apiMocks.fetchMe.mockResolvedValue({ username: "default-user", photo_url: null });
+    apiMocks.fetchMe.mockResolvedValue({
+      id: "user-default",
+      username: "default-user",
+      is_admin: false,
+      photo_url: null,
+    });
     apiMocks.fetchMyPlayer.mockResolvedValue({
       id: "default-player",
       name: "Default Player",
@@ -72,7 +77,12 @@ describe("ProfilePage", () => {
   });
 
   it("loads and displays existing player details", async () => {
-    apiMocks.fetchMe.mockResolvedValue({ username: "existing", photo_url: "photo.png" });
+    apiMocks.fetchMe.mockResolvedValue({
+      id: "user-existing",
+      username: "existing",
+      is_admin: false,
+      photo_url: "photo.png",
+    });
     apiMocks.fetchMyPlayer.mockResolvedValue({
       id: "player-1",
       name: "Existing Player",
@@ -97,7 +107,9 @@ describe("ProfilePage", () => {
 
   it("normalizes relative profile photo URLs", async () => {
     apiMocks.fetchMe.mockResolvedValue({
+      id: "user-relative",
       username: "relative-user",
+      is_admin: false,
       photo_url: "/media/photos/me.png",
     });
 
@@ -110,7 +122,11 @@ describe("ProfilePage", () => {
   });
 
   it("submits updated country and favorite club when saving", async () => {
-    apiMocks.fetchMe.mockResolvedValue({ username: "existing" });
+    apiMocks.fetchMe.mockResolvedValue({
+      id: "user-existing",
+      username: "existing",
+      is_admin: false,
+    });
     apiMocks.fetchMyPlayer.mockResolvedValue({
       id: "player-1",
       name: "Existing Player",
@@ -169,7 +185,11 @@ describe("ProfilePage", () => {
   });
 
   it("allows clearing country and club", async () => {
-    apiMocks.fetchMe.mockResolvedValue({ username: "existing" });
+    apiMocks.fetchMe.mockResolvedValue({
+      id: "user-existing",
+      username: "existing",
+      is_admin: false,
+    });
     apiMocks.fetchMyPlayer.mockResolvedValue({
       id: "player-1",
       name: "Existing Player",

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -13,6 +13,7 @@ import {
   updateMySocialLink,
   deleteMySocialLink,
   type PlayerSocialLink,
+  type UserMe,
   ensureAbsoluteApiUrl,
 } from "../../lib/api";
 import type { PlayerLocationPayload } from "../../lib/api";
@@ -84,7 +85,7 @@ export default function ProfilePage() {
     let active = true;
     (async () => {
       try {
-        const me = await fetchMe();
+        const me: UserMe = await fetchMe();
         if (!active) return;
         setUsername(me.username);
         setPhotoUrl(

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -136,22 +136,37 @@ export function isAdmin(): boolean {
   return !!payload?.is_admin;
 }
 
-export async function fetchMe() {
+export interface UserMe {
+  id: string;
+  username: string;
+  is_admin: boolean;
+  photo_url?: string | null;
+}
+
+export async function fetchMe(): Promise<UserMe> {
   const res = await apiFetch("/v0/auth/me");
-  const data = (await res.json()) as PlayerMe;
+  const data = (await res.json()) as UserMe;
   return withAbsolutePhotoUrl(data);
 }
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+export type UpdateMeResponse = Partial<TokenResponse>;
 
 export async function updateMe(data: {
   username?: string;
   password?: string;
-}) {
+}): Promise<UpdateMeResponse> {
   const res = await apiFetch("/v0/auth/me", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
-  return res.json();
+  const payload = (await res.json()) as UpdateMeResponse;
+  return payload;
 }
 
 export interface ClubSummary {


### PR DESCRIPTION
## Summary
- add a dedicated UserMe interface and token response typing for auth endpoints
- update the profile page to use the typed auth/me response when loading the current user
- refresh profile page tests to mock the full auth/me payload

## Testing
- pnpm test --run src/app/profile/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d2a223edc88323ab088bf043dc0059