### PR TITLE
Fix client photo URL normalization duplication

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,33 @@ export function ensureAbsoluteApiUrl(
   if (path === '') return path;
   if (path.startsWith('//')) return path;
   if (ABSOLUTE_URL_REGEX.test(path)) return path;
+
+  if (path.startsWith('/')) {
+    const base = apiBase();
+
+    if (!ABSOLUTE_URL_REGEX.test(base)) {
+      const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+      if (path.startsWith(normalizedBase)) {
+        return path;
+      }
+    } else {
+      try {
+        const baseUrl = new URL(base);
+        const pathnameWithTrailingSlash = baseUrl.pathname.endsWith('/')
+          ? baseUrl.pathname
+          : `${baseUrl.pathname}/`;
+        if (
+          baseUrl.pathname === '/' ||
+          path.startsWith(pathnameWithTrailingSlash)
+        ) {
+          return `${baseUrl.origin}${path}`;
+        }
+      } catch {
+        // If the base URL cannot be parsed, fall through to the default logic.
+      }
+    }
+  }
+
   return apiUrl(path);
 }
 


### PR DESCRIPTION
## Summary
- avoid re-prefixing the API base in `ensureAbsoluteApiUrl` when a path already includes the base segment
- preserve the correct origin for absolute API bases so photo URLs stay valid instead of producing `/api/api/...`

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d2ae9910b08323a252a0f4c1d906c8