### PR TITLE
test: mock next headers for match pages

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -5,6 +5,12 @@ import { execSync } from "child_process";
 
 const apiFetchMock = vi.hoisted(() => vi.fn());
 
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get: () => undefined,
+  }),
+}));
+
 vi.mock("../../../lib/api", async () => {
   const actual = await vi.importActual<typeof import("../../../lib/api")>(
     "../../../lib/api"
@@ -54,11 +60,13 @@ describe("MatchDetailPage", () => {
       )
     ).toBeInTheDocument();
 
-    const displayed = new Date(match.playedAt).toLocaleDateString();
+    const displayed = new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+    }).format(new Date(match.playedAt));
     expect(screen.getByText((t) => t.includes(displayed))).toBeInTheDocument();
 
     const laDate = execSync(
-      "TZ=America/Los_Angeles node -e \"console.log(new Date('2024-01-01T00:00:00').toLocaleDateString())\""
+      "TZ=America/Los_Angeles node -e \"console.log(new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date('2024-01-01T00:00:00')))\""
     )
       .toString()
       .trim();

--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -1,7 +1,13 @@
 import type { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import MatchesPage from "./page";
 import "@testing-library/jest-dom";
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get: () => undefined,
+  }),
+}));
 
 vi.mock("next/link", () => ({
   default: ({ children, href }: { children: ReactNode; href: string }) => (
@@ -59,7 +65,9 @@ describe("MatchesPage", () => {
     const page = await MatchesPage({ searchParams: {} });
     render(page);
 
-    await screen.findByText((_, el) => el?.textContent === "Alice vs Bob");
+    const matchItem = await screen.findByRole("listitem");
+    expect(within(matchItem).getByText("Alice")).toBeInTheDocument();
+    expect(within(matchItem).getByText("Bob")).toBeInTheDocument();
     expect(
       screen.getByText((text) => text.includes("6-4, 7-5"))
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- mock `next/headers` in the matches list and detail tests so they run outside of Next.js request scope
- adjust the matches page test to verify participant names via `within`
- mock the bowling summary helper in the record sport test and align it with the score-based payload

## Testing
- CI=1 pnpm --dir apps/web test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d344c9eb088323ada1a2e2ac2a0865