### PR TITLE
Fix locale fallback and adjust live summary typing

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -36,6 +36,7 @@ export default function HomePageClient({
   matches: initialMatches,
   sportError: initialSportError,
   matchError: initialMatchError,
+  initialLocale,
 }: Props): ReactElement {
   const [sports, setSports] = useState(initialSports);
   const [matches, setMatches] = useState(initialMatches);

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -5,7 +5,7 @@ import { useMatchStream } from "../../../lib/useMatchStream";
 import MatchScoreboard from "./MatchScoreboard";
 
 type NumericRecord = Record<string, number>;
-type SetScores = Array<Record<string, number>>;
+type SetScores = Array<Record<string, unknown>>;
 
 export type RacketSummary = {
   sets?: NumericRecord;


### PR DESCRIPTION
## Summary
- ensure the home page client component reads the provided `initialLocale` fallback
- relax live summary set score typing so type checks tolerate unknown values from the feed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d35214aeec8323941d9e2cf8d22f19