### PR TITLE
Improve padel match recording form usability

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -110,6 +110,11 @@ img {
   font-weight: 600;
 }
 
+.form-hint {
+  font-size: 0.8rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
 input,
 select,
 textarea,

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -39,22 +39,22 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
     fireEvent.change(screen.getByPlaceholderText("Location"), {
       target: { value: "Center Court" },
     });
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player A2"), {
+    fireEvent.change(screen.getByLabelText("Player A 2"), {
       target: { value: "p2" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p3" },
     });
-    fireEvent.change(screen.getByLabelText("Player B2"), {
+    fireEvent.change(screen.getByLabelText("Player B 2"), {
       target: { value: "p4" },
     });
 
@@ -121,9 +121,9 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
 
@@ -137,7 +137,7 @@ describe("RecordPadelPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
@@ -162,12 +162,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p1" },
     });
 
@@ -181,12 +181,60 @@ describe("RecordPadelPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows validation errors for incomplete set scores", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          players: [
+            { id: "p1", name: "A" },
+            { id: "p2", name: "B" },
+          ],
+        }),
+      });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordPadelPage />);
+
+    await waitFor(() => screen.getByLabelText("Player A 1"));
+
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
+      target: { value: "p1" },
+    });
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
+      target: { value: "p2" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
+      target: { value: "6" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("alert").some((alert) =>
+          alert.textContent?.includes("Enter a score for both teams."),
+        ),
+      ).toBe(true),
+    );
+
+    expect(
+      screen.getAllByRole("alert").some((alert) =>
+        alert.textContent?.includes("Please fix the highlighted set scores before saving."),
+      ),
+    ).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
   });
 
   it("shows an error when saving the match fails", async () => {
@@ -206,12 +254,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
 
@@ -248,12 +296,12 @@ describe("RecordPadelPage", () => {
 
     render(<RecordPadelPage />);
 
-    await waitFor(() => screen.getByLabelText("Player A1"));
+    await waitFor(() => screen.getByLabelText("Player A 1"));
 
-    fireEvent.change(screen.getByLabelText("Player A1"), {
+    fireEvent.change(screen.getByLabelText("Player A 1"), {
       target: { value: "p1" },
     });
-    fireEvent.change(screen.getByLabelText("Player B1"), {
+    fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
 

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
@@ -36,6 +36,7 @@ export default function RecordPadelPage() {
   const [ids, setIds] = useState<IdMap>({ a1: "", a2: "", b1: "", b2: "" });
   const [bestOf, setBestOf] = useState("3");
   const [sets, setSets] = useState<SetScore[]>([{ A: "", B: "" }]);
+  const [setErrors, setSetErrors] = useState<string[]>([""]);
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
   const [location, setLocation] = useState("");
@@ -72,16 +73,70 @@ export default function RecordPadelPage() {
       next[idx] = { ...next[idx], [side]: value };
       return next;
     });
+    setSetErrors((prev) => {
+      const next = [...prev];
+      next[idx] = "";
+      return next;
+    });
   };
 
   const addSet = () => {
     setSets((prev) => [...prev, { A: "", B: "" }]);
+    setSetErrors((prev) => [...prev, ""]);
+  };
+
+  const datePlaceholder = useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+    const parts = formatter.formatToParts(new Date(2001, 10, 21));
+    return parts
+      .map((part) => {
+        if (part.type === "day") return "dd";
+        if (part.type === "month") return "mm";
+        if (part.type === "year") return "yyyy";
+        return part.value;
+      })
+      .join("");
+  }, [locale]);
+
+  const validateSets = () => {
+    const errors = sets.map(() => "");
+    let hasErrors = false;
+
+    sets.forEach((set, idx) => {
+      const a = set.A.trim();
+      const b = set.B.trim();
+
+      if (!a && !b) {
+        return;
+      }
+
+      if ((a && !b) || (!a && b)) {
+        errors[idx] = "Enter a score for both teams.";
+        hasErrors = true;
+        return;
+      }
+
+      const aNum = Number(a);
+      const bNum = Number(b);
+      if (!Number.isInteger(aNum) || aNum < 0 || !Number.isInteger(bNum) || bNum < 0) {
+        errors[idx] = "Scores must be whole numbers of zero or more.";
+        hasErrors = true;
+      }
+    });
+
+    setSetErrors(errors);
+    return !hasErrors;
   };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (saving) return;
     setError(null);
+    setSuccess(false);
     setSaving(true);
 
     const idValues = [ids.a1, ids.a2, ids.b1, ids.b2];
@@ -89,6 +144,7 @@ export default function RecordPadelPage() {
     if (new Set(filtered).size !== filtered.length) {
       setError("Please select unique players.");
       setSaving(false);
+      setSuccess(false);
       return;
     }
 
@@ -96,6 +152,13 @@ export default function RecordPadelPage() {
     const sideB = [ids.b1, ids.b2].filter(Boolean);
     if (!sideA.length || !sideB.length) {
       setError("Select at least one player for each side");
+      setSaving(false);
+      setSuccess(false);
+      return;
+    }
+
+    if (!validateSets()) {
+      setError("Please fix the highlighted set scores before saving.");
       setSaving(false);
       return;
     }
@@ -162,7 +225,12 @@ export default function RecordPadelPage() {
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 lang={locale}
+                placeholder={datePlaceholder}
+                aria-describedby="padel-date-format"
               />
+              <span id="padel-date-format" className="form-hint">
+                Format: {datePlaceholder}
+              </span>
             </label>
             <label className="form-field" htmlFor="padel-time">
               <span className="form-label">Start time</span>
@@ -191,7 +259,7 @@ export default function RecordPadelPage() {
           <legend className="form-legend">Players</legend>
           <div className="form-grid form-grid--two">
             <label className="form-field" htmlFor="padel-player-a1">
-              <span className="form-label">Team A player 1</span>
+              <span className="form-label">Player A 1</span>
               <select
                 id="padel-player-a1"
                 value={ids.a1}
@@ -207,7 +275,7 @@ export default function RecordPadelPage() {
             </label>
 
             <label className="form-field" htmlFor="padel-player-a2">
-              <span className="form-label">Team A player 2</span>
+              <span className="form-label">Player A 2</span>
               <select
                 id="padel-player-a2"
                 value={ids.a2}
@@ -223,7 +291,7 @@ export default function RecordPadelPage() {
             </label>
 
             <label className="form-field" htmlFor="padel-player-b1">
-              <span className="form-label">Team B player 1</span>
+              <span className="form-label">Player B 1</span>
               <select
                 id="padel-player-b1"
                 value={ids.b1}
@@ -239,7 +307,7 @@ export default function RecordPadelPage() {
             </label>
 
             <label className="form-field" htmlFor="padel-player-b2">
-              <span className="form-label">Team B player 2</span>
+              <span className="form-label">Player B 2</span>
               <select
                 id="padel-player-b2"
                 value={ids.b2}
@@ -269,36 +337,49 @@ export default function RecordPadelPage() {
         </fieldset>
 
         <div className="sets">
-          {sets.map((s, idx) => (
-            <div key={idx} className="set">
-              <label className="form-field" htmlFor={`padel-set-${idx + 1}-a`}>
-                <span className="form-label">Set {idx + 1} team A</span>
-                <input
-                  id={`padel-set-${idx + 1}-a`}
-                  type="number"
-                  min="0"
-                  step="1"
-                  placeholder={`Set ${idx + 1} A`}
-                  value={s.A}
-                  onChange={(e) => handleSetChange(idx, "A", e.target.value)}
-                  inputMode="numeric"
-                />
-              </label>
-              <label className="form-field" htmlFor={`padel-set-${idx + 1}-b`}>
-                <span className="form-label">Set {idx + 1} team B</span>
-                <input
-                  id={`padel-set-${idx + 1}-b`}
-                  type="number"
-                  min="0"
-                  step="1"
-                  placeholder={`Set ${idx + 1} B`}
-                  value={s.B}
-                  onChange={(e) => handleSetChange(idx, "B", e.target.value)}
-                  inputMode="numeric"
-                />
-              </label>
-            </div>
-          ))}
+          {sets.map((s, idx) => {
+            const setError = setErrors[idx];
+            const errorId = setError ? `padel-set-${idx + 1}-error` : undefined;
+            return (
+              <div key={idx} className="set">
+                <label className="form-field" htmlFor={`padel-set-${idx + 1}-a`}>
+                  <span className="form-label">Set {idx + 1} team A</span>
+                  <input
+                    id={`padel-set-${idx + 1}-a`}
+                    type="number"
+                    min="0"
+                    step="1"
+                    placeholder={`Set ${idx + 1} A`}
+                    value={s.A}
+                    onChange={(e) => handleSetChange(idx, "A", e.target.value)}
+                    inputMode="numeric"
+                    aria-invalid={Boolean(setError)}
+                    aria-describedby={errorId}
+                  />
+                </label>
+                <label className="form-field" htmlFor={`padel-set-${idx + 1}-b`}>
+                  <span className="form-label">Set {idx + 1} team B</span>
+                  <input
+                    id={`padel-set-${idx + 1}-b`}
+                    type="number"
+                    min="0"
+                    step="1"
+                    placeholder={`Set ${idx + 1} B`}
+                    value={s.B}
+                    onChange={(e) => handleSetChange(idx, "B", e.target.value)}
+                    inputMode="numeric"
+                    aria-invalid={Boolean(setError)}
+                    aria-describedby={errorId}
+                  />
+                </label>
+                {setError && (
+                  <p id={errorId} role="alert" className="error">
+                    {setError}
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </div>
         <button type="button" onClick={addSet}>
           Add Set


### PR DESCRIPTION
## Summary
- add locale-aware date placeholder and descriptive player labels to the padel match form
- validate set entries with inline feedback before submitting a match
- update styling and tests to cover the new labels and validation rules

## Testing
- npx vitest run src/app/record/padel/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d33ae46c808323aad2d72028fdb109