### PR TITLE
Handle non-OK player stats responses in player page

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -203,15 +203,43 @@ type PlayerStatsResult = {
 
 async function getStats(playerId: string): Promise<PlayerStatsResult> {
   try {
-    const r = await apiFetch(
+    const response = await apiFetch(
       `/v0/players/${encodeURIComponent(playerId)}/stats`,
-      { cache: "no-store" } as RequestInit
+      { cache: "no-store" } as RequestInit,
     );
-    if (!r.ok) {
+
+    if (!response.ok) {
       return { stats: null, error: true };
     }
-    const data = (await r.json()) as PlayerStats | null;
-    return { stats: data, error: false };
+
+    if (response.status === 204) {
+      return { stats: null, error: false };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch (parseError) {
+      console.warn(
+        `Failed to parse stats payload for player ${playerId}`,
+        parseError,
+      );
+      return { stats: null, error: true };
+    }
+
+    if (parsed === null) {
+      return { stats: null, error: false };
+    }
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as { playerId?: unknown }).playerId !== "string"
+    ) {
+      return { stats: null, error: true };
+    }
+
+    return { stats: parsed as PlayerStats, error: false };
   } catch (err) {
     console.warn(`Failed to load stats for player ${playerId}`, err);
     return { stats: null, error: true };


### PR DESCRIPTION
## Summary
- ensure the player stats fetch helper treats non-success HTTP statuses as failures before attempting to parse the payload
- treat parse errors and unexpected payload shapes as failures while still allowing 204/no-content responses to surface as "no stats"

## Testing
- npm test *(fails: src/app/record/[sport]/page.test.tsx > RecordSportPage > allows recording multiple bowling players – existing placeholder lookup failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d3642ccc388323bcde100acd054017