### PR TITLE
test: mock next headers in matches page tests

### DIFF
--- a/apps/web/src/app/matches/page.test.tsx
+++ b/apps/web/src/app/matches/page.test.tsx
@@ -13,7 +13,9 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("next/headers", () => ({
-  headers: vi.fn(() => new Headers()),
+  headers: () => ({
+    get: () => undefined,
+  }),
 }));
 
 describe("MatchesPage", () => {


### PR DESCRIPTION
## Summary
- mock `next/headers` in the matches page tests so locale parsing uses a harmless stubbed header getter

## Testing
- `pnpm test -- --runInBand` *(fails: no package manifest in repo root)*
- `pnpm test -- --runInBand` *(apps/web; fails: existing bowling score placeholder expectation in RecordSportPage test)*
- `pnpm test src/app/matches/page.test.tsx -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d34bf7b6b88323b4de1a956c410f7e