### PR TITLE
Fix racket summary rebuild when payload lacks set totals

### DIFF
--- a/apps/web/src/lib/match-summary.test.ts
+++ b/apps/web/src/lib/match-summary.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRebuildRacketSummary } from "./match-summary";
+
+describe("shouldRebuildRacketSummary", () => {
+  it("returns true for empty summary objects", () => {
+    expect(shouldRebuildRacketSummary({})).toBe(true);
+  });
+
+  it("returns true when only aggregate sets are present", () => {
+    expect(
+      shouldRebuildRacketSummary({
+        sets: { A: 2, B: 1 },
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when set details are already populated", () => {
+    expect(
+      shouldRebuildRacketSummary({
+        sets: { A: 2, B: 1 },
+        set_scores: [{ A: 6, B: 4 }],
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when games or points already exist", () => {
+    expect(
+      shouldRebuildRacketSummary({
+        games: { A: 3, B: 4 },
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/match-summary.ts
+++ b/apps/web/src/lib/match-summary.ts
@@ -143,8 +143,6 @@ function hasSetScoreDetails(summary: SummaryData): boolean {
 export function shouldRebuildRacketSummary(summary: SummaryData): boolean {
   if (!isRecord(summary)) return false;
   const record = summary as Record<string, unknown>;
-  const hasSets = hasPositiveValues(record["sets"]);
-  if (!hasSets) return false;
   const hasGames = hasPositiveValues(record["games"]);
   const hasPoints = hasPositiveValues(record["points"]);
   const hasDetails = hasSetScoreDetails(summary) || hasGames || hasPoints;


### PR DESCRIPTION
## Summary
- allow racket summaries without score details to trigger the event-based reconstruction
- add unit coverage ensuring empty or aggregate-only payloads request a rebuild while populated summaries do not

## Testing
- npm test -- --run src/lib/match-summary.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d363e6e0c08323932922d697ac6a55