### PR TITLE
Improve player stats handling and toast notifications

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  trailingSlash: true,
   eslint: {
     // Allow production builds to complete even if there are ESLint errors.
     ignoreDuringBuilds: true,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -660,3 +660,30 @@ textarea {
 .bowling-total {
   font-weight: 700;
 }
+
+.toast-container {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.toast {
+  min-width: 240px;
+  max-width: min(320px, 90vw);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: 8px;
+  box-shadow: 0 12px 24px rgba(10, 31, 68, 0.18);
+  padding: 0.75rem 1rem;
+  border-left: 4px solid var(--color-accent-blue);
+  pointer-events: auto;
+}
+
+.toast--error {
+  border-left-color: var(--color-accent-red);
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import ChunkErrorReload from '../components/ChunkErrorReload';
 import { headers } from 'next/headers';
 import { LocaleProvider } from '../lib/LocaleContext';
 import { parseAcceptLanguage } from '../lib/i18n';
+import { ToastProvider } from '../lib/toast';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -24,9 +25,11 @@ export default function RootLayout({
     <html lang={locale}>
       <body>
         <LocaleProvider locale={locale}>
-          <ChunkErrorReload />
-          <Header />
-          {children}
+          <ToastProvider>
+            <ChunkErrorReload />
+            <Header />
+            {children}
+          </ToastProvider>
         </LocaleProvider>
       </body>
     </html>

--- a/apps/web/src/app/players/[id]/StatsErrorToast.tsx
+++ b/apps/web/src/app/players/[id]/StatsErrorToast.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useToast } from "../../../lib/toast";
+
+const MESSAGE =
+  "Player stats failed to load. Displayed records may be incomplete.";
+
+export default function StatsErrorToast({ error }: { error: boolean }) {
+  const { showToast } = useToast();
+  const hasShownRef = useRef(false);
+
+  useEffect(() => {
+    if (error) {
+      if (!hasShownRef.current) {
+        showToast(MESSAGE, { type: "error" });
+      }
+      hasShownRef.current = true;
+    } else {
+      hasShownRef.current = false;
+    }
+  }, [error, showToast]);
+
+  return null;
+}

--- a/apps/web/src/lib/stats.ts
+++ b/apps/web/src/lib/stats.ts
@@ -1,0 +1,139 @@
+export interface MatchSummary {
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+  winPct: number;
+}
+
+export interface VersusRecord {
+  playerId: string;
+  playerName?: string;
+  wins: number;
+  losses: number;
+  winPct: number;
+}
+
+export interface PlayerStats {
+  playerId?: string;
+  matchSummary: MatchSummary | null;
+  bestAgainst: VersusRecord | null;
+  worstAgainst: VersusRecord | null;
+  bestWith: VersusRecord | null;
+  worstWith: VersusRecord | null;
+  withRecords: VersusRecord[];
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function parseMatchSummary(value: unknown): MatchSummary | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as UnknownRecord;
+  const wins = toFiniteNumber(record.wins);
+  const losses = toFiniteNumber(record.losses);
+  const total = toFiniteNumber(record.total);
+  const winPct = toFiniteNumber(record.winPct);
+  const drawsValue =
+    record.draws === null || record.draws === undefined
+      ? 0
+      : toFiniteNumber(record.draws);
+
+  if (
+    wins === null ||
+    losses === null ||
+    total === null ||
+    winPct === null ||
+    drawsValue === null
+  ) {
+    return null;
+  }
+
+  if (wins < 0 || losses < 0 || drawsValue < 0 || total <= 0) {
+    return null;
+  }
+
+  if (winPct < 0 || winPct > 1) {
+    return null;
+  }
+
+  if (wins + losses + drawsValue === 0) {
+    return null;
+  }
+
+  return {
+    wins,
+    losses,
+    draws: drawsValue,
+    total,
+    winPct,
+  };
+}
+
+function parseVersusRecord(value: unknown): VersusRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as UnknownRecord;
+  const playerId =
+    typeof record.playerId === "string" && record.playerId.length > 0
+      ? record.playerId
+      : null;
+  if (!playerId) return null;
+
+  const wins = toFiniteNumber(record.wins);
+  const losses = toFiniteNumber(record.losses);
+  const winPct = toFiniteNumber(record.winPct);
+
+  if (wins === null || losses === null || winPct === null) {
+    return null;
+  }
+
+  const playerName =
+    typeof record.playerName === "string" && record.playerName.trim().length
+      ? record.playerName
+      : undefined;
+
+  return {
+    playerId,
+    playerName,
+    wins,
+    losses,
+    winPct,
+  };
+}
+
+export function sanitizePlayerStats(raw: unknown): PlayerStats | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as UnknownRecord;
+
+  const matchSummary = parseMatchSummary(record.matchSummary);
+  const bestAgainst = parseVersusRecord(record.bestAgainst);
+  const worstAgainst = parseVersusRecord(record.worstAgainst);
+  const bestWith = parseVersusRecord(record.bestWith);
+  const worstWith = parseVersusRecord(record.worstWith);
+  const withRecords = Array.isArray(record.withRecords)
+    ? (record.withRecords
+        .map(parseVersusRecord)
+        .filter((item): item is VersusRecord => item !== null))
+    : [];
+
+  const playerId =
+    typeof record.playerId === "string" && record.playerId.length > 0
+      ? record.playerId
+      : undefined;
+
+  return {
+    playerId,
+    matchSummary,
+    bestAgainst,
+    worstAgainst,
+    bestWith,
+    worstWith,
+    withRecords,
+  };
+}

--- a/apps/web/src/lib/toast.tsx
+++ b/apps/web/src/lib/toast.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type ToastType = "info" | "error";
+
+export interface ToastOptions {
+  type?: ToastType;
+  duration?: number;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, options?: ToastOptions) => void;
+}
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+  duration: number;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let toastIdCounter = 0;
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timers = useRef<Map<number, number>>(new Map());
+
+  const remove = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    const timer = timers.current.get(id);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, options?: ToastOptions) => {
+      if (!message) return;
+      const id = ++toastIdCounter;
+      const type = options?.type ?? "info";
+      const duration = options?.duration ?? 5000;
+      setToasts((prev) => [...prev, { id, message, type, duration }]);
+      if (duration > 0) {
+        const timer = window.setTimeout(() => {
+          remove(id);
+        }, duration);
+        timers.current.set(id, timer);
+      }
+    },
+    [remove]
+  );
+
+  useEffect(() => {
+    return () => {
+      timers.current.forEach((timer) => window.clearTimeout(timer));
+      timers.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      showToast,
+    }),
+    [showToast]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="toast-container" aria-live="polite" aria-atomic="true">
+        {toasts.map((toast) => (
+          <div key={toast.id} className={`toast toast--${toast.type}`} role="status">
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add a reusable toast provider and styling, wire it into the layout, player list, and player detail pages, and ensure missing stats render as “Stats unavailable” instead of zeroed records
- sanitize player stats payloads before use so invalid data no longer crashes the player page and failed fetches emit a toast warning
- extend the player list tests for stats failure scenarios, update the bowling record test to mock summarized totals, and enable trailing-slash routing in Next config so the root URL resolves consistently

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d35cede1bc83239f45687aa17ff714