### PR TITLE
Fix leaderboard tab routing and errors

### DIFF
--- a/apps/web/src/app/all-sports/page.tsx
+++ b/apps/web/src/app/all-sports/page.tsx
@@ -16,9 +16,10 @@ export default function AllSportsRedirect({
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
 
-  const params = new URLSearchParams({ tab: "all" });
+  const params = new URLSearchParams();
   if (country) params.set("country", country);
   if (clubId) params.set("clubId", clubId);
 
-  redirect(`/leaderboard?${params.toString()}`);
+  const query = params.toString();
+  redirect(query ? `/leaderboard?${query}` : "/leaderboard");
 }

--- a/apps/web/src/app/leaderboard/[sport]/page.tsx
+++ b/apps/web/src/app/leaderboard/[sport]/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from "next/navigation";
-import { ALL_SPORTS, SPORTS } from "../leaderboard";
+import {
+  ALL_SPORTS,
+  type LeaderboardSport,
+  isLeaderboardSport,
+} from "../constants";
 
 type LeaderboardSearchParams = {
   country?: string | string[];
@@ -9,8 +13,18 @@ type LeaderboardSearchParams = {
 const toSingleValue = (value?: string | string[]) =>
   Array.isArray(value) ? value[0] : value;
 
-const isSupportedSport = (value: string) =>
-  value === ALL_SPORTS || (SPORTS as readonly string[]).includes(value);
+const redirectToLeaderboard = (
+  sport: LeaderboardSport | undefined,
+  country?: string,
+  clubId?: string,
+): never => {
+  const params = new URLSearchParams();
+  if (sport && sport !== ALL_SPORTS) params.set("sport", sport);
+  if (country) params.set("country", country);
+  if (clubId) params.set("clubId", clubId);
+  const query = params.toString();
+  redirect(query ? `/leaderboard?${query}` : "/leaderboard");
+};
 
 export default function LeaderboardSportPage({
   params,
@@ -23,17 +37,9 @@ export default function LeaderboardSportPage({
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
 
-  if (!isSupportedSport(sport)) {
-    const fallback = new URLSearchParams();
-    if (country) fallback.set("country", country);
-    if (clubId) fallback.set("clubId", clubId);
-    const query = fallback.toString();
-    redirect(query ? `/leaderboard?${query}` : "/leaderboard");
+  if (!isLeaderboardSport(sport)) {
+    redirectToLeaderboard(undefined, country, clubId);
   }
 
-  const paramsWithFilters = new URLSearchParams({ tab: sport });
-  if (country) paramsWithFilters.set("country", country);
-  if (clubId) paramsWithFilters.set("clubId", clubId);
-
-  redirect(`/leaderboard?${paramsWithFilters.toString()}`);
+  redirectToLeaderboard(sport, country, clubId);
 }

--- a/apps/web/src/app/leaderboard/constants.ts
+++ b/apps/web/src/app/leaderboard/constants.ts
@@ -1,0 +1,16 @@
+export const ALL_SPORTS = "all" as const;
+export const MASTER_SPORT = "master" as const;
+export const SPORTS = ["padel", "badminton", "table-tennis", "disc_golf"] as const;
+
+export const SPORT_OPTIONS = [ALL_SPORTS, MASTER_SPORT, ...SPORTS] as const;
+
+export type LeaderboardSport = (typeof SPORT_OPTIONS)[number];
+
+const SPORT_OPTION_SET = new Set<string>(SPORT_OPTIONS);
+
+export function isLeaderboardSport(
+  value: string | null | undefined,
+): value is LeaderboardSport {
+  if (value == null) return false;
+  return SPORT_OPTION_SET.has(value);
+}

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import Leaderboard from "./leaderboard";
 import { apiUrl } from "../../lib/api";
@@ -19,6 +19,7 @@ describe("Leaderboard", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     // @ts-expect-error - cleanup mocked fetch between tests
     global.fetch = undefined;
   });
@@ -79,5 +80,16 @@ describe("Leaderboard", () => {
     expect(urls).toContain(
       apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")
     );
+  });
+
+  it("shows an error message when fetching fails", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("boom"));
+    global.fetch = fetchMock as typeof fetch;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(<Leaderboard sport="padel" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await screen.findByText("We couldn't load the leaderboard right now.");
   });
 });

--- a/apps/web/src/app/leaderboard/master/page.tsx
+++ b/apps/web/src/app/leaderboard/master/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { MASTER_SPORT } from "../constants";
 
 type LeaderboardSearchParams = {
   country?: string | string[];
@@ -15,7 +16,7 @@ export default function MasterLeaderboardPage({
 }) {
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
-  const params = new URLSearchParams({ tab: "master" });
+  const params = new URLSearchParams({ sport: MASTER_SPORT });
   if (country) params.set("country", country);
   if (clubId) params.set("clubId", clubId);
   redirect(`/leaderboard?${params.toString()}`);

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from "next/navigation";
-import Leaderboard, { ALL_SPORTS, SPORTS } from "./leaderboard";
+import Leaderboard from "./leaderboard";
+import {
+  ALL_SPORTS,
+  type LeaderboardSport,
+  isLeaderboardSport,
+} from "./constants";
 
 type LeaderboardSearchParams = {
   country?: string | string[];
@@ -11,19 +16,24 @@ type LeaderboardSearchParams = {
 const toSingleValue = (value?: string | string[]) =>
   Array.isArray(value) ? value[0] : value;
 
-const resolveTab = (raw?: string) => {
-  if (!raw) return ALL_SPORTS;
-  if (raw === "master" || raw === ALL_SPORTS) return raw;
-  if ((SPORTS as readonly string[]).includes(raw)) return raw;
-  return null;
+const parseSportParam = (
+  raw?: string | null,
+): LeaderboardSport | undefined | null => {
+  if (raw == null) return undefined;
+  return isLeaderboardSport(raw) ? raw : null;
 };
 
-const buildFilterQuery = (country?: string, clubId?: string) => {
+const redirectToLeaderboard = (
+  sport: LeaderboardSport | undefined,
+  country?: string,
+  clubId?: string,
+): never => {
   const params = new URLSearchParams();
+  if (sport && sport !== ALL_SPORTS) params.set("sport", sport);
   if (country) params.set("country", country);
   if (clubId) params.set("clubId", clubId);
   const query = params.toString();
-  return query ? `?${query}` : "";
+  redirect(query ? `/leaderboard?${query}` : "/leaderboard");
 };
 
 export default function LeaderboardIndexPage({
@@ -33,20 +43,32 @@ export default function LeaderboardIndexPage({
 }) {
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
-  const rawTab =
-    toSingleValue(searchParams?.tab) ?? toSingleValue(searchParams?.sport);
-  const tab = resolveTab(rawTab ?? undefined);
+  const rawSport = toSingleValue(searchParams?.sport);
+  const rawTab = toSingleValue(searchParams?.tab);
 
-  if (rawTab && !tab) {
-    const filterQuery = buildFilterQuery(country, clubId);
-    redirect(`/leaderboard${filterQuery}`);
+  const sportParam = parseSportParam(rawSport);
+  const tabParam = parseSportParam(rawTab);
+
+  if (sportParam === null) {
+    if (tabParam) {
+      redirectToLeaderboard(tabParam, country, clubId);
+    }
+    redirectToLeaderboard(undefined, country, clubId);
   }
 
+  if (tabParam === null) {
+    redirectToLeaderboard(sportParam ?? undefined, country, clubId);
+  }
+
+  if (sportParam && rawTab) {
+    redirectToLeaderboard(sportParam, country, clubId);
+  } else if (!sportParam && tabParam) {
+    redirectToLeaderboard(tabParam, country, clubId);
+  }
+
+  const sport = sportParam ?? tabParam ?? ALL_SPORTS;
+
   return (
-    <Leaderboard
-      sport={tab ?? ALL_SPORTS}
-      country={country}
-      clubId={clubId}
-    />
+    <Leaderboard sport={sport} country={country} clubId={clubId} />
   );
 }


### PR DESCRIPTION
## Summary
- share sport constants between server and client components and validate sport parameters before rendering leaderboards
- update the leaderboard UI to link with sport=... queries, add better fetch error handling, and keep regional filters intact
- redirect legacy tab-based routes to canonical sport URLs for all-sports and master pages and add coverage for fetch failures

## Testing
- `pnpm vitest run src/app/leaderboard/leaderboard.test.tsx`
- `pnpm test` *(fails: existing src/app/matches/[mid]/live-summary.tsx parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68d3729e2aa083239d051c4c16918b56