### PR TITLE
Simplify all-sports leaderboards

### DIFF
--- a/apps/web/src/app/all-sports/page.tsx
+++ b/apps/web/src/app/all-sports/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../leaderboard/master/page";

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -67,11 +67,6 @@ export default function Header() {
               Leaderboard
             </Link>
           </li>
-          <li>
-            <Link href="/leaderboard/master" onClick={() => setOpen(false)}>
-              All Sports
-            </Link>
-          </li>
           {admin && (
             <>
               <li>

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -66,7 +66,7 @@ describe("Leaderboard", () => {
     );
   });
 
-  it("passes region filters to each sport when viewing the combined board", async () => {
+  it("ignores region filters when viewing the combined board", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue({ ok: true, json: async () => [] });
@@ -76,8 +76,12 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
-    expect(urls).toContain(
+    expect(urls).toContain(apiUrl("/v0/leaderboards?sport=disc_golf"));
+    expect(urls).not.toContain(
       apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")
+    );
+    await waitFor(() =>
+      expect(replaceMock).toHaveBeenCalledWith("/leaderboard", { scroll: false })
     );
   });
 });


### PR DESCRIPTION
## Summary
- clarify the leaderboard navigation by removing the duplicate header link, renaming the combined tab, and expanding the global empty-state copy
- ensure region filters are only enabled for individual sport tabs, clean up unsupported query parameters, and explain where filters apply
- add an /all-sports alias for the master leaderboard and refresh the related test coverage

## Testing
- pnpm vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68d2b4fe56888323940220b384d451a6