### PR TITLE
Improve profile save feedback and URL validation

### DIFF
--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -99,7 +99,8 @@ describe("ProfilePage", () => {
     expect(await screen.findByDisplayValue("existing")).toBeInTheDocument();
     const countrySelect = (await screen.findByLabelText("Country")) as HTMLSelectElement;
     expect(countrySelect.value).toBe("US");
-    expect(await screen.findByText(/Continent:/i)).toHaveTextContent("North America");
+    const continentDisplay = await screen.findByTestId("continent-display");
+    expect(continentDisplay).toHaveTextContent("North America");
     const favoriteClubFields = await screen.findAllByLabelText("Favorite club");
     const clubSearchInput = favoriteClubFields[0] as HTMLInputElement;
     expect(clubSearchInput).toHaveValue("club-old");
@@ -171,7 +172,7 @@ describe("ProfilePage", () => {
       fireEvent.click(saveButton);
     });
 
-    const statusMessage = await screen.findByRole("status");
+    const statusMessage = await screen.findByText(/Profile saved successfully\./i);
 
     expect(apiMocks.updateMyPlayerLocation).toHaveBeenCalledWith({
       location: "SE",
@@ -180,7 +181,7 @@ describe("ProfilePage", () => {
       club_id: "club-new",
     });
     expect(apiMocks.updateMe).toHaveBeenCalledWith({ username: "existing" });
-    expect(statusMessage).toHaveTextContent(/profile updated/i);
+    expect(statusMessage).toBeInTheDocument();
     expect(window.localStorage.getItem("token")).toBe("new.token.value");
   });
 


### PR DESCRIPTION
## Summary
- add inline profile save feedback with saving indicator and contextual helper text around country, continent, and club fields
- tighten social link validation by requiring complete http(s) URLs and update helper messaging
- refresh profile page tests to cover the new continent display and success messaging

## Testing
- npm test -- --run src/app/profile/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d346a73e648323b122cc8954fcd238