### PR TITLE
Improve live match summary event handling

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  SummaryData,
-  RacketSummary,
-  DiscGolfSummary,
-  BowlingSummary,
-  SetScores,
+  type SummaryData,
+  type RacketSummary,
+  type SetScores,
+  type ScoreEvent,
   getNumericEntries,
   hasPositiveValues,
   isRecord,
@@ -15,12 +14,13 @@ import {
 import { useMatchStream } from "../../../lib/useMatchStream";
 import MatchScoreboard from "./MatchScoreboard";
 
-function extractConfig(summary: SummaryData): unknown {
-  if (isRecord(summary) && "config" in summary) {
-    return (summary as { config?: unknown }).config;
-  }
-  return undefined;
-}
+type LiveSummaryProps = {
+  mid: string;
+  sport?: string | null;
+  status?: string | null;
+  initialSummary?: SummaryData | null;
+  initialEvents?: ScoreEvent[] | null;
+};
 
 function sanitizeStatus(value?: string | null): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -101,15 +101,293 @@ function enrichSummary(summary: SummaryData): SummaryData {
   return changed ? next : summary;
 }
 
-function formatScoreline(summary?: SummaryData): string {
-  if (!isRecord(summary)) return "—";
-  const maybe = summary as RacketSummary;
+function formatScoreline(summary?: SummaryData | null): string {
+  if (!isRecord(summary)) return "Overall: —";
+  const maybe = summary as RacketSummary & Record<string, unknown>;
   const setsHistory = maybe.set_scores;
   if (Array.isArray(setsHistory) && setsHistory.length) {
     const formatted = setsHistory
       .map((set) => {
         const entries = getNumericEntries(set);
         if (entries.length < 2) return null;
-        return entries
+        const values = entries
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([, value]) => value.toString());
+        return values.length ? values.join("-") : null;
+      })
+      .filter((value): value is string => Boolean(value));
+    if (formatted.length) {
+      return `Overall: ${formatted.join(", ")}`;
+    }
+  }
+
+  const candidateKeys = ["sets", "games", "points", "score", "totals"] as const;
+  for (const key of candidateKeys) {
+    if (key in maybe) {
+      const entries = getNumericEntries((maybe as Record<string, unknown>)[key]);
+      if (entries.length >= 2) {
+        const result = entries
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([, value]) => value.toString())
+          .join("-");
+        if (result) {
+          return `Overall: ${result}`;
+        }
+      }
+      if (entries.length === 1) {
+        const [side, value] = entries[0];
+        return `Overall: ${side} ${value}`;
+      }
+    }
+  }
+
+  const totalValue = (maybe as { total?: unknown }).total;
+  if (typeof totalValue === "number" && Number.isFinite(totalValue)) {
+    return `Overall: ${totalValue}`;
+  }
+
+  return "Overall: —";
+}
+
+function resolveScoreEventPayload(event: unknown): Record<string, unknown> | null {
+  if (!isRecord(event)) return null;
+  const record = event as Record<string, unknown>;
+  const maybePayload = record.payload;
+  if (maybePayload && typeof maybePayload === "object" && !Array.isArray(maybePayload)) {
+    return maybePayload as Record<string, unknown>;
+  }
+  return record;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getPointWinner(event: unknown): string | null {
+  if (!event || typeof event !== "object") return null;
+  const container = event as Record<string, unknown>;
+  const payload = resolveScoreEventPayload(event);
+  const rawType =
+    (payload && readString(payload, "type")) ?? readString(container, "type");
+  if (!rawType || rawType.trim().toUpperCase() !== "POINT") return null;
+  const rawSide =
+    (payload &&
+      (readString(payload, "by") ??
+        readString(payload, "side") ??
+        readString(payload, "winner") ??
+        readString(payload, "team"))) ??
+    readString(container, "by") ??
+    readString(container, "side") ??
+    readString(container, "winner") ??
+    readString(container, "team");
+  if (!rawSide) return null;
+  const normalized = rawSide.trim().toUpperCase();
+  return normalized ? normalized : null;
+}
+
+function derivePointTotalsFromEvents(
+  events: Array<ScoreEvent | Record<string, unknown>> | null | undefined
+): Record<string, number> | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const totals: Record<string, number> = {};
+  events.forEach((event) => {
+    const winner = getPointWinner(event);
+    if (!winner) return;
+    totals[winner] = (totals[winner] ?? 0) + 1;
+  });
+  return Object.keys(totals).length ? totals : null;
+}
+
+function collectSides(source: unknown, into: Set<string>): void {
+  if (!source || typeof source !== "object" || Array.isArray(source)) return;
+  Object.keys(source as Record<string, unknown>).forEach((key) => {
+    if (key) into.add(key);
+  });
+}
+
+function normalizePointTotals(
+  summary: SummaryData,
+  totals: Record<string, number>
+): Record<string, number> {
+  const normalized: Record<string, number> = {};
+  const sides = new Set<string>(Object.keys(totals));
+  if (isRecord(summary)) {
+    const maybe = summary as RacketSummary & Record<string, unknown>;
+    collectSides(maybe.sets ?? null, sides);
+    collectSides(maybe.games ?? null, sides);
+    collectSides((maybe as { points?: unknown }).points ?? null, sides);
+    const setScores = maybe.set_scores;
+    if (Array.isArray(setScores)) {
+      setScores.forEach((set) => collectSides(set, sides));
+    }
+  }
+  sides.forEach((side) => {
+    const value = totals[side];
+    normalized[side] =
+      typeof value === "number" && Number.isFinite(value) ? value : 0;
+  });
+  return normalized;
+}
+
+function applyPointTotals(
+  summary: SummaryData,
+  totals: Record<string, number> | null
+): SummaryData {
+  if (!totals || Object.keys(totals).length === 0) return summary ?? null;
+  if (!isRecord(summary)) return summary ?? null;
+  const maybe = summary as RacketSummary;
+  if (hasPositiveValues(maybe.points)) return summary;
+  const normalized = normalizePointTotals(summary, totals);
+  if (!Object.keys(normalized).length) return summary;
+  const next: RacketSummary = { ...maybe, points: normalized };
+  return next;
+}
+
+function describeEvent(event: unknown): string | null {
+  const payload = resolveScoreEventPayload(event);
+  if (!payload) return null;
+
+  const type = readString(payload, "type");
+  const by = readString(payload, "by");
+  const side = readString(payload, "side");
+  const actor = by ?? side;
+
+  if (type && actor) {
+    const normalizedType = type
+      .replace(/_/g, " ")
+      .toLowerCase()
+      .replace(/^[a-z]/, (char) => char.toUpperCase());
+    return `${normalizedType} – ${actor}`;
+  }
+
+  if (type) {
+    return type.replace(/_/g, " ");
+  }
+
+  if (actor) {
+    return `Side ${actor}`;
+  }
+
+  return null;
+}
+
+export default function LiveSummary({
+  mid,
+  sport,
+  status,
+  initialSummary = null,
+  initialEvents = null,
+}: LiveSummaryProps) {
+  const { event, connected, fallback } = useMatchStream(mid);
+  const [summary, setSummary] = useState<SummaryData>(initialSummary ?? null);
+  const summaryRef = useRef<SummaryData>(initialSummary ?? null);
+  const [statusLabel, setStatusLabel] = useState<string | undefined>(() =>
+    sanitizeStatus(status)
+  );
+  const [latestEvent, setLatestEvent] = useState<string | null>(null);
+  const [pointTotals, setPointTotals] = useState<Record<string, number> | null>(
+    () => derivePointTotalsFromEvents(initialEvents)
+  );
+
+  useEffect(() => {
+    setSummary(initialSummary ?? null);
+  }, [initialSummary]);
+
+  useEffect(() => {
+    summaryRef.current = summary;
+  }, [summary]);
+
+  useEffect(() => {
+    setPointTotals(derivePointTotalsFromEvents(initialEvents));
+  }, [initialEvents]);
+
+  useEffect(() => {
+    setStatusLabel(sanitizeStatus(status));
+  }, [status]);
+
+  useEffect(() => {
+    if (isRecord(summary) && hasPositiveValues((summary as RacketSummary).points)) {
+      setPointTotals(null);
+    }
+  }, [summary]);
+
+  useEffect(() => {
+    if (!event) return;
+
+    const incomingStatus = sanitizeStatus((event as { status?: string | null }).status);
+    if (incomingStatus !== undefined) {
+      setStatusLabel(incomingStatus);
+    }
+
+    let nextSummary: SummaryData | undefined;
+
+    if ("summary" in event) {
+      const incomingSummary = (event as { summary?: SummaryData | null }).summary;
+      if (incomingSummary !== undefined) {
+        nextSummary = incomingSummary ?? null;
+        setSummary(nextSummary);
+      }
+    }
+
+    if ("event" in event) {
+      const rawEvent = (event as { event?: unknown }).event;
+      const label = describeEvent(rawEvent);
+      if (label) {
+        setLatestEvent(label);
+      }
+      const winner = getPointWinner(rawEvent);
+      if (winner) {
+        const summaryToCheck = nextSummary ?? summaryRef.current;
+        const shouldTrack = !(
+          isRecord(summaryToCheck) &&
+          hasPositiveValues((summaryToCheck as RacketSummary).points)
+        );
+        if (shouldTrack) {
+          setPointTotals((current) => {
+            const next = { ...(current ?? {}) };
+            next[winner] = (next[winner] ?? 0) + 1;
+            return next;
+          });
+        }
+      }
+    }
+  }, [event]);
+
+  const enrichedSummary = useMemo(() => enrichSummary(summary), [summary]);
+  const effectiveSummary = useMemo(
+    () => applyPointTotals(enrichedSummary, pointTotals),
+    [enrichedSummary, pointTotals]
+  );
+  const scoreline = useMemo(() => formatScoreline(effectiveSummary), [effectiveSummary]);
+  const finished = isFinishedStatus(statusLabel);
+
+  const indicatorLabel = connected ? "Live" : fallback ? "Polling" : "Offline";
+  const indicatorDotClass = connected ? "dot-live" : "dot-polling";
+  const showStatusSuffix = statusLabel ? ` · ${statusLabel}` : "";
+
+  return (
+    <section className="live-summary-card" aria-labelledby="live-summary-heading">
+      <div className="live-summary-header">
+        <span id="live-summary-heading">{`Live summary${showStatusSuffix}`}</span>
+        <span className="connection-indicator" aria-live="polite">
+          <span className={`dot ${indicatorDotClass}`} aria-hidden="true" />
+          <span>{indicatorLabel}</span>
+        </span>
+      </div>
+
+      <p className="live-summary-overall">{scoreline}</p>
+
+      <MatchScoreboard summary={effectiveSummary} sport={sport} isFinished={finished} />
+
+      {latestEvent ? (
+        <p className="match-meta">Latest update: {latestEvent}</p>
+      ) : null}
+      {fallback && !connected ? (
+        <p className="match-meta">
+          Realtime connection unavailable. Refreshing every few seconds.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -188,11 +188,6 @@ export default async function MatchDetailPage({
     }
   }
 
-  const summaryConfig =
-    isRecord(initialSummary) && "config" in initialSummary
-      ? (initialSummary as { config?: unknown }).config
-      : undefined;
-
   return (
     <main className="container">
       <div className="text-sm">
@@ -225,7 +220,7 @@ export default async function MatchDetailPage({
         sport={match.sport}
         status={statusText}
         initialSummary={initialSummary}
-        initialConfig={summaryConfig}
+        initialEvents={match.events ?? []}
       />
     </main>
   );

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -322,13 +322,15 @@ export default function RecordSportPage() {
               />
             </label>
             <label className="form-field" htmlFor="record-time">
-              <span className="form-label">Start time</span>
+              <span className="form-label" id="record-time-label">
+                Start time
+              </span>
               <input
                 id="record-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                lang={locale}
+                aria-labelledby="record-time-label"
               />
             </label>
           </div>

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -233,13 +233,15 @@ export default function RecordPadelPage() {
               </span>
             </label>
             <label className="form-field" htmlFor="padel-time">
-              <span className="form-label">Start time</span>
+              <span className="form-label" id="padel-time-label">
+                Start time
+              </span>
               <input
                 id="padel-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                lang={locale}
+                aria-labelledby="padel-time-label"
               />
             </label>
           </div>

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LocaleProvider, useLocale } from './LocaleContext';
+
+describe('LocaleProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function LocaleConsumer() {
+    const locale = useLocale();
+    return <span data-testid="locale-value">{locale}</span>;
+  }
+
+  it('prefers the primary browser locale when available', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-AU', 'en-US']);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-AU');
+  });
+
+  it('falls back to navigator.language when languages is empty', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-GB');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-GB');
+  });
+
+  it('falls back to the provided locale when browser values are unavailable', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('');
+
+    render(
+      <LocaleProvider locale="fr-FR">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('fr-FR');
+  });
+
+  it('updates when the browser language changes', async () => {
+    let languages: string[] = ['en-US'];
+    vi.spyOn(window.navigator, 'languages', 'get').mockImplementation(() => languages);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    await screen.findByTestId('locale-value');
+    languages = ['en-GB'];
+
+    await act(async () => {
+      window.dispatchEvent(new Event('languagechange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('en-GB');
+    });
+  });
+});

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -5,23 +5,52 @@ import { normalizeLocale } from './i18n';
 
 const LocaleContext = createContext('en-US');
 
+function getBrowserLocale(fallback: string): string {
+  if (typeof navigator === 'undefined') {
+    return fallback;
+  }
+
+  const languages = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+  const preferred = languages.find((lang) => typeof lang === 'string' && lang.length > 0);
+  const candidate = preferred ?? navigator.language;
+
+  return normalizeLocale(candidate, fallback);
+}
+
 interface ProviderProps {
   locale: string;
   children: React.ReactNode;
 }
 
 export function LocaleProvider({ locale, children }: ProviderProps) {
-  const [currentLocale, setCurrentLocale] = useState(locale);
+  const [currentLocale, setCurrentLocale] = useState(() => normalizeLocale(locale));
 
   useEffect(() => {
-    const browserLocale = normalizeLocale(
-      typeof navigator !== 'undefined' ? navigator.language : undefined,
-      locale,
-    );
-    if (browserLocale !== currentLocale) {
-      setCurrentLocale(browserLocale);
+    setCurrentLocale((prev) => {
+      const normalized = normalizeLocale(locale);
+      return prev === normalized ? prev : normalized;
+    });
+  }, [locale]);
+
+  useEffect(() => {
+    const applyBrowserLocale = () => {
+      const browserLocale = getBrowserLocale(locale);
+      setCurrentLocale((prev) => (prev === browserLocale ? prev : browserLocale));
+    };
+
+    applyBrowserLocale();
+
+    if (typeof window === 'undefined') {
+      return;
     }
-  }, [locale, currentLocale]);
+
+    window.addEventListener('languagechange', applyBrowserLocale);
+    return () => {
+      window.removeEventListener('languagechange', applyBrowserLocale);
+    };
+  }, [locale]);
 
   return <LocaleContext.Provider value={currentLocale}>{children}</LocaleContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- update the live summary component to accept initial match events, derive missing totals, and keep the scoreboard in sync with streamed point updates
- compute overall scorelines more robustly while preserving connection indicators and latest update messaging
- pass match events from the detail page so the live summary can seed derived point totals when the backend omits them

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d372545d1c8323ad1d7ec6a2119eca