### PR TITLE
Fix locale detection and label time input

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -322,13 +322,15 @@ export default function RecordSportPage() {
               />
             </label>
             <label className="form-field" htmlFor="record-time">
-              <span className="form-label">Start time</span>
+              <span className="form-label" id="record-time-label">
+                Start time
+              </span>
               <input
                 id="record-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                lang={locale}
+                aria-labelledby="record-time-label"
               />
             </label>
           </div>

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -233,13 +233,15 @@ export default function RecordPadelPage() {
               </span>
             </label>
             <label className="form-field" htmlFor="padel-time">
-              <span className="form-label">Start time</span>
+              <span className="form-label" id="padel-time-label">
+                Start time
+              </span>
               <input
                 id="padel-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                lang={locale}
+                aria-labelledby="padel-time-label"
               />
             </label>
           </div>

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LocaleProvider, useLocale } from './LocaleContext';
+
+describe('LocaleProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function LocaleConsumer() {
+    const locale = useLocale();
+    return <span data-testid="locale-value">{locale}</span>;
+  }
+
+  it('prefers the primary browser locale when available', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-AU', 'en-US']);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-AU');
+  });
+
+  it('falls back to navigator.language when languages is empty', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-GB');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-GB');
+  });
+
+  it('falls back to the provided locale when browser values are unavailable', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('');
+
+    render(
+      <LocaleProvider locale="fr-FR">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('fr-FR');
+  });
+
+  it('updates when the browser language changes', async () => {
+    let languages: string[] = ['en-US'];
+    vi.spyOn(window.navigator, 'languages', 'get').mockImplementation(() => languages);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    await screen.findByTestId('locale-value');
+    languages = ['en-GB'];
+
+    await act(async () => {
+      window.dispatchEvent(new Event('languagechange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('en-GB');
+    });
+  });
+});

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -5,23 +5,52 @@ import { normalizeLocale } from './i18n';
 
 const LocaleContext = createContext('en-US');
 
+function getBrowserLocale(fallback: string): string {
+  if (typeof navigator === 'undefined') {
+    return fallback;
+  }
+
+  const languages = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+  const preferred = languages.find((lang) => typeof lang === 'string' && lang.length > 0);
+  const candidate = preferred ?? navigator.language;
+
+  return normalizeLocale(candidate, fallback);
+}
+
 interface ProviderProps {
   locale: string;
   children: React.ReactNode;
 }
 
 export function LocaleProvider({ locale, children }: ProviderProps) {
-  const [currentLocale, setCurrentLocale] = useState(locale);
+  const [currentLocale, setCurrentLocale] = useState(() => normalizeLocale(locale));
 
   useEffect(() => {
-    const browserLocale = normalizeLocale(
-      typeof navigator !== 'undefined' ? navigator.language : undefined,
-      locale,
-    );
-    if (browserLocale !== currentLocale) {
-      setCurrentLocale(browserLocale);
+    setCurrentLocale((prev) => {
+      const normalized = normalizeLocale(locale);
+      return prev === normalized ? prev : normalized;
+    });
+  }, [locale]);
+
+  useEffect(() => {
+    const applyBrowserLocale = () => {
+      const browserLocale = getBrowserLocale(locale);
+      setCurrentLocale((prev) => (prev === browserLocale ? prev : browserLocale));
+    };
+
+    applyBrowserLocale();
+
+    if (typeof window === 'undefined') {
+      return;
     }
-  }, [locale, currentLocale]);
+
+    window.addEventListener('languagechange', applyBrowserLocale);
+    return () => {
+      window.removeEventListener('languagechange', applyBrowserLocale);
+    };
+  }, [locale]);
 
   return <LocaleContext.Provider value={currentLocale}>{children}</LocaleContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- prefer the browser locale in LocaleProvider and fall back cleanly when unavailable
- add unit tests covering locale detection and languagechange updates
- label the padel and general record time fields while removing the incorrect lang attribute

## Testing
- pnpm test --run src/lib/LocaleContext.test.tsx
- pnpm lint *(fails: existing parse error in apps/web/src/app/matches/[mid]/live-summary.tsx)*
- pnpm test *(fails: existing parse error in apps/web/src/app/matches/[mid]/live-summary.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d372545d1c8323ad1d7ec6a2119eca