### PR TITLE
Use cumulative bowling frame totals

### DIFF
--- a/apps/web/src/lib/bowlingSummary.test.ts
+++ b/apps/web/src/lib/bowlingSummary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { summarizeBowlingInput } from "./bowlingSummary";
+
+describe("summarizeBowlingInput", () => {
+  it("produces cumulative frame totals for a perfect game", () => {
+    const frames: string[][] = Array.from({ length: 9 }, () => ["10", ""]);
+    frames.push(["10", "10", "10"]);
+
+    const result = summarizeBowlingInput(frames, { playerLabel: "Test" });
+
+    expect(result.frameScores).toEqual([
+      30,
+      60,
+      90,
+      120,
+      150,
+      180,
+      210,
+      240,
+      270,
+      300,
+    ]);
+    expect(result.total).toBe(300);
+  });
+
+  it("accumulates running totals across open and spare frames", () => {
+    const frames: string[][] = [
+      ["9", "0"],
+      ["5", "5"],
+      ["3", "4"],
+      ["0", "0"],
+      ["0", "0"],
+      ["0", "0"],
+      ["0", "0"],
+      ["0", "0"],
+      ["0", "0"],
+      ["0", "0"],
+    ];
+
+    const result = summarizeBowlingInput(frames, { playerLabel: "Test" });
+
+    expect(result.frameScores).toEqual([9, 22, 29, 29, 29, 29, 29, 29, 29, 29]);
+    expect(result.total).toBe(29);
+  });
+});

--- a/apps/web/src/lib/bowlingSummary.ts
+++ b/apps/web/src/lib/bowlingSummary.ts
@@ -176,8 +176,8 @@ export function summarizeBowlingInput(
   let total = 0;
   for (let i = 0; i < FRAME_COUNT; i += 1) {
     const score = frameScore(frames, i, tenthBonus);
-    frameScores.push(score);
     total += score;
+    frameScores.push(total);
   }
   return { frames, frameScores, total };
 }


### PR DESCRIPTION
## Summary
- accumulate running bowling frame totals so frameScores align with the scoreboard display
- add vitest coverage for perfect and mixed games to guard the cumulative scoring logic

## Testing
- pnpm vitest run src/lib/bowlingSummary.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d343a454c48323979d88a8a490eb41