### PR TITLE
Implement session timeout handling with banner

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -221,6 +221,31 @@ textarea {
   border-left-color: var(--color-accent-red);
 }
 
+.session-banner {
+  background: var(--color-accent-red);
+  color: var(--color-surface);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  box-shadow: 0 2px 6px rgba(10, 31, 68, 0.25);
+}
+
+.session-banner__close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.session-banner__close:hover,
+.session-banner__close:focus-visible {
+  opacity: 0.8;
+}
+
 /* Navigation bar */
 .nav {
   background: var(--color-nav-bg);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import Header from './header';
 import ChunkErrorReload from '../components/ChunkErrorReload';
 import ToastProvider from '../components/ToastProvider';
+import SessionBanner from '../components/SessionBanner';
 import { headers } from 'next/headers';
 import { LocaleProvider } from '../lib/LocaleContext';
 import { parseAcceptLanguage } from '../lib/i18n';
@@ -28,6 +29,7 @@ export default function RootLayout({
           <ToastProvider>
             <ChunkErrorReload />
             <Header />
+            <SessionBanner />
             {children}
           </ToastProvider>
         </LocaleProvider>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,7 +2,12 @@
 
 import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { apiFetch, currentUsername, logout } from "../../lib/api";
+import {
+  apiFetch,
+  currentUsername,
+  logout,
+  persistSession,
+} from "../../lib/api";
 
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -37,12 +42,7 @@ export default function LoginPage() {
       });
       if (res.ok) {
         const data = await res.json();
-        window.localStorage.setItem("token", data.access_token);
-        // The header listens for the `storage` event to refresh auth state,
-        // but that event isn't emitted in the same tab that updates
-        // localStorage.  Manually dispatch it so the header reflects the new
-        // login immediately.
-        window.dispatchEvent(new Event("storage"));
+        persistSession(data);
         router.push("/");
       } else {
         setErrors(["Login failed. Please check your username and password."]); 
@@ -96,10 +96,7 @@ export default function LoginPage() {
       });
       if (res.ok) {
         const data = await res.json();
-        window.localStorage.setItem("token", data.access_token);
-        // Notify other components of the updated auth token.  Without this the
-        // header will continue showing stale login state until a page reload.
-        window.dispatchEvent(new Event("storage"));
+        persistSession(data);
         router.push("/");
       } else {
         setErrors(["Signup failed. Please try again."]);

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -15,6 +15,7 @@ import {
   type PlayerSocialLink,
   type UserMe,
   ensureAbsoluteApiUrl,
+  persistSession,
 } from "../../lib/api";
 import type { PlayerLocationPayload } from "../../lib/api";
 import ClubSelect from "../../components/ClubSelect";
@@ -319,9 +320,8 @@ export default function ProfilePage() {
 
       try {
         const res = await updateMe(body);
-        if (res.access_token) {
-          window.localStorage.setItem("token", res.access_token);
-          window.dispatchEvent(new Event("storage"));
+        if (res.access_token || res.refresh_token) {
+          persistSession(res);
         }
       } catch (err) {
         const status = (err as Error & { status?: number }).status;

--- a/apps/web/src/components/SessionBanner.tsx
+++ b/apps/web/src/components/SessionBanner.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  SESSION_ENDED_EVENT,
+  SESSION_ENDED_STORAGE_KEY,
+  type SessionEndDetail,
+} from "../lib/api";
+
+function parseSessionEnd(value: string | null): SessionEndDetail | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<SessionEndDetail>;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed.reason !== "expired" && parsed.reason !== "error") ||
+      typeof parsed.timestamp !== "number"
+    ) {
+      return null;
+    }
+    return { reason: parsed.reason, timestamp: parsed.timestamp } as SessionEndDetail;
+  } catch {
+    return null;
+  }
+}
+
+export default function SessionBanner() {
+  const [sessionEnd, setSessionEnd] = useState<SessionEndDetail | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = window.localStorage?.getItem(SESSION_ENDED_STORAGE_KEY) ?? null;
+      return parseSessionEnd(raw);
+    } catch {
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === SESSION_ENDED_STORAGE_KEY) {
+        setSessionEnd(parseSessionEnd(event.newValue));
+      }
+    };
+
+    const handleSessionEnded = (event: Event) => {
+      const detail = (event as CustomEvent<SessionEndDetail | null>).detail;
+      if (detail) {
+        setSessionEnd(detail);
+      } else {
+        try {
+          const raw = window.localStorage?.getItem(SESSION_ENDED_STORAGE_KEY) ?? null;
+          setSessionEnd(parseSessionEnd(raw));
+        } catch {
+          setSessionEnd(null);
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(SESSION_ENDED_EVENT, handleSessionEnded as EventListener);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(
+        SESSION_ENDED_EVENT,
+        handleSessionEnded as EventListener
+      );
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage?.removeItem(SESSION_ENDED_STORAGE_KEY);
+    } catch {
+      // Ignore storage errors when dismissing the banner.
+    }
+    setSessionEnd(null);
+  }, []);
+
+  if (!sessionEnd || sessionEnd.reason !== "expired") {
+    return null;
+  }
+
+  return (
+    <div className="session-banner" role="status" aria-live="assertive">
+      <span>Your session has expired. Please log in again.</span>
+      <button
+        type="button"
+        className="session-banner__close"
+        onClick={dismiss}
+        aria-label="Dismiss session expiration notice"
+      >
+        ×
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add persistent token management, refresh handling, and session end broadcasts to the shared API client
- persist login updates across profile and login flows and surface session expiration with a banner component
- style the expiration banner and cover new logic with unit tests

## Testing
- npx vitest run *(fails: existing transform error in src/app/matches/[mid]/live-summary.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d3812d818483238b1bdc24843d6b0d