### PR TITLE
Reset derived point totals when scoreboard resets

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -307,7 +307,9 @@ export default function LiveSummary({
   }, [status]);
 
   useEffect(() => {
-    if (isRecord(summary) && hasPositiveValues((summary as RacketSummary).points)) {
+    if (!isRecord(summary)) return;
+    const maybePoints = (summary as RacketSummary).points;
+    if (getNumericEntries(maybePoints).length) {
       setPointTotals(null);
     }
   }, [summary]);


### PR DESCRIPTION
## Summary
- clear the derived point totals whenever the incoming summary includes point values
- ensure the UI defers to zeroed point data from the live stream before new points are scored

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d383264078832389c50e6a733f8c30