### PR TITLE
Consolidate all sports leaderboards

### DIFF
--- a/apps/web/src/app/all-sports/page.tsx
+++ b/apps/web/src/app/all-sports/page.tsx
@@ -1,23 +1,24 @@
 import { redirect } from "next/navigation";
 
-type LeaderboardSearchParams = {
+const toSingleValue = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value;
+
+type SearchParams = {
   country?: string | string[];
   clubId?: string | string[];
 };
 
-const toSingleValue = (value?: string | string[]) =>
-  Array.isArray(value) ? value[0] : value;
-
-export default function MasterLeaderboardPage({
+export default function AllSportsRedirect({
   searchParams,
 }: {
-  searchParams?: LeaderboardSearchParams;
+  searchParams?: SearchParams;
 }) {
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
-  const params = new URLSearchParams({ tab: "master" });
+
+  const params = new URLSearchParams({ tab: "all" });
   if (country) params.set("country", country);
   if (clubId) params.set("clubId", clubId);
+
   redirect(`/leaderboard?${params.toString()}`);
 }
-

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -64,12 +64,7 @@ export default function Header() {
           </li>
           <li>
             <Link href="/leaderboard" onClick={() => setOpen(false)}>
-              Leaderboard
-            </Link>
-          </li>
-          <li>
-            <Link href="/leaderboard/master" onClick={() => setOpen(false)}>
-              All Sports
+              Leaderboards
             </Link>
           </li>
           {admin && (

--- a/apps/web/src/app/leaderboard/[sport]/page.tsx
+++ b/apps/web/src/app/leaderboard/[sport]/page.tsx
@@ -1,4 +1,5 @@
-import Leaderboard from "../leaderboard";
+import { redirect } from "next/navigation";
+import { ALL_SPORTS, SPORTS } from "../leaderboard";
 
 type LeaderboardSearchParams = {
   country?: string | string[];
@@ -8,6 +9,9 @@ type LeaderboardSearchParams = {
 const toSingleValue = (value?: string | string[]) =>
   Array.isArray(value) ? value[0] : value;
 
+const isSupportedSport = (value: string) =>
+  value === ALL_SPORTS || (SPORTS as readonly string[]).includes(value);
+
 export default function LeaderboardSportPage({
   params,
   searchParams,
@@ -15,7 +19,21 @@ export default function LeaderboardSportPage({
   params: { sport: string };
   searchParams?: LeaderboardSearchParams;
 }) {
+  const { sport } = params;
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
-  return <Leaderboard sport={params.sport} country={country} clubId={clubId} />;
+
+  if (!isSupportedSport(sport)) {
+    const fallback = new URLSearchParams();
+    if (country) fallback.set("country", country);
+    if (clubId) fallback.set("clubId", clubId);
+    const query = fallback.toString();
+    redirect(query ? `/leaderboard?${query}` : "/leaderboard");
+  }
+
+  const paramsWithFilters = new URLSearchParams({ tab: sport });
+  if (country) paramsWithFilters.set("country", country);
+  if (clubId) paramsWithFilters.set("clubId", clubId);
+
+  redirect(`/leaderboard?${paramsWithFilters.toString()}`);
 }

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,12 +1,30 @@
-import Leaderboard from "./leaderboard";
+import { redirect } from "next/navigation";
+import Leaderboard, { ALL_SPORTS, SPORTS } from "./leaderboard";
 
 type LeaderboardSearchParams = {
   country?: string | string[];
   clubId?: string | string[];
+  tab?: string | string[];
+  sport?: string | string[];
 };
 
 const toSingleValue = (value?: string | string[]) =>
   Array.isArray(value) ? value[0] : value;
+
+const resolveTab = (raw?: string) => {
+  if (!raw) return ALL_SPORTS;
+  if (raw === "master" || raw === ALL_SPORTS) return raw;
+  if ((SPORTS as readonly string[]).includes(raw)) return raw;
+  return null;
+};
+
+const buildFilterQuery = (country?: string, clubId?: string) => {
+  const params = new URLSearchParams();
+  if (country) params.set("country", country);
+  if (clubId) params.set("clubId", clubId);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+};
 
 export default function LeaderboardIndexPage({
   searchParams,
@@ -15,5 +33,20 @@ export default function LeaderboardIndexPage({
 }) {
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
-  return <Leaderboard sport="all" country={country} clubId={clubId} />;
+  const rawTab =
+    toSingleValue(searchParams?.tab) ?? toSingleValue(searchParams?.sport);
+  const tab = resolveTab(rawTab ?? undefined);
+
+  if (rawTab && !tab) {
+    const filterQuery = buildFilterQuery(country, clubId);
+    redirect(`/leaderboard${filterQuery}`);
+  }
+
+  return (
+    <Leaderboard
+      sport={tab ?? ALL_SPORTS}
+      country={country}
+      clubId={clubId}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- remove the redundant All Sports navigation link and route everything through the Leaderboards page
- add redirects for /leaderboard/master, individual sport routes, and /all-sports so every tab shares the same URL format
- update the leaderboards client to preserve query params, clarify tab labels, and hide regional filters when the view is global-only

## Testing
- pnpm test -- --runInBand *(fails: existing Next.js headers() usage in unrelated match tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d33e5817d4832381ade45301a62eb6