### PR TITLE
Allow zero totals in player stats normalizer

### DIFF
--- a/apps/web/src/lib/player-stats.test.ts
+++ b/apps/web/src/lib/player-stats.test.ts
@@ -64,6 +64,18 @@ describe("normalizeMatchSummary", () => {
       winPct: 0,
     });
   });
+
+  it("returns null when a zero total includes wins or losses", () => {
+    expect(
+      normalizeMatchSummary({
+        wins: 1,
+        losses: 0,
+        draws: 0,
+        total: 0,
+        winPct: 1,
+      })
+    ).toBeNull();
+  });
 });
 
 describe("formatMatchRecord", () => {

--- a/apps/web/src/lib/player-stats.ts
+++ b/apps/web/src/lib/player-stats.ts
@@ -39,6 +39,18 @@ export function normalizeMatchSummary(
   }
   const normalizedDraws =
     typeof draws === "number" && Number.isFinite(draws) && draws > 0 ? draws : 0;
+  if (total === 0) {
+    if (wins !== 0 || losses !== 0 || normalizedDraws !== 0) {
+      return null;
+    }
+    return {
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      total: 0,
+      winPct: 0,
+    };
+  }
   if (wins + losses + normalizedDraws > total) {
     return null;
   }


### PR DESCRIPTION
## Summary
- allow zero-total match summaries when no wins, losses, or draws are recorded
- continue validating inconsistent zero totals and clamp the win percentage to zero for that case
- add a regression test to ensure zero totals that include results are rejected

## Testing
- pnpm test player-stats

------
https://chatgpt.com/codex/tasks/task_e_68d3812425508323b2443fe9df5556aa