### PR TITLE
Refine match participant layout

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,5 +7,7 @@ The current Vitest run exposes a couple of actionable gaps. Capture them here so
 - [ ] Alternatively, document that application-specific tests must be invoked from `apps/web/` until the workspace is wired up, and update any CI helpers that assume the root command works. (Choose one approach.)
 
 ## Bowling record page test missing score placeholders
-- [ ] Update the bowling score inputs (or their test queries) so the "allows recording multiple bowling players" spec can find the score fields without relying on placeholder text that is not rendered today.
-- [ ] When the fields are discoverable again, re-run `pnpm test -- --runInBand` inside `apps/web/` to confirm the suite returns to green.
+- [ ] Audit `apps/web/src/app/record/[sport]/page.tsx` to confirm how bowling score inputs are labelled and decide whether the UI should expose placeholders, visible labels, or `aria-label`s for each score field.
+- [ ] If the UI should surface labels, update the markup so every bowling score input has a reliable accessible name without depending on placeholder text that disappears on focus.
+- [ ] Adjust `apps/web/src/app/record/[sport]/page.test.tsx` so the "allows recording multiple bowling players" spec queries the score fields via the new accessible names (for example, `getByLabelText`), rather than looking for `/score/i` placeholders that never render.
+- [ ] Run `pnpm test -- --runInBand` from `apps/web/` to verify the suite passes once the bowling inputs and tests are aligned.

--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { apiFetch, isAdmin, withAbsolutePhotoUrl } from "../../../lib/api";
-import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
+import { PlayerInfo } from "../../../components/PlayerName";
+import MatchParticipants from "../../../components/MatchParticipants";
 import { useLocale } from "../../../lib/LocaleContext";
 
 type MatchRow = {
@@ -161,19 +162,7 @@ export default function AdminMatchesPage() {
       <ul className="match-list">
         {matches.map((m) => (
           <li key={m.id} className="card match-item">
-            <div style={{ fontWeight: 500 }}>
-              {m.participants.map((side, i) => (
-                <span key={i}>
-                  {side.map((pl, j) => (
-                    <span key={pl.id}>
-                      <PlayerName player={pl} />
-                      {j < side.length - 1 ? " & " : ""}
-                    </span>
-                  ))}
-                  {i < m.participants.length - 1 ? " vs " : ""}
-                </span>
-              ))}
-            </div>
+            <MatchParticipants sides={m.participants} style={{ fontWeight: 500 }} />
             <div className="match-meta">
               {formatSummary(m.summary)}
               {m.summary ? " · " : ""}

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -3,13 +3,8 @@
 import { useMemo, useState, type MouseEvent, type ReactElement } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
-import {
-  enrichMatches,
-  type MatchRow,
-  type EnrichedMatch,
-  type PlayerInfo,
-} from '../lib/matches';
-import PlayerName from '../components/PlayerName';
+import { enrichMatches, type MatchRow, type EnrichedMatch } from '../lib/matches';
+import MatchParticipants from '../components/MatchParticipants';
 import { useLocale } from '../lib/LocaleContext';
 
 interface Sport { id: string; name: string }
@@ -166,19 +161,10 @@ export default function HomePageClient({
           <ul className="match-list" role="list">
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
-                <div style={{ fontWeight: 500 }}>
-                  {Object.values(m.players).map((side: PlayerInfo[], i) => (
-                    <span key={i}>
-                      {side.map((pl, j) => (
-                        <span key={pl.id}>
-                          <PlayerName player={pl} />
-                          {j < side.length - 1 ? ' & ' : ''}
-                        </span>
-                      ))}
-                      {i < Object.values(m.players).length - 1 ? ' vs ' : ''}
-                    </span>
-                  ))}
-                </div>
+                <MatchParticipants
+                  sides={Object.values(m.players)}
+                  style={{ fontWeight: 500 }}
+                />
                 <div className="match-meta">
                   {m.sport} · Best of {m.bestOf ?? '—'} ·{' '}
                   {m.playedAt ? dateFormatter.format(new Date(m.playedAt)) : '—'}

--- a/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
+++ b/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import type { BowlingSummaryPlayer, SummaryData } from "./live-summary";
+import type {
+  BowlingSummaryPlayer,
+  SummaryData,
+} from "../../../lib/match-summary";
 
 const RACKET_SPORTS = new Set([
   "padel",

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -1,60 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import {
+  type SummaryData,
+  type RacketSummary,
+  isRecord,
+} from "../../../lib/match-summary";
 import { useMatchStream } from "../../../lib/useMatchStream";
 import MatchScoreboard from "./MatchScoreboard";
 
-type NumericRecord = Record<string, number>;
 type SetScores = Array<Record<string, unknown>>;
-
-export type RacketSummary = {
-  sets?: NumericRecord;
-  games?: NumericRecord;
-  points?: NumericRecord;
-  set_scores?: SetScores;
-  config?: unknown;
-  [key: string]: unknown;
-};
-
-export type DiscGolfSummary = {
-  scores?: Record<string, Array<number | null | undefined>>;
-  pars?: Array<number | null | undefined>;
-  totals?: NumericRecord;
-  parTotal?: number | null;
-  toPar?: NumericRecord;
-  config?: unknown;
-  [key: string]: unknown;
-};
-
-export type BowlingSummaryPlayer = {
-  side?: string;
-  playerId?: string;
-  playerName?: string;
-  frames?: Array<Array<number | null | undefined>>;
-  scores?: Array<number | null | undefined>;
-  total?: number | null;
-};
-
-export type BowlingSummary = {
-  frames?: Array<Array<number | null | undefined>>;
-  scores?: Array<number | null | undefined>;
-  total?: number | null;
-  players?: BowlingSummaryPlayer[];
-  config?: unknown;
-  [key: string]: unknown;
-};
-
-export type SummaryData =
-  | RacketSummary
-  | DiscGolfSummary
-  | BowlingSummary
-  | Record<string, unknown>
-  | null
-  | undefined;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 function extractConfig(summary: SummaryData): unknown {
   if (isRecord(summary) && "config" in summary) {

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary, { type SummaryData } from "./live-summary";
-import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
+import MatchParticipants from "../../../components/MatchParticipants";
+import { PlayerInfo } from "../../../components/PlayerName";
 import { formatDateTime, parseAcceptLanguage } from "../../../lib/i18n";
 
 export const dynamic = "force-dynamic";
@@ -159,17 +160,15 @@ export default async function MatchDetailPage({
 
       <header className="section">
         <h1 className="heading">
-          {Object.keys(sidePlayers).map((s, i) => (
-            <span key={s}>
-              {sidePlayers[s]?.map((pl, j) => (
-                <span key={pl.id}>
-                  <PlayerName player={pl} />
-                  {j < (sidePlayers[s]?.length ?? 0) - 1 ? " / " : ""}
-                </span>
-              ))}
-              {i < Object.keys(sidePlayers).length - 1 ? " vs " : ""}
-            </span>
-          )) || "A vs B"}
+          {Object.keys(sidePlayers).length ? (
+            <MatchParticipants
+              as="span"
+              sides={Object.values(sidePlayers)}
+              separatorSymbol="/"
+            />
+          ) : (
+            "A vs B"
+          )}
         </h1>
         <p className="match-meta">
           {sportLabel} · {rulesetLabel} · {" "}

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { headers } from "next/headers";
 import { apiFetch, withAbsolutePhotoUrl } from "../../lib/api";
 import Pager from "./pager";
-import PlayerName, { PlayerInfo } from "../../components/PlayerName";
+import { PlayerInfo } from "../../components/PlayerName";
+import MatchParticipants from "../../components/MatchParticipants";
 import { formatDate, parseAcceptLanguage } from "../../lib/i18n";
 
 export const dynamic = "force-dynamic";
@@ -184,41 +185,7 @@ export default async function MatchesPage(
           <ul className="match-list">
             {matches.map((m) => (
               <li key={m.id} className="card match-item">
-                <div className="match-participants">
-                  {m.participants.map((side, sideIndex) => (
-                    <div
-                      key={sideIndex}
-                      className="match-participants__side-wrapper"
-                    >
-                      {sideIndex > 0 && (
-                        <span
-                          className="match-participants__versus"
-                          aria-label="versus"
-                        >
-                          vs
-                        </span>
-                      )}
-                      <div className="match-participants__side">
-                        {side.map((pl, playerIndex) => (
-                          <span
-                            key={pl.id}
-                            className="match-participants__entry"
-                          >
-                            {playerIndex > 0 && (
-                              <span
-                                className="match-participants__separator"
-                                aria-label="and"
-                              >
-                                &
-                              </span>
-                            )}
-                            <PlayerName player={pl} />
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                <MatchParticipants sides={m.participants} />
                 <div className="match-meta">
                   {formatSummary(m.summary)}
                   {m.summary ? " · " : ""}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -5,6 +5,7 @@ import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
 import PlayerDetailErrorBoundary from "./PlayerDetailErrorBoundary";
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
+import MatchParticipants from "../../../components/MatchParticipants";
 import PhotoUpload from "./PhotoUpload";
 import { formatDate, parseAcceptLanguage } from "../../../lib/i18n";
 
@@ -498,17 +499,10 @@ export default async function PlayerPage({
                         <li key={m.id} className="mb-2">
                           <div>
                             <Link href={`/matches/${m.id}`}>
-                              {Object.values(m.players).map((side, i) => (
-                                <span key={i}>
-                                  {side.map((pl, j) => (
-                                    <span key={pl.id}>
-                                      <PlayerName player={pl} />
-                                      {j < side.length - 1 ? " & " : ""}
-                                    </span>
-                                  ))}
-                                  {i < Object.values(m.players).length - 1 ? " vs " : ""}
-                                </span>
-                              ))}
+                              <MatchParticipants
+                                as="span"
+                                sides={Object.values(m.players)}
+                              />
                             </Link>
                           </div>
                           <div className="text-sm text-gray-700">
@@ -554,12 +548,7 @@ export default async function PlayerPage({
                 {recentOpponents.map((o) => (
                   <li key={o.id} className="mb-2">
                     <div>
-                      {o.opponents.map((pl, j) => (
-                        <span key={pl.id}>
-                          <PlayerName player={pl} />
-                          {j < o.opponents.length - 1 ? " & " : ""}
-                        </span>
-                      ))}
+                      <MatchParticipants as="span" sides={[o.opponents]} />
                     </div>
                     <div className="text-sm text-gray-700">
                       {o.date} · {o.result}
@@ -599,17 +588,10 @@ export default async function PlayerPage({
               {upcoming.map((m) => (
                 <li key={m.id} className="mb-2">
                   <Link href={`/matches/${m.id}`}>
-                    {Object.values(m.players).map((side, i) => (
-                      <span key={i}>
-                        {side.map((pl, j) => (
-                          <span key={pl.id}>
-                            <PlayerName player={pl} />
-                            {j < side.length - 1 ? " & " : ""}
-                          </span>
-                        ))}
-                        {i < Object.values(m.players).length - 1 ? " vs " : ""}
-                      </span>
-                    ))}
+                    <MatchParticipants
+                      as="span"
+                      sides={Object.values(m.players)}
+                    />
                   </Link>
                   <div className="text-sm text-gray-700">
                     {formatDate(m.playedAt, locale)} · {m.location ?? "—"}

--- a/apps/web/src/components/MatchParticipants.tsx
+++ b/apps/web/src/components/MatchParticipants.tsx
@@ -1,0 +1,70 @@
+import { ComponentPropsWithoutRef, ElementType } from 'react';
+import PlayerName, { PlayerInfo } from './PlayerName';
+
+type BaseProps = {
+  sides: PlayerInfo[][];
+  separatorLabel?: string;
+  versusLabel?: string;
+  separatorSymbol?: string;
+  versusSymbol?: string;
+  className?: string;
+};
+
+type MatchParticipantsProps<T extends ElementType> = BaseProps &
+  Omit<ComponentPropsWithoutRef<T>, keyof BaseProps | 'as'> & {
+    as?: T;
+  };
+
+const DEFAULT_ELEMENT = 'div';
+
+export default function MatchParticipants<
+  T extends ElementType = typeof DEFAULT_ELEMENT
+>({
+  as,
+  sides,
+  separatorLabel,
+  versusLabel,
+  separatorSymbol = '&',
+  versusSymbol = 'vs',
+  className,
+  ...rest
+}: MatchParticipantsProps<T>) {
+  const Component = (as ?? DEFAULT_ELEMENT) as ElementType;
+  const classes = ['match-participants', className].filter(Boolean).join(' ');
+
+  if (!sides.length) {
+    return <Component className={classes} {...rest} />;
+  }
+
+  return (
+    <Component className={classes} {...rest}>
+      {sides.map((side, sideIndex) => (
+        <span key={sideIndex} className="match-participants__side-wrapper">
+          {sideIndex > 0 && (
+            <span
+              className="match-participants__versus"
+              aria-label={versusLabel || undefined}
+            >
+              {` ${versusSymbol} `}
+            </span>
+          )}
+          <span className="match-participants__side">
+            {side.map((player, playerIndex) => (
+              <span key={player.id} className="match-participants__entry">
+                {playerIndex > 0 && (
+                  <span
+                    className="match-participants__separator"
+                    aria-label={separatorLabel || undefined}
+                  >
+                    {` ${separatorSymbol} `}
+                  </span>
+                )}
+                <PlayerName player={player} />
+              </span>
+            ))}
+          </span>
+        </span>
+      ))}
+    </Component>
+  );
+}

--- a/apps/web/src/lib/match-summary.ts
+++ b/apps/web/src/lib/match-summary.ts
@@ -1,0 +1,448 @@
+export type NumericRecord = Record<string, number>;
+export type SetScores = Array<Record<string, unknown>>;
+
+export type RacketSummary = {
+  sets?: NumericRecord;
+  games?: NumericRecord;
+  points?: NumericRecord;
+  set_scores?: SetScores;
+  config?: unknown;
+  [key: string]: unknown;
+};
+
+export type DiscGolfSummary = {
+  scores?: Record<string, Array<number | null | undefined>>;
+  pars?: Array<number | null | undefined>;
+  totals?: NumericRecord;
+  parTotal?: number | null;
+  toPar?: NumericRecord;
+  config?: unknown;
+  [key: string]: unknown;
+};
+
+export type BowlingSummaryPlayer = {
+  side?: string;
+  playerId?: string;
+  playerName?: string;
+  frames?: Array<Array<number | null | undefined>>;
+  scores?: Array<number | null | undefined>;
+  total?: number | null;
+};
+
+export type BowlingSummary = {
+  frames?: Array<Array<number | null | undefined>>;
+  scores?: Array<number | null | undefined>;
+  total?: number | null;
+  players?: BowlingSummaryPlayer[];
+  config?: unknown;
+  [key: string]: unknown;
+};
+
+export type SummaryData =
+  | RacketSummary
+  | DiscGolfSummary
+  | BowlingSummary
+  | Record<string, unknown>
+  | null
+  | undefined;
+
+export type ScoreEvent = {
+  id?: string;
+  type?: string;
+  payload?: Record<string, unknown> | null;
+  createdAt?: string;
+  [key: string]: unknown;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const FINISHED_STATUS_KEYWORDS = new Set([
+  "complete",
+  "completed",
+  "finished",
+  "final",
+  "finalized",
+  "finalised",
+  "done",
+]);
+
+export function isFinishedStatus(status?: string | null): boolean {
+  if (typeof status !== "string") return false;
+  const normalized = status.trim().toLowerCase();
+  if (!normalized) return false;
+  if (FINISHED_STATUS_KEYWORDS.has(normalized)) return true;
+  return normalized.includes("final");
+}
+
+const RACKET_SPORT_IDS = new Set([
+  "padel",
+  "tennis",
+  "pickleball",
+  "badminton",
+  "table-tennis",
+  "table_tennis",
+]);
+
+export function isRacketSport(sport?: string | null): boolean {
+  if (!sport) return false;
+  return RACKET_SPORT_IDS.has(sport.toLowerCase());
+}
+
+export function shouldRebuildRacketSummary(
+  summary: SummaryData | null | undefined
+): boolean {
+  if (!summary || !isRecord(summary)) return false;
+  const maybeSetScores = (summary as { set_scores?: unknown }).set_scores;
+  if (!Array.isArray(maybeSetScores)) return true;
+  if (maybeSetScores.length === 0) return true;
+  return !maybeSetScores.some(
+    (set) =>
+      isRecord(set) &&
+      Object.values(set).some(
+        (value) => typeof value === "number" && Number.isFinite(value)
+      )
+  );
+}
+
+type Side = "A" | "B";
+
+type RacketConfig = {
+  tiebreakTo?: number;
+  sets?: number;
+  goldenPoint?: boolean;
+};
+
+type PickleballConfig = {
+  pointsTo: number;
+  winBy: number;
+  bestOf?: number;
+};
+
+type PadelOrTennisState = {
+  sport: "padel" | "tennis";
+  config: RacketConfig;
+  points: Record<Side, number>;
+  games: Record<Side, number>;
+  sets: Record<Side, number>;
+  setScores: Array<Record<Side, number>>;
+  tiebreak: boolean;
+};
+
+type PickleballState = {
+  sport: "pickleball";
+  config: PickleballConfig;
+  points: Record<Side, number>;
+  games: Record<Side, number>;
+};
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function sanitizePositiveInteger(value: unknown): number | undefined {
+  const num = toNumber(value);
+  if (num === undefined) return undefined;
+  const truncated = Math.trunc(num);
+  return truncated > 0 ? truncated : undefined;
+}
+
+function sanitizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return undefined;
+    if (["true", "yes", "1", "on"].includes(normalized)) return true;
+    if (["false", "no", "0", "off"].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
+function sanitizeSide(value: unknown): Side | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toUpperCase();
+  return normalized === "A" || normalized === "B" ? (normalized as Side) : null;
+}
+
+function createPadelOrTennisState(
+  sport: "padel" | "tennis",
+  configRaw: unknown
+): PadelOrTennisState {
+  const config: RacketConfig = {};
+  if (isRecord(configRaw)) {
+    const rawTiebreak = configRaw.tiebreakTo ?? configRaw.tiebreak_to;
+    const tiebreak = sanitizePositiveInteger(rawTiebreak);
+    if (tiebreak !== undefined) config.tiebreakTo = tiebreak;
+    const rawSets = configRaw.sets ?? configRaw.bestOf ?? configRaw.best_of;
+    const sets = sanitizePositiveInteger(rawSets);
+    if (sets !== undefined) config.sets = sets;
+    const rawGolden = configRaw.goldenPoint ?? configRaw.golden_point;
+    const golden = sanitizeBoolean(rawGolden);
+    if (golden !== undefined) config.goldenPoint = golden;
+  }
+  if (config.tiebreakTo === undefined) config.tiebreakTo = 7;
+
+  return {
+    sport,
+    config,
+    points: { A: 0, B: 0 },
+    games: { A: 0, B: 0 },
+    sets: { A: 0, B: 0 },
+    setScores: [],
+    tiebreak: false,
+  };
+}
+
+function createPickleballState(configRaw: unknown): PickleballState {
+  const config: PickleballConfig = {
+    pointsTo: 11,
+    winBy: 2,
+  };
+  if (isRecord(configRaw)) {
+    const pts = sanitizePositiveInteger(configRaw.pointsTo ?? configRaw.points_to);
+    if (pts !== undefined) config.pointsTo = pts;
+    const winBy = sanitizePositiveInteger(configRaw.winBy ?? configRaw.win_by);
+    if (winBy !== undefined) config.winBy = winBy;
+    const best = sanitizePositiveInteger(configRaw.bestOf ?? configRaw.best_of);
+    if (best !== undefined) config.bestOf = best;
+  }
+  return {
+    sport: "pickleball",
+    config,
+    points: { A: 0, B: 0 },
+    games: { A: 0, B: 0 },
+  };
+}
+
+function getSetsNeeded(config: RacketConfig): number | undefined {
+  if (config.sets === undefined) return undefined;
+  const sets = sanitizePositiveInteger(config.sets);
+  if (sets === undefined) return undefined;
+  return Math.floor(sets / 2) + 1;
+}
+
+function recordSetScore(
+  state: PadelOrTennisState,
+  winner: Side,
+  { tiebreak }: { tiebreak?: boolean } = {}
+): void {
+  const scores: Record<Side, number> = {
+    A: state.games.A,
+    B: state.games.B,
+  };
+  if (tiebreak) {
+    scores[winner] = (scores[winner] ?? 0) + 1;
+  }
+  state.setScores.push(scores);
+}
+
+function applyPadelOrTennisPoint(
+  state: PadelOrTennisState,
+  side: Side
+): void {
+  const opp: Side = side === "A" ? "B" : "A";
+  const config = state.config;
+  const tiebreakTo = config.tiebreakTo ?? 7;
+  const setsNeeded = getSetsNeeded(config);
+
+  if (
+    setsNeeded &&
+    (state.sets.A >= setsNeeded || state.sets.B >= setsNeeded)
+  ) {
+    return;
+  }
+
+  state.points[side] += 1;
+  const ps = state.points[side];
+  const po = state.points[opp];
+
+  if (state.tiebreak) {
+    if (ps >= tiebreakTo && ps - po >= 2) {
+      state.sets[side] += 1;
+      recordSetScore(state, side, { tiebreak: true });
+      state.points.A = 0;
+      state.points.B = 0;
+      state.games.A = 0;
+      state.games.B = 0;
+      state.tiebreak = false;
+    }
+    return;
+  }
+
+  const goldenPoint = state.sport === "padel" && config.goldenPoint === true;
+  const winsGame =
+    ps >= 4 &&
+    (ps - po >= 2 || (goldenPoint && po >= 3));
+
+  if (!winsGame) return;
+
+  state.games[side] += 1;
+  state.points.A = 0;
+  state.points.B = 0;
+  const gs = state.games[side];
+  const go = state.games[opp];
+
+  if (state.games.A === 6 && state.games.B === 6) {
+    state.tiebreak = true;
+    return;
+  }
+
+  if (gs >= 6 && gs - go >= 2) {
+    state.sets[side] += 1;
+    recordSetScore(state, side);
+    state.games.A = 0;
+    state.games.B = 0;
+  }
+}
+
+function applyPickleballPoint(state: PickleballState, side: Side): void {
+  const opp: Side = side === "A" ? "B" : "A";
+  const config = state.config;
+  const gamesNeeded = config.bestOf
+    ? Math.floor(config.bestOf / 2) + 1
+    : undefined;
+
+  if (
+    gamesNeeded &&
+    (state.games.A >= gamesNeeded || state.games.B >= gamesNeeded)
+  ) {
+    return;
+  }
+
+  state.points[side] += 1;
+  const ps = state.points[side];
+  const po = state.points[opp];
+  if (ps >= config.pointsTo && ps - po >= config.winBy) {
+    state.games[side] += 1;
+    state.points.A = 0;
+    state.points.B = 0;
+  }
+}
+
+function cloneNumericRecord(record: Record<Side, number>): Record<string, number> {
+  return { A: record.A, B: record.B };
+}
+
+function unwrapScoreEvent(
+  event: ScoreEvent | Record<string, unknown> | null | undefined
+): Record<string, unknown> | null {
+  if (!event || typeof event !== "object") return null;
+  if ("payload" in event && isRecord((event as ScoreEvent).payload)) {
+    return (event as ScoreEvent).payload as Record<string, unknown>;
+  }
+  return event as Record<string, unknown>;
+}
+
+function getEventType(
+  event: ScoreEvent | Record<string, unknown>,
+  payload: Record<string, unknown> | null
+): string | undefined {
+  if (payload && typeof payload.type === "string") {
+    return payload.type;
+  }
+  if (typeof (event as { type?: unknown }).type === "string") {
+    return (event as { type?: string }).type;
+  }
+  return undefined;
+}
+
+function getEventWinner(payload: Record<string, unknown> | null): Side | null {
+  if (!payload) return null;
+  return sanitizeSide(payload.by ?? payload.side ?? payload.winner);
+}
+
+function summarisePadelOrTennis(state: PadelOrTennisState): RacketSummary {
+  const result: RacketSummary = {
+    points: cloneNumericRecord(state.points),
+    games: cloneNumericRecord(state.games),
+    sets: cloneNumericRecord(state.sets),
+    set_scores: state.setScores.map((set) => ({ ...set })),
+  };
+  const config: Record<string, unknown> = {};
+  if (state.config.tiebreakTo !== undefined) config.tiebreakTo = state.config.tiebreakTo;
+  if (state.config.sets !== undefined) config.sets = state.config.sets;
+  if (state.config.goldenPoint !== undefined) config.goldenPoint = state.config.goldenPoint;
+  if (Object.keys(config).length) {
+    result.config = config;
+  }
+  return result;
+}
+
+function summarisePickleball(state: PickleballState): RacketSummary {
+  const result: RacketSummary = {
+    points: cloneNumericRecord(state.points),
+    games: cloneNumericRecord(state.games),
+  };
+  const config: Record<string, unknown> = {
+    pointsTo: state.config.pointsTo,
+    winBy: state.config.winBy,
+  };
+  if (state.config.bestOf !== undefined) config.bestOf = state.config.bestOf;
+  result.config = config;
+  return result;
+}
+
+function rebuildPadelOrTennis(
+  sport: "padel" | "tennis",
+  events: ScoreEvent[] | null | undefined,
+  config: unknown
+): RacketSummary | null {
+  if (!events || events.length === 0) return null;
+  const state = createPadelOrTennisState(sport, config);
+  let processed = false;
+  for (const event of events) {
+    const payload = unwrapScoreEvent(event);
+    const type = getEventType(event, payload);
+    if (type !== "POINT") continue;
+    const side = getEventWinner(payload);
+    if (!side) continue;
+    applyPadelOrTennisPoint(state, side);
+    processed = true;
+  }
+  return processed ? summarisePadelOrTennis(state) : null;
+}
+
+function rebuildPickleball(
+  events: ScoreEvent[] | null | undefined,
+  config: unknown
+): RacketSummary | null {
+  if (!events || events.length === 0) return null;
+  const state = createPickleballState(config);
+  let processed = false;
+  for (const event of events) {
+    const payload = unwrapScoreEvent(event);
+    const type = getEventType(event, payload);
+    if (type !== "POINT") continue;
+    const side = getEventWinner(payload);
+    if (!side) continue;
+    applyPickleballPoint(state, side);
+    processed = true;
+  }
+  return processed ? summarisePickleball(state) : null;
+}
+
+export function rebuildRacketSummaryFromEvents(
+  sport: string | null | undefined,
+  events: ScoreEvent[] | null | undefined,
+  config: unknown
+): RacketSummary | null {
+  const normalized = sport?.toLowerCase();
+  if (normalized === "padel" || normalized === "tennis") {
+    return rebuildPadelOrTennis(normalized, events, config);
+  }
+  if (normalized === "pickleball") {
+    return rebuildPickleball(events, config);
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable `MatchParticipants` component that lays out sides with flex spacing and configurable separators
- update home, admin, matches list, player timeline/upcoming, and match detail views to rely on the shared component for consistent participant rendering
- support alternate separator symbols such as `/` for match headers to match existing formatting

## Testing
- npx vitest run *(fails: RecordSportPage > allows recording multiple bowling players – unable to find placeholder matching /score/i)*

------
https://chatgpt.com/codex/tasks/task_e_68d361a11d848323b5cc42f4b9f0d73b