### PR TITLE
Handle missing player stats with toast notifications

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  trailingSlash: true,
   eslint: {
     // Allow production builds to complete even if there are ESLint errors.
     ignoreDuringBuilds: true,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -673,3 +673,56 @@ textarea {
 .bowling-total {
   font-weight: 700;
 }
+
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.toast {
+  background: var(--color-surface);
+  color: inherit;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(10, 31, 68, 0.18);
+  padding: 0.75rem 1rem;
+  border-left: 4px solid var(--color-accent-blue);
+  min-width: min(320px, 80vw);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  pointer-events: auto;
+}
+
+.toast--error {
+  border-left-color: var(--color-accent-red);
+}
+
+.toast--success {
+  border-left-color: #2b8a3e;
+}
+
+.toast__message {
+  flex: 1;
+}
+
+.toast__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.toast__close:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 2px;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import './globals.css';
 import Header from './header';
 import ChunkErrorReload from '../components/ChunkErrorReload';
+import ToastProvider from '../components/ToastProvider';
 import { headers } from 'next/headers';
 import { LocaleProvider } from '../lib/LocaleContext';
 import { parseAcceptLanguage } from '../lib/i18n';
@@ -24,9 +25,11 @@ export default function RootLayout({
     <html lang={locale}>
       <body>
         <LocaleProvider locale={locale}>
-          <ChunkErrorReload />
-          <Header />
-          {children}
+          <ToastProvider>
+            <ChunkErrorReload />
+            <Header />
+            {children}
+          </ToastProvider>
         </LocaleProvider>
       </body>
     </html>

--- a/apps/web/src/app/players/[id]/StatsErrorToast.tsx
+++ b/apps/web/src/app/players/[id]/StatsErrorToast.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useToast } from "../../../components/ToastProvider";
+
+interface StatsErrorToastProps {
+  show: boolean;
+}
+
+export default function StatsErrorToast({ show }: StatsErrorToastProps) {
+  const { showToast } = useToast();
+  const previous = useRef(false);
+
+  useEffect(() => {
+    if (show && !previous.current) {
+      showToast({
+        message: "We couldn't load this player's stats right now.",
+        type: "error",
+      });
+    }
+    previous.current = show;
+  }, [show, showToast]);
+
+  return null;
+}

--- a/apps/web/src/components/ToastProvider.tsx
+++ b/apps/web/src/components/ToastProvider.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type ToastType = "info" | "success" | "error";
+
+export interface ShowToastOptions {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+}
+
+interface Toast extends Required<Omit<ShowToastOptions, "duration">> {
+  id: number;
+  duration: number;
+}
+
+interface ToastContextValue {
+  showToast: (options: ShowToastOptions) => void;
+  dismissToast: (id: number) => void;
+}
+
+const DEFAULT_DURATION = 5000;
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}
+
+function normalizeDuration(duration: number | undefined): number {
+  if (typeof duration !== "number") return DEFAULT_DURATION;
+  if (!Number.isFinite(duration) || duration <= 0) return DEFAULT_DURATION;
+  return duration;
+}
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef(new Map<number, number>());
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+    const timeoutId = timers.current.get(id);
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const showToast = useCallback(
+    ({ message, type = "info", duration }: ShowToastOptions) => {
+      if (!message) return;
+      const toast: Toast = {
+        id: Date.now() + Math.floor(Math.random() * 1000),
+        message,
+        type,
+        duration: normalizeDuration(duration),
+      };
+      setToasts((current) => [...current, toast]);
+
+      const timeoutId = window.setTimeout(() => {
+        dismissToast(toast.id);
+      }, toast.duration);
+      timers.current.set(toast.id, timeoutId);
+    },
+    [dismissToast]
+  );
+
+  useEffect(() => {
+    return () => {
+      timers.current.forEach((timeoutId) => window.clearTimeout(timeoutId));
+      timers.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ showToast, dismissToast }),
+    [showToast, dismissToast]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="toast-container" aria-live="assertive" aria-atomic="true">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`toast toast--${toast.type}`}
+            role="status"
+            aria-live="assertive"
+          >
+            <span className="toast__message">{toast.message}</span>
+            <button
+              type="button"
+              className="toast__close"
+              onClick={() => dismissToast(toast.id)}
+              aria-label="Dismiss notification"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/apps/web/src/lib/stats.ts
+++ b/apps/web/src/lib/stats.ts
@@ -1,0 +1,64 @@
+export interface MatchSummary {
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+  winPct: number;
+}
+
+type MatchSummaryInput =
+  | MatchSummary
+  | {
+      wins?: unknown;
+      losses?: unknown;
+      draws?: unknown;
+      total?: unknown;
+      winPct?: unknown;
+    };
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value)) return null;
+  return value;
+}
+
+export function parseMatchSummary(value: unknown): MatchSummary | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const summary = value as MatchSummaryInput;
+  const wins = coerceNumber(summary.wins);
+  const losses = coerceNumber(summary.losses);
+  const draws = coerceNumber(summary.draws ?? 0);
+  const total = coerceNumber(summary.total);
+  const winPct = coerceNumber(summary.winPct);
+
+  if (
+    wins === null ||
+    losses === null ||
+    draws === null ||
+    total === null ||
+    winPct === null
+  ) {
+    return null;
+  }
+
+  if (total <= 0) {
+    return null;
+  }
+
+  return { wins, losses, draws, total, winPct };
+}
+
+export function normalizePlayerStats<T extends { matchSummary?: unknown }>(
+  raw: T | null | undefined
+): (T & { matchSummary: MatchSummary }) | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const summary = parseMatchSummary((raw as { matchSummary?: unknown }).matchSummary);
+  if (!summary) {
+    return null;
+  }
+  return { ...raw, matchSummary: summary } as T & { matchSummary: MatchSummary };
+}


### PR DESCRIPTION
## Summary
- add a global toast provider and styles so API failures surface non-blocking alerts
- normalize player stats responses, show "Stats unavailable" when data is missing, and guard the player detail view from bad stats payloads
- emit stats failure toasts on list/detail pages and enforce trailing slashes in Next routing to stabilize navigation

## Testing
- npx vitest run src/app/players/page.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d3641f0f50832380a6f5f176cb098d