### PR TITLE
Remove duplicate locale hook declaration

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -43,7 +43,6 @@ export default function RecordSportPage() {
   const [doubles, setDoubles] = useState(isPadel);
   const [submitting, setSubmitting] = useState(false);
   const locale = useLocale();
-  const locale = useLocale();
 
   useEffect(() => {
     async function loadPlayers() {


### PR DESCRIPTION
## Summary
- remove the duplicated `useLocale` hook declaration on the record sport page to prevent redeclaration errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34059d07883239c95972b47dd530a