### PR TITLE
Refine match participant rendering

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { apiFetch, isAdmin, withAbsolutePhotoUrl } from "../../../lib/api";
-import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
+import MatchParticipants from "../../../components/MatchParticipants";
+import { type PlayerInfo } from "../../../components/PlayerName";
 import { useLocale } from "../../../lib/LocaleContext";
 
 type MatchRow = {
@@ -161,19 +162,10 @@ export default function AdminMatchesPage() {
       <ul className="match-list">
         {matches.map((m) => (
           <li key={m.id} className="card match-item">
-            <div style={{ fontWeight: 500 }}>
-              {m.participants.map((side, i) => (
-                <span key={i}>
-                  {side.map((pl, j) => (
-                    <span key={pl.id}>
-                      <PlayerName player={pl} />
-                      {j < side.length - 1 ? " & " : ""}
-                    </span>
-                  ))}
-                  {i < m.participants.length - 1 ? " vs " : ""}
-                </span>
-              ))}
-            </div>
+            <MatchParticipants
+              sides={m.participants}
+              className="match-participants--emphasized"
+            />
             <div className="match-meta">
               {formatSummary(m.summary)}
               {m.summary ? " · " : ""}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -374,11 +374,19 @@ textarea {
 }
 
 .match-participants {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
+  font-weight: inherit;
+}
+
+.match-participants--emphasized {
   font-weight: 500;
+}
+
+.match-participants--heading {
+  font-weight: inherit;
 }
 
 .match-participants__side-wrapper {

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -9,7 +9,7 @@ import {
   type EnrichedMatch,
   type PlayerInfo,
 } from '../lib/matches';
-import PlayerName from '../components/PlayerName';
+import MatchParticipants from '../components/MatchParticipants';
 import { useLocale } from '../lib/LocaleContext';
 
 interface Sport { id: string; name: string }
@@ -166,19 +166,10 @@ export default function HomePageClient({
           <ul className="match-list" role="list">
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
-                <div style={{ fontWeight: 500 }}>
-                  {Object.values(m.players).map((side: PlayerInfo[], i) => (
-                    <span key={i}>
-                      {side.map((pl, j) => (
-                        <span key={pl.id}>
-                          <PlayerName player={pl} />
-                          {j < side.length - 1 ? ' & ' : ''}
-                        </span>
-                      ))}
-                      {i < Object.values(m.players).length - 1 ? ' vs ' : ''}
-                    </span>
-                  ))}
-                </div>
+                <MatchParticipants
+                  sides={Object.values(m.players) as PlayerInfo[][]}
+                  className="match-participants--emphasized"
+                />
                 <div className="match-meta">
                   {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}
                   {m.playedAt ? dateFormatter.format(new Date(m.playedAt)) : '—'}

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary, { type SummaryData } from "./live-summary";
-import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
+import MatchParticipants from "../../../components/MatchParticipants";
+import { type PlayerInfo } from "../../../components/PlayerName";
 import { formatDateTime, parseAcceptLanguage } from "../../../lib/i18n";
 
 export const dynamic = "force-dynamic";
@@ -159,17 +160,16 @@ export default async function MatchDetailPage({
 
       <header className="section">
         <h1 className="heading">
-          {Object.keys(sidePlayers).map((s, i) => (
-            <span key={s}>
-              {sidePlayers[s]?.map((pl, j) => (
-                <span key={pl.id}>
-                  <PlayerName player={pl} />
-                  {j < (sidePlayers[s]?.length ?? 0) - 1 ? " / " : ""}
-                </span>
-              ))}
-              {i < Object.keys(sidePlayers).length - 1 ? " vs " : ""}
-            </span>
-          )) || "A vs B"}
+          {Object.keys(sidePlayers).length > 0 ? (
+            <MatchParticipants
+              as="span"
+              className="match-participants--heading"
+              sides={Object.keys(sidePlayers).map((s) => sidePlayers[s] ?? [])}
+              playerSeparator=" / "
+            />
+          ) : (
+            "A vs B"
+          )}
         </h1>
         <p className="match-meta">
           {sportLabel} · {rulesetLabel} · {" "}

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { apiFetch, withAbsolutePhotoUrl } from "../../lib/api";
 import Pager from "./pager";
-import PlayerName, { PlayerInfo } from "../../components/PlayerName";
+import MatchParticipants from "../../components/MatchParticipants";
+import { type PlayerInfo } from "../../components/PlayerName";
 import { formatDate, parseAcceptLanguage } from "../../lib/i18n";
 
 export const dynamic = "force-dynamic";
@@ -184,41 +185,10 @@ export default async function MatchesPage(
           <ul className="match-list">
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
-                <div className="match-participants">
-                  {m.participants.map((side, sideIndex) => (
-                    <div
-                      key={sideIndex}
-                      className="match-participants__side-wrapper"
-                    >
-                      {sideIndex > 0 && (
-                        <span
-                          className="match-participants__versus"
-                          aria-label="versus"
-                        >
-                          vs
-                        </span>
-                      )}
-                      <div className="match-participants__side">
-                        {side.map((pl, playerIndex) => (
-                          <span
-                            key={pl.id}
-                            className="match-participants__entry"
-                          >
-                            {playerIndex > 0 && (
-                              <span
-                                className="match-participants__separator"
-                                aria-label="and"
-                              >
-                                &
-                              </span>
-                            )}
-                            <PlayerName player={pl} />
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                <MatchParticipants
+                  sides={m.participants}
+                  className="match-participants--emphasized"
+                />
                 <div className="match-meta">
                   {formatSummary(m.summary)}
                   {m.summary ? " · " : ""}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { apiFetch, fetchClubs, withAbsolutePhotoUrl } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
+import MatchParticipants from "../../../components/MatchParticipants";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
 import PhotoUpload from "./PhotoUpload";
 import { formatDate, parseAcceptLanguage } from "../../../lib/i18n";
@@ -494,17 +495,12 @@ export default async function PlayerPage({
                       <li key={m.id} className="mb-2">
                         <div>
                           <Link href={`/matches/${m.id}`}>
-                            {Object.values(m.players).map((side, i) => (
-                              <span key={i}>
-                                {side.map((pl, j) => (
-                                  <span key={pl.id}>
-                                    <PlayerName player={pl} />
-                                    {j < side.length - 1 ? " & " : ""}
-                                  </span>
-                                ))}
-                                {i < Object.values(m.players).length - 1 ? " vs " : ""}
-                              </span>
-                            ))}
+                            <MatchParticipants
+                              as="span"
+                              sides={
+                                Object.values(m.players) as PlayerInfo[][]
+                              }
+                            />
                           </Link>
                         </div>
                         <div className="text-sm text-gray-700">
@@ -549,14 +545,7 @@ export default async function PlayerPage({
             <ul>
               {recentOpponents.map((o) => (
                 <li key={o.id} className="mb-2">
-                  <div>
-                    {o.opponents.map((pl, j) => (
-                      <span key={pl.id}>
-                        <PlayerName player={pl} />
-                        {j < o.opponents.length - 1 ? " & " : ""}
-                      </span>
-                    ))}
-                  </div>
+                  <MatchParticipants sides={[o.opponents]} />
                   <div className="text-sm text-gray-700">
                     {o.date} · {o.result}
                   </div>
@@ -595,17 +584,10 @@ export default async function PlayerPage({
               {upcoming.map((m) => (
                 <li key={m.id} className="mb-2">
                   <Link href={`/matches/${m.id}`}>
-                    {Object.values(m.players).map((side, i) => (
-                      <span key={i}>
-                        {side.map((pl, j) => (
-                          <span key={pl.id}>
-                            <PlayerName player={pl} />
-                            {j < side.length - 1 ? " & " : ""}
-                          </span>
-                        ))}
-                        {i < Object.values(m.players).length - 1 ? " vs " : ""}
-                      </span>
-                    ))}
+                    <MatchParticipants
+                      as="span"
+                      sides={Object.values(m.players) as PlayerInfo[][]}
+                    />
                   </Link>
                   <div className="text-sm text-gray-700">
                     {formatDate(m.playedAt, locale)} · {m.location ?? "—"}

--- a/apps/web/src/components/MatchParticipants.tsx
+++ b/apps/web/src/components/MatchParticipants.tsx
@@ -1,0 +1,69 @@
+import type { ComponentPropsWithoutRef, ElementType, ReactElement } from 'react';
+import PlayerName, { type PlayerInfo } from './PlayerName';
+
+type MatchParticipantsProps<E extends ElementType> = {
+  /**
+   * Ordered list of sides. Each side is rendered in sequence with the
+   * configured separators. The component assumes the players are already in
+   * the desired display order.
+   */
+  sides: PlayerInfo[][];
+  /**
+   * Allows overriding the root element (defaults to a <div>). Useful when the
+   * participants need to be displayed inside inline contexts like headings.
+   */
+  as?: E;
+  className?: string;
+  /**
+   * Symbol placed between players on the same side.
+   */
+  playerSeparator?: string;
+  /**
+   * Symbol placed between opposing sides.
+   */
+  sideSeparator?: string;
+} & Omit<ComponentPropsWithoutRef<E>, 'as' | 'children'>;
+
+const defaultPlayerSeparator = ' & ';
+const defaultSideSeparator = ' vs ';
+
+export default function MatchParticipants<E extends ElementType = 'div'>(
+  props: MatchParticipantsProps<E>,
+): ReactElement {
+  const {
+    as,
+    className,
+    sides,
+    playerSeparator = defaultPlayerSeparator,
+    sideSeparator = defaultSideSeparator,
+    ...rest
+  } = props;
+
+  const Component = (as ?? 'div') as ElementType;
+  const classes = ['match-participants'];
+  if (className) classes.push(className);
+
+  return (
+    <Component className={classes.join(' ')} {...rest}>
+      {sides.map((side, sideIndex) => (
+        <span key={`side-${sideIndex}`} className="match-participants__side-wrapper">
+          <span className="match-participants__side">
+            {side.map((player, playerIndex) => (
+              <span key={player.id} className="match-participants__entry">
+                {playerIndex > 0 ? (
+                  <span className="match-participants__separator">
+                    {playerSeparator}
+                  </span>
+                ) : null}
+                <PlayerName player={player} />
+              </span>
+            ))}
+          </span>
+          {sideIndex < sides.length - 1 ? (
+            <span className="match-participants__versus">{sideSeparator}</span>
+          ) : null}
+        </span>
+      ))}
+    </Component>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable `MatchParticipants` component to render match participants with flexbox spacing and conditional separators
- swap inline participant markup on the home, matches, admin, player, and match detail pages to use the new component and update supporting styles
- ensure headings and lists keep participant names unbroken while preserving existing typography

## Testing
- npm run lint
- npm run test -- --run *(fails: RecordSportPage > allows recording multiple bowling players – existing issue not touched in this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d35dd85e1083238058757993cf1b45