### PR TITLE
Validate bowling inputs live and show frame totals

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -42,6 +42,139 @@ function createEmptyBowlingFrames(): BowlingFrames {
   );
 }
 
+function getBowlingPlayerLabel(
+  entry: BowlingEntry,
+  index: number,
+  players: Player[]
+): string {
+  const player = players.find((p) => p.id === entry.playerId);
+  return player?.name?.trim() ? player.name : `Player ${index + 1}`;
+}
+
+function sanitizeBowlingRollInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const pins = Number(trimmed);
+  if (!Number.isFinite(pins) || !Number.isInteger(pins)) {
+    return null;
+  }
+  if (pins < 0 || pins > 10) {
+    return null;
+  }
+  return String(pins);
+}
+
+function invalidRollMessage(
+  playerLabel: string,
+  frameIndex: number,
+  rollIndex: number
+): string {
+  return `${playerLabel} – Frame ${frameIndex + 1}: roll ${
+    rollIndex + 1
+  } must be a whole number between 0 and 10 pins.`;
+}
+
+function validateRegularFrame(
+  frame: string[],
+  frameIndex: number,
+  playerLabel: string
+): string | null {
+  const context = `${playerLabel} – Frame ${frameIndex + 1}`;
+  const firstRaw = frame[0]?.trim() ?? "";
+  if (!firstRaw) {
+    return null;
+  }
+  const first = Number(firstRaw);
+  if (!Number.isFinite(first) || !Number.isInteger(first)) {
+    return `${context}: roll 1 must be a whole number.`;
+  }
+  if (first < 0 || first > 10) {
+    return `${context}: roll 1 must be between 0 and 10 pins.`;
+  }
+  const secondRaw = frame[1]?.trim() ?? "";
+  if (first === 10) {
+    if (secondRaw) {
+      return `${context}: leave roll 2 empty after a strike.`;
+    }
+    return null;
+  }
+  if (!secondRaw) {
+    return null;
+  }
+  const second = Number(secondRaw);
+  if (!Number.isFinite(second) || !Number.isInteger(second)) {
+    return `${context}: roll 2 must be a whole number.`;
+  }
+  if (second < 0 || second > 10) {
+    return `${context}: roll 2 must be between 0 and 10 pins.`;
+  }
+  if (first + second > 10) {
+    return `${context}: rolls 1 and 2 cannot exceed 10 pins.`;
+  }
+  return null;
+}
+
+function validateFinalFrame(frame: string[], playerLabel: string): string | null {
+  const context = `${playerLabel} – Frame ${BOWLING_FRAME_COUNT}`;
+  const firstRaw = frame[0]?.trim() ?? "";
+  if (!firstRaw) {
+    return null;
+  }
+  const first = Number(firstRaw);
+  if (!Number.isFinite(first) || !Number.isInteger(first)) {
+    return `${context}: roll 1 must be a whole number.`;
+  }
+  if (first < 0 || first > 10) {
+    return `${context}: roll 1 must be between 0 and 10 pins.`;
+  }
+  const secondRaw = frame[1]?.trim() ?? "";
+  if (!secondRaw) {
+    return null;
+  }
+  const second = Number(secondRaw);
+  if (!Number.isFinite(second) || !Number.isInteger(second)) {
+    return `${context}: roll 2 must be a whole number.`;
+  }
+  if (second < 0 || second > 10) {
+    return `${context}: roll 2 must be between 0 and 10 pins.`;
+  }
+  if (first !== 10 && first + second > 10) {
+    return `${context}: rolls 1 and 2 cannot exceed 10 pins.`;
+  }
+  const thirdRaw = frame[2]?.trim() ?? "";
+  const earnedThird = first === 10 || first + second === 10;
+  if (!thirdRaw) {
+    return null;
+  }
+  if (!earnedThird) {
+    return `${context}: roll 3 is only available after a strike or spare.`;
+  }
+  const third = Number(thirdRaw);
+  if (!Number.isFinite(third) || !Number.isInteger(third)) {
+    return `${context}: roll 3 must be a whole number.`;
+  }
+  if (third < 0 || third > 10) {
+    return `${context}: roll 3 must be between 0 and 10 pins.`;
+  }
+  if (first === 10 && second !== 10 && second + third > 10) {
+    return `${context}: rolls 2 and 3 cannot exceed 10 pins unless roll 2 is a strike.`;
+  }
+  return null;
+}
+
+function validateBowlingFrameInput(
+  frames: BowlingFrames,
+  frameIndex: number,
+  playerLabel: string
+): string | null {
+  if (frameIndex === BOWLING_FRAME_COUNT - 1) {
+    return validateFinalFrame(frames[frameIndex] ?? [], playerLabel);
+  }
+  return validateRegularFrame(frames[frameIndex] ?? [], frameIndex, playerLabel);
+}
+
 export default function RecordSportPage() {
   const router = useRouter();
   const params = useParams();
@@ -55,6 +188,9 @@ export default function RecordSportPage() {
   const [bowlingEntries, setBowlingEntries] = useState<BowlingEntry[]>([
     { playerId: "", frames: createEmptyBowlingFrames() },
   ]);
+  const [bowlingValidationErrors, setBowlingValidationErrors] = useState<
+    (string | null)[]
+  >([null]);
   const [scoreA, setScoreA] = useState("0");
   const [scoreB, setScoreB] = useState("0");
   const [error, setError] = useState<string | null>(null);
@@ -90,38 +226,151 @@ export default function RecordSportPage() {
         i === index ? { ...entry, playerId: value } : entry
       )
     );
+    setBowlingValidationErrors((prev) => {
+      const next = prev.slice();
+      if (index >= next.length) {
+        next.length = index + 1;
+      }
+      next[index] = null;
+      return next;
+    });
   };
 
   const handleBowlingRollChange = (
     entryIndex: number,
     frameIndex: number,
     rollIndex: number,
-    value: string
+    rawValue: string
   ) => {
-    setBowlingEntries((prev) =>
-      prev.map((entry, idx) => {
-        if (idx !== entryIndex) return entry;
-        const frames = entry.frames.map((frame, fIdx) => {
-          if (fIdx !== frameIndex) return frame;
-          const updated = frame.slice();
-          updated[rollIndex] = value;
-          return updated;
-        });
-        return { ...entry, frames };
-      })
-    );
+    let nextError: string | null = null;
+    let updated = false;
+
+    setBowlingEntries((prev) => {
+      const entry = prev[entryIndex];
+      if (!entry) {
+        return prev;
+      }
+      const playerLabel = getBowlingPlayerLabel(entry, entryIndex, players);
+      const sanitized = sanitizeBowlingRollInput(rawValue);
+      if (sanitized === null) {
+        nextError = invalidRollMessage(playerLabel, frameIndex, rollIndex);
+        return prev;
+      }
+
+      const frames = entry.frames.map((frame) => frame.slice());
+      const frame = frames[frameIndex] ?? [];
+      const isTenthFrame = frameIndex === BOWLING_FRAME_COUNT - 1;
+
+      if (!isTenthFrame && rollIndex === 1) {
+        const firstValue = frame[0]?.trim() ?? "";
+        if (firstValue === "10" && sanitized !== "") {
+          nextError = `${playerLabel} – Frame ${frameIndex + 1}: leave roll 2 empty after a strike.`;
+          return prev;
+        }
+      }
+
+      if (isTenthFrame && rollIndex === 2 && sanitized !== "") {
+        const secondValue = frame[1]?.trim() ?? "";
+        if (!secondValue) {
+          nextError = `${playerLabel} – Frame ${BOWLING_FRAME_COUNT}: enter roll 2 before roll 3.`;
+          return prev;
+        }
+      }
+
+      frame[rollIndex] = sanitized;
+
+      if (rollIndex === 0) {
+        if (!sanitized) {
+          for (let i = 1; i < frame.length; i += 1) {
+            frame[i] = "";
+          }
+        } else if (!isTenthFrame && sanitized === "10") {
+          frame[1] = "";
+        } else if (isTenthFrame && sanitized !== "10") {
+          frame[2] = "";
+        }
+      }
+
+      if (isTenthFrame && rollIndex === 1) {
+        if (!sanitized) {
+          frame[2] = "";
+        }
+      }
+
+      if (isTenthFrame) {
+        const firstValue = frame[0]?.trim() ?? "";
+        const secondValue = frame[1]?.trim() ?? "";
+        if (!firstValue) {
+          frame[1] = "";
+          frame[2] = "";
+        } else {
+          const firstPins = Number(firstValue);
+          const secondPins = secondValue ? Number(secondValue) : null;
+          const earnedThird =
+            firstPins === 10 ||
+            (secondPins !== null && firstPins + secondPins === 10);
+          if (!earnedThird) {
+            frame[2] = "";
+          }
+        }
+      }
+
+      frames[frameIndex] = frame;
+
+      const validationError = validateBowlingFrameInput(
+        frames,
+        frameIndex,
+        playerLabel
+      );
+      if (validationError) {
+        nextError = validationError;
+        return prev;
+      }
+
+      nextError = null;
+      updated = true;
+      return prev.map((item, idx) =>
+        idx === entryIndex ? { ...item, frames } : item
+      );
+    });
+
+    setBowlingValidationErrors((prev) => {
+      const next = prev.slice();
+      if (entryIndex >= next.length) {
+        for (let i = next.length; i <= entryIndex; i += 1) {
+          next[i] = null;
+        }
+      }
+      next[entryIndex] = nextError;
+      return next;
+    });
+
+    if (updated) {
+      setError(null);
+    }
   };
 
   const handleAddBowlingPlayer = () => {
     setBowlingEntries((prev) =>
       prev.concat({ playerId: "", frames: createEmptyBowlingFrames() })
     );
+    setBowlingValidationErrors((prev) => prev.concat(null));
   };
 
   const handleRemoveBowlingPlayer = (index: number) => {
-    setBowlingEntries((prev) =>
-      prev.length > 1 ? prev.filter((_, i) => i !== index) : prev
-    );
+    let removed = false;
+    setBowlingEntries((prev) => {
+      if (prev.length <= 1) {
+        return prev;
+      }
+      removed = true;
+      return prev.filter((_, i) => i !== index);
+    });
+    if (removed) {
+      setBowlingValidationErrors((prev) =>
+        prev.length > 1 ? prev.filter((_, i) => i !== index) : prev
+      );
+    }
   };
 
   const handleToggle = (checked: boolean) => {
@@ -354,19 +603,17 @@ export default function RecordSportPage() {
             </p>
             <div className="form-stack">
               {bowlingEntries.map((entry, idx) => {
-                const player = players.find((p) => p.id === entry.playerId);
-                const playerLabel = player?.name?.trim()
-                  ? player.name
-                  : `Player ${idx + 1}`;
-                let previewTotal: number | null = null;
+                const playerLabel = getBowlingPlayerLabel(entry, idx, players);
+                const entryError = bowlingValidationErrors[idx] ?? null;
+                let summary: BowlingSummaryResult | null = null;
                 try {
-                  const summary = summarizeBowlingInput(entry.frames, {
+                  summary = summarizeBowlingInput(entry.frames, {
                     playerLabel,
                   });
-                  previewTotal = summary.total;
                 } catch {
-                  previewTotal = null;
+                  summary = null;
                 }
+                const previewTotal = summary?.total ?? null;
                 return (
                   <section key={idx} className="bowling-entry">
                     <div className="bowling-entry-header">
@@ -405,51 +652,73 @@ export default function RecordSportPage() {
                         )}
                       </div>
                     </div>
+                    {entryError && (
+                      <p className="error" role="alert">
+                        {entryError}
+                      </p>
+                    )}
                     <div className="bowling-frames-grid">
-                      {entry.frames.map((frame, frameIdx) => (
-                        <div key={frameIdx} className="bowling-frame-card">
-                          <span className="bowling-frame-label">
-                            Frame {frameIdx + 1}
-                          </span>
-                          <div
-                            className={`bowling-rolls bowling-rolls--${frame.length}`}
-                          >
-                            {frame.map((roll, rollIdx) => {
-                              const inputId = `bowling-${idx}-${frameIdx}-${rollIdx}`;
-                              return (
-                                <div key={rollIdx} className="bowling-roll-field">
-                                  <label
-                                    className="bowling-roll-label"
-                                    htmlFor={inputId}
-                                  >
-                                    R{rollIdx + 1}
-                                  </label>
-                                  <input
-                                    id={inputId}
-                                    type="number"
-                                    min={0}
-                                    max={10}
-                                    step={1}
-                                    value={roll}
-                                    inputMode="numeric"
-                                    onChange={(e) =>
-                                      handleBowlingRollChange(
-                                        idx,
-                                        frameIdx,
-                                        rollIdx,
-                                        e.target.value
-                                      )
-                                    }
-                                    aria-label={`${playerLabel} frame ${
-                                      frameIdx + 1
-                                    } roll ${rollIdx + 1}`}
-                                  />
-                                </div>
-                              );
-                            })}
+                      {entry.frames.map((frame, frameIdx) => {
+                        const frameTotal =
+                          summary &&
+                          typeof summary.frameScores?.[frameIdx] === "number"
+                            ? summary.frameScores[frameIdx]
+                            : null;
+                        return (
+                          <div key={frameIdx} className="bowling-frame-card">
+                            <span className="bowling-frame-label">
+                              Frame {frameIdx + 1}
+                            </span>
+                            <div
+                              className={`bowling-rolls bowling-rolls--${frame.length}`}
+                            >
+                              {frame.map((roll, rollIdx) => {
+                                const inputId = `bowling-${idx}-${frameIdx}-${rollIdx}`;
+                                return (
+                                  <div key={rollIdx} className="bowling-roll-field">
+                                    <label
+                                      className="bowling-roll-label"
+                                      htmlFor={inputId}
+                                    >
+                                      R{rollIdx + 1}
+                                    </label>
+                                    <input
+                                      id={inputId}
+                                      type="number"
+                                      min={0}
+                                      max={10}
+                                      step={1}
+                                      value={roll}
+                                      inputMode="numeric"
+                                      onChange={(e) =>
+                                        handleBowlingRollChange(
+                                          idx,
+                                          frameIdx,
+                                          rollIdx,
+                                          e.target.value
+                                        )
+                                      }
+                                      aria-label={`${playerLabel} frame ${
+                                        frameIdx + 1
+                                      } roll ${rollIdx + 1}`}
+                                    />
+                                  </div>
+                                );
+                              })}
+                            </div>
+                            <span
+                              className="bowling-frame-total"
+                              role="status"
+                              aria-live="polite"
+                              aria-label={`${playerLabel} frame ${
+                                frameIdx + 1
+                              } total`}
+                            >
+                              Total: {frameTotal != null ? frameTotal : "—"}
+                            </span>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   </section>
                 );


### PR DESCRIPTION
## Summary
- add client-side bowling roll validation helpers and track per-player errors
- prevent invalid frame updates while keeping totals in sync via summarizeBowlingInput
- surface cumulative frame totals and a running score preview in the bowling entry UI
- extend record page tests to cover validation feedback and total updates

## Testing
- pnpm vitest run src/app/record/[sport]/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3727247b08323a77bd83830a91110