### PR TITLE
Allow zero totals in match summary normalization

### DIFF
--- a/apps/web/src/lib/player-stats.test.ts
+++ b/apps/web/src/lib/player-stats.test.ts
@@ -35,7 +35,19 @@ describe("normalizeMatchSummary", () => {
     ).toBeNull();
   });
 
-  it("returns null for non-positive totals", () => {
+  it("returns null for negative totals", () => {
+    expect(
+      normalizeMatchSummary({
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        total: -1,
+        winPct: 0,
+      })
+    ).toBeNull();
+  });
+
+  it("allows zero totals when no games have been played", () => {
     expect(
       normalizeMatchSummary({
         wins: 0,
@@ -44,7 +56,13 @@ describe("normalizeMatchSummary", () => {
         total: 0,
         winPct: 0,
       })
-    ).toBeNull();
+    ).toEqual({
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      total: 0,
+      winPct: 0,
+    });
   });
 });
 

--- a/apps/web/src/lib/player-stats.ts
+++ b/apps/web/src/lib/player-stats.ts
@@ -34,7 +34,7 @@ export function normalizeMatchSummary(
   ) {
     return null;
   }
-  if (total <= 0 || wins < 0 || losses < 0 || winPct < 0) {
+  if (total < 0 || wins < 0 || losses < 0 || winPct < 0) {
     return null;
   }
   const normalizedDraws =


### PR DESCRIPTION
## Summary
- allow match summaries with zero total to pass validation while keeping other guardrails
- add coverage ensuring zero-total summaries return sanitized data and negative totals are rejected

## Testing
- npx vitest run src/lib/player-stats.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d36fcaf8888323a1f4736224094699