### PR TITLE
Improve match participant layout

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -266,6 +266,48 @@ textarea {
   margin-bottom: 8px;
 }
 
+.match-participants {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+.match-participants__side-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.match-participants__side {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.match-participants__entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.match-participants__separator,
+.match-participants__versus {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.match-participants__separator {
+  font-weight: 600;
+}
+
+.match-participants__versus {
+  font-weight: 600;
+}
+
 .match-meta {
   color: #555;
   font-size: 0.9rem;

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -184,17 +184,39 @@ export default async function MatchesPage(
           <ul className="match-list">
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
-                <div style={{ fontWeight: 500 }}>
-                  {m.participants.map((side, i) => (
-                    <span key={i}>
-                      {side.map((pl, j) => (
-                        <span key={pl.id}>
-                          <PlayerName player={pl} />
-                          {j < side.length - 1 ? " & " : ""}
+                <div className="match-participants">
+                  {m.participants.map((side, sideIndex) => (
+                    <div
+                      key={sideIndex}
+                      className="match-participants__side-wrapper"
+                    >
+                      {sideIndex > 0 && (
+                        <span
+                          className="match-participants__versus"
+                          aria-label="versus"
+                        >
+                          vs
                         </span>
-                      ))}
-                      {i < m.participants.length - 1 ? " vs " : ""}
-                    </span>
+                      )}
+                      <div className="match-participants__side">
+                        {side.map((pl, playerIndex) => (
+                          <span
+                            key={pl.id}
+                            className="match-participants__entry"
+                          >
+                            {playerIndex > 0 && (
+                              <span
+                                className="match-participants__separator"
+                                aria-label="and"
+                              >
+                                &
+                              </span>
+                            )}
+                            <PlayerName player={pl} />
+                          </span>
+                        ))}
+                      </div>
+                    </div>
                   ))}
                 </div>
                 <div className="match-meta">


### PR DESCRIPTION
## Summary
- replace inline separator strings in match cards with structured markup so names and separators render consistently
- add flex-based styling for participant rows to keep partners and versus labels aligned without awkward wrapping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d340a7ecb4832392c768283a5d5c26