### PR TITLE
Fix record slug handling for sports with underscores

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -144,6 +144,46 @@ describe("RecordSportPage", () => {
     expect(typeof payload.sets[0][1]).toBe("number");
   });
 
+  it("sends the canonical sport id when the route uses a dashed slug", async () => {
+    sportParam = "table-tennis";
+    const players = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+      { id: "3", name: "Cara" },
+      { id: "4", name: "Dan" },
+    ];
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ players }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordSportPage />);
+
+    await screen.findAllByText("Alice");
+
+    fireEvent.change(screen.getByLabelText(/team a player 1/i), {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText(/team b player 1/i), {
+      target: { value: "3" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("A"), {
+      target: { value: "6" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("B"), {
+      target: { value: "8" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const payload = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(payload.sport).toBe("table_tennis");
+  });
+
   it("allows recording multiple bowling players", async () => {
     sportParam = "bowling";
     const players = [

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -178,7 +178,8 @@ function validateBowlingFrameInput(
 export default function RecordSportPage() {
   const router = useRouter();
   const params = useParams();
-  const sport = typeof params.sport === "string" ? params.sport : "";
+  const rawSport = typeof params.sport === "string" ? params.sport : "";
+  const sport = rawSport.replace(/-/g, "_");
   const isPadel = sport === "padel";
   const isPickleball = sport === "pickleball";
   const isBowling = sport === "bowling";


### PR DESCRIPTION
## Summary
- convert dashed sport route params back to canonical underscore ids before invoking the record APIs
- add a regression test to ensure dashed slugs submit the underscore sport id

## Testing
- npm test -- --run *(fails: existing esbuild error in src/app/matches/[mid]/live-summary.tsx)*
- npm test -- --run src/app/record/[sport]/page.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d37c0998548323b3fd515db74084c2