### PR TITLE
Fix sport list links on home page

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -265,6 +265,24 @@ textarea {
   gap: 0.75rem;
 }
 
+.sport-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.sport-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.sport-link:hover .sport-name,
+.sport-link:focus-visible .sport-name {
+  text-decoration: underline;
+}
+
 .sport-icon {
   font-size: 1.5rem;
   line-height: 1;
@@ -272,11 +290,6 @@ textarea {
 
 .sport-name {
   font-weight: 600;
-}
-
-.sport-id {
-  color: #555;
-  font-size: 0.9rem;
 }
 
 /* Match list */

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -23,6 +23,8 @@ const sportIcons: Record<string, string> = {
   table_tennis: '🏓',
 };
 
+const toRecordPath = (sportId: string) => `/record/${sportId.replace(/_/g, '-')}`;
+
 interface Props {
   sports: Sport[];
   matches: EnrichedMatch[];
@@ -121,18 +123,20 @@ export default function HomePageClient({
           <ul className="sport-list" role="list">
             {sports.map((s) => {
               const icon = sportIcons[s.id];
+              const href = toRecordPath(s.id);
               return (
                 <li key={s.id} className="sport-item">
-                  {icon ? (
-                    <span className="sport-icon" aria-hidden="true">
-                      {icon}
-                    </span>
-                  ) : null}
-                  {icon ? (
-                    <span className="sr-only">{`${s.name} icon`}</span>
-                  ) : null}
-                  <span className="sport-name">{s.name}</span>
-                  <span className="sport-id">{s.id}</span>
+                  <Link href={href} className="sport-link">
+                    {icon ? (
+                      <span className="sport-icon" aria-hidden="true">
+                        {icon}
+                      </span>
+                    ) : null}
+                    {icon ? (
+                      <span className="sr-only">{`${s.name} icon`}</span>
+                    ) : null}
+                    <span className="sport-name">{s.name}</span>
+                  </Link>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- remove the redundant sport id label on the home page list
- wrap each sport in a single link that routes to the record form for that sport
- add styling for the new sport link including focus and hover feedback

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d35ccc991c8323911ef14938c65336