### PR TITLE
Adjust players page access and layout

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -288,6 +288,87 @@ textarea {
   gap: 0.75rem;
 }
 
+.player-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.player-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: var(--color-surface);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+}
+
+.player-list__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.player-list__link {
+  font-weight: 600;
+  text-decoration: none;
+  color: inherit;
+}
+
+.player-list__link:hover {
+  text-decoration: underline;
+}
+
+.player-list__stats {
+  font-size: 0.9rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
+.player-list__admin {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.player-list__label {
+  font-weight: 600;
+}
+
+.player-list__select {
+  max-width: 220px;
+}
+
+.player-list__delete {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid rgba(10, 31, 68, 0.2);
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.player-list__delete:hover {
+  background: rgba(26, 115, 232, 0.08);
+}
+
+.player-list__error {
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-accent-red);
+}
+
+.player-list__admin-note {
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
 .match-item {
   margin-bottom: 8px;
 }

--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -39,6 +39,7 @@ function mockStatsResponse({
 describe("PlayersPage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    window.localStorage.clear();
   });
 
   it("shows a loading message while fetching players", async () => {
@@ -53,6 +54,7 @@ describe("PlayersPage", () => {
   });
 
   it("disables add button for blank names", async () => {
+    window.localStorage.setItem("token", "x.eyJpc19hZG1pbiI6dHJ1ZX0.y");
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
@@ -202,6 +204,7 @@ describe("PlayersPage", () => {
   });
 
   it("shows a success message after adding a player", async () => {
+    window.localStorage.setItem("token", "x.eyJpc19hZG1pbiI6dHJ1ZX0.y");
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) })
@@ -229,6 +232,22 @@ describe("PlayersPage", () => {
     });
     expect(screen.queryByText(/added successfully/i)).toBeNull();
     vi.useRealTimers();
+  });
+
+  it("informs non-admins that the add form is unavailable", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players: [] }) });
+    global.fetch = fetchMock as typeof fetch;
+
+    await act(async () => {
+      render(<PlayersPage />);
+    });
+
+    expect(
+      screen.getByText(/only administrators can add new players/i)
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /add/i })).toBeNull();
   });
 
   it("allows admin to delete a player", async () => {


### PR DESCRIPTION
## Summary
- hide the add player form for non-admins and show a note explaining the restriction
- clean up the players list markup, styling, and surface a message when stats cannot be loaded
- update the players page tests to cover the new behaviours

## Testing
- pnpm test -- --runInBand *(fails: existing Next.js tests call `headers()` outside a request scope)*
- pnpm test src/app/players/page.test.tsx -- --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d343bfffd0832384146a9bb431be26