### PR TITLE
Improve padel record form accessibility and validation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -38,6 +38,59 @@ a {
   margin: 0 auto;
 }
 
+.datetime {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.datetime .field-group {
+  flex: 1 1 160px;
+  min-width: 160px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.field-hint {
+  color: #555;
+  font-size: 0.85rem;
+  margin-top: -4px;
+}
+
+.field-group select,
+.field-group input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.players {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.sets .set {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.input-error {
+  border: 1px solid var(--color-accent-red);
+  box-shadow: 0 0 0 1px var(--color-accent-red);
+}
+
 .heading {
   margin-top: 0;
   color: var(--color-accent-red);

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -39,22 +39,22 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
     fireEvent.change(screen.getByPlaceholderText("Location"), {
       target: { value: "Center Court" },
     });
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player A2"), {
+    fireEvent.change(screen.getByLabelText("Player A 2"), {
       target: { value: "p2" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p3" },
     });
-    fireEvent.change(screen.getByLabelText("Player B2"), {
+    fireEvent.change(screen.getByLabelText("Player B 2"), {
       target: { value: "p4" },
     });
 
@@ -121,9 +121,9 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
 
@@ -137,7 +137,7 @@ describe("RecordPadelPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
@@ -162,12 +162,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p1" },
     });
 
@@ -181,12 +181,73 @@ describe("RecordPadelPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("validates incomplete set scores before submission", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "p1", name: "A" },
+            { id: "p2", name: "B" },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "m1" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordPadelPage />);
+
+    await waitFor(() => screen.getByLabelText("Player A 1"));
+
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
+      target: { value: "p1" },
+    });
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
+      target: { value: "p2" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
+      target: { value: "6" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Set 1 is incomplete/i),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByPlaceholderText("Set 1 A")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByPlaceholderText("Set 1 B")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+
+    fireEvent.change(screen.getByPlaceholderText("Set 1 B"), {
+      target: { value: "4" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Set 1 A")).not.toHaveAttribute("aria-invalid"),
+    );
+    expect(screen.getByPlaceholderText("Set 1 B")).not.toHaveAttribute("aria-invalid");
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
   });
 
   it("shows an error when saving the match fails", async () => {
@@ -206,12 +267,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
 
@@ -248,12 +309,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
 

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -29,6 +29,33 @@ interface CreateMatchPayload {
   location?: string;
 }
 
+function getDatePlaceholder(locale: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+    const sample = formatter.formatToParts(new Date(Date.UTC(2020, 11, 31)));
+    return sample
+      .map((part) => {
+        switch (part.type) {
+          case "day":
+            return "dd";
+          case "month":
+            return "mm";
+          case "year":
+            return "yyyy";
+          default:
+            return part.value;
+        }
+      })
+      .join("");
+  } catch {
+    return "yyyy-mm-dd";
+  }
+}
+
 export default function RecordPadelPage() {
   const router = useRouter();
   const [players, setPlayers] = useState<Player[]>([]);
@@ -41,6 +68,11 @@ export default function RecordPadelPage() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [invalidSetIndexes, setInvalidSetIndexes] = useState<number[]>([]);
+  const [dateLocale, setDateLocale] = useState<string>("en-US");
+  const [datePlaceholder, setDatePlaceholder] = useState<string>(
+    getDatePlaceholder("en-US"),
+  );
 
   useEffect(() => {
     async function loadPlayers() {
@@ -60,6 +92,13 @@ export default function RecordPadelPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const locale = window.navigator?.language || "en-US";
+    setDateLocale(locale);
+    setDatePlaceholder(getDatePlaceholder(locale));
+  }, []);
+
   const handleIdChange = (key: keyof IdMap, value: string) => {
     setIds((prev) => ({ ...prev, [key]: value }));
   };
@@ -70,6 +109,7 @@ export default function RecordPadelPage() {
       next[idx] = { ...next[idx], [side]: value };
       return next;
     });
+    setInvalidSetIndexes((prev) => prev.filter((i) => i !== idx));
   };
 
   const addSet = () => {
@@ -80,7 +120,9 @@ export default function RecordPadelPage() {
     e.preventDefault();
     if (saving) return;
     setError(null);
+    setSuccess(false);
     setSaving(true);
+    setInvalidSetIndexes([]);
 
     const idValues = [ids.a1, ids.a2, ids.b1, ids.b2];
     const filtered = idValues.filter((v) => v);
@@ -103,6 +145,65 @@ export default function RecordPadelPage() {
       { side: "B", playerIds: sideB },
     ];
 
+    const trimmedSets = sets.map((set) => ({
+      A: set.A.trim(),
+      B: set.B.trim(),
+    }));
+    const invalidIndexes: number[] = [];
+    const completeSets: { index: number; set: { A: number; B: number } }[] = [];
+
+    trimmedSets.forEach((set, index) => {
+      const hasA = set.A !== "";
+      const hasB = set.B !== "";
+
+      if (!hasA && !hasB) {
+        return;
+      }
+
+      if (!hasA || !hasB) {
+        invalidIndexes.push(index);
+        return;
+      }
+
+      const parsedA = Number(set.A);
+      const parsedB = Number(set.B);
+
+      if (!Number.isFinite(parsedA) || !Number.isFinite(parsedB) || parsedA < 0 || parsedB < 0) {
+        invalidIndexes.push(index);
+        return;
+      }
+
+      completeSets.push({ index, set: { A: parsedA, B: parsedB } });
+    });
+
+    if (invalidIndexes.length) {
+      setInvalidSetIndexes(invalidIndexes);
+      const setList = invalidIndexes.map((i) => `Set ${i + 1}`).join(", ");
+      setError(
+        invalidIndexes.length === 1
+          ? `${setList} is incomplete. Enter both non-negative scores.`
+          : `${setList} are incomplete. Enter both non-negative scores.`,
+      );
+      setSaving(false);
+      return;
+    }
+
+    const maxSets = Number(bestOf);
+    if (completeSets.length > maxSets) {
+      const extraSets = completeSets.slice(maxSets);
+      const extras = extraSets.map(({ index }) => `Set ${index + 1}`);
+      setInvalidSetIndexes(extraSets.map(({ index }) => index));
+      setError(
+        `Best of ${bestOf} allows at most ${maxSets} completed sets. Remove ${extras.join(
+          ", ",
+        )} or adjust the format.`,
+      );
+      setSaving(false);
+      return;
+    }
+
+    const setsForPayload = completeSets.map(({ set }) => set);
+
     try {
       const payload: CreateMatchPayload = {
         sport: "padel",
@@ -124,16 +225,11 @@ export default function RecordPadelPage() {
         body: JSON.stringify(payload),
       });
       const data = (await res.json()) as { id: string };
-      const setPayload = {
-        sets: sets
-          .filter((s) => s.A !== "" && s.B !== "")
-          .map((s) => ({ A: Number(s.A), B: Number(s.B) })),
-      };
-      if (setPayload.sets.length) {
+      if (setsForPayload.length) {
         await apiFetch(`/v0/matches/${data.id}/sets`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(setPayload),
+          body: JSON.stringify({ sets: setsForPayload }),
         });
       }
       setSuccess(true);
@@ -150,86 +246,128 @@ export default function RecordPadelPage() {
     <main className="container">
       <form onSubmit={handleSubmit}>
         <div className="datetime">
-          <input
-            type="date"
-            aria-label="Date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-          />
-          <input
-            type="time"
-            aria-label="Time"
-            value={time}
-            onChange={(e) => setTime(e.target.value)}
-          />
+          <div className="field-group">
+            <label className="field-label" htmlFor="match-date">
+              Date
+            </label>
+            <input
+              id="match-date"
+              type="date"
+              lang={dateLocale}
+              aria-describedby="match-date-format"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+            <small id="match-date-format" className="field-hint">
+              Format: {datePlaceholder}
+            </small>
+          </div>
+          <div className="field-group">
+            <label className="field-label" htmlFor="match-time">
+              Time
+            </label>
+            <input
+              id="match-time"
+              type="time"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+          </div>
         </div>
 
-        <input
-          type="text"
-          aria-label="Location"
-          placeholder="Location"
-          value={location}
-          onChange={(e) => setLocation(e.target.value)}
-        />
+        <div className="field-group">
+          <label className="field-label" htmlFor="match-location">
+            Location
+          </label>
+          <input
+            id="match-location"
+            type="text"
+            placeholder="Location"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+          />
+        </div>
 
         <div className="players">
-          <select
-            aria-label="Player A1"
-            value={ids.a1}
-            onChange={(e) => handleIdChange("a1", e.target.value)}
-          >
-            <option value="">Select player</option>
-            {players.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+          <div className="field-group">
+            <label className="field-label" htmlFor="player-a1">
+              Player A 1
+            </label>
+            <select
+              id="player-a1"
+              value={ids.a1}
+              onChange={(e) => handleIdChange("a1", e.target.value)}
+            >
+              <option value="">Select player</option>
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-          <select
-            aria-label="Player A2"
-            value={ids.a2}
-            onChange={(e) => handleIdChange("a2", e.target.value)}
-          >
-            <option value="">Select player</option>
-            {players.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+          <div className="field-group">
+            <label className="field-label" htmlFor="player-a2">
+              Player A 2
+            </label>
+            <select
+              id="player-a2"
+              value={ids.a2}
+              onChange={(e) => handleIdChange("a2", e.target.value)}
+            >
+              <option value="">Select player</option>
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-          <select
-            aria-label="Player B1"
-            value={ids.b1}
-            onChange={(e) => handleIdChange("b1", e.target.value)}
-          >
-            <option value="">Select player</option>
-            {players.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+          <div className="field-group">
+            <label className="field-label" htmlFor="player-b1">
+              Player B 1
+            </label>
+            <select
+              id="player-b1"
+              value={ids.b1}
+              onChange={(e) => handleIdChange("b1", e.target.value)}
+            >
+              <option value="">Select player</option>
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-          <select
-            aria-label="Player B2"
-            value={ids.b2}
-            onChange={(e) => handleIdChange("b2", e.target.value)}
-          >
-            <option value="">Select player</option>
-            {players.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+          <div className="field-group">
+            <label className="field-label" htmlFor="player-b2">
+              Player B 2
+            </label>
+            <select
+              id="player-b2"
+              value={ids.b2}
+              onChange={(e) => handleIdChange("b2", e.target.value)}
+            >
+              <option value="">Select player</option>
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
-        <label>
-          Best of
+        <div className="field-group">
+          <label className="field-label" htmlFor="best-of">
+            Best of
+          </label>
           <select
-            aria-label="Best of"
+            id="best-of"
             value={bestOf}
             onChange={(e) => setBestOf(e.target.value)}
           >
@@ -237,7 +375,7 @@ export default function RecordPadelPage() {
             <option value="3">3</option>
             <option value="5">5</option>
           </select>
-        </label>
+        </div>
 
         <div className="sets">
           {sets.map((s, idx) => (
@@ -249,6 +387,8 @@ export default function RecordPadelPage() {
                 placeholder={`Set ${idx + 1} A`}
                 value={s.A}
                 onChange={(e) => handleSetChange(idx, "A", e.target.value)}
+                aria-invalid={invalidSetIndexes.includes(idx) ? true : undefined}
+                className={invalidSetIndexes.includes(idx) ? "input-error" : undefined}
               />
               <input
                 type="number"
@@ -257,6 +397,8 @@ export default function RecordPadelPage() {
                 placeholder={`Set ${idx + 1} B`}
                 value={s.B}
                 onChange={(e) => handleSetChange(idx, "B", e.target.value)}
+                aria-invalid={invalidSetIndexes.includes(idx) ? true : undefined}
+                className={invalidSetIndexes.includes(idx) ? "input-error" : undefined}
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary
- add visible labels to padel player selectors, location, and best-of controls while styling the layout for clarity
- localize the padel match date picker based on the user locale and surface the expected format to players
- validate set entry before submission, highlight problematic sets, and extend tests for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b496bdb883239665b44df1a33f6c