### PR TITLE
Improve bowling record form

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -297,3 +297,98 @@ a {
   overflow-x: auto;
   font-size: 0.85rem;
 }
+
+.bowling-players {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.bowling-player {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(10, 31, 68, 0.04);
+  border-radius: 8px;
+}
+
+.bowling-player-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.bowling-player-header select {
+  min-width: 200px;
+}
+
+.bowling-remove {
+  background: none;
+  border: none;
+  color: var(--color-accent-red);
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.bowling-remove:hover {
+  text-decoration: underline;
+}
+
+.bowling-frames {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+.bowling-frame {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  background: var(--color-surface);
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(10, 31, 68, 0.08);
+}
+
+.bowling-frame-number {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.bowling-frame-rolls {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+}
+
+.bowling-frame-rolls input {
+  padding: 6px;
+  text-align: center;
+}
+
+.bowling-add {
+  align-self: flex-start;
+  padding: 8px 16px;
+  background: var(--color-accent-blue);
+  color: var(--color-surface);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.bowling-add:hover {
+  background: #155ab8;
+}
+
+@media (max-width: 600px) {
+  .bowling-frames {
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  }
+
+  .bowling-player-header select {
+    min-width: 160px;
+  }
+}


### PR DESCRIPTION
## Summary
- add bowling frame parsing and validation to compute totals before match submission
- replace the bowling score input with frame-by-frame entry and the ability to add or remove bowlers
- style the bowling form with a grid layout so each player’s frames and rolls are easy to enter

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b4c56e108323979a4061526eecf2