### PR TITLE
Reset derived point totals when live summary supplies points

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -308,11 +308,16 @@ export default function LiveSummary({
 
   useEffect(() => {
     if (!isRecord(summary)) return;
+    if (isFinishedStatus(statusLabel)) return;
     const maybePoints = (summary as RacketSummary).points;
-    if (getNumericEntries(maybePoints).length) {
+    if (
+      maybePoints !== null &&
+      typeof maybePoints === "object" &&
+      !Array.isArray(maybePoints)
+    ) {
       setPointTotals(null);
     }
-  }, [summary]);
+  }, [summary, statusLabel]);
 
   useEffect(() => {
     if (!event) return;


### PR DESCRIPTION
## Summary
- clear derived point totals whenever the live summary provides a points object during in-progress matches, even if all values are zero
- avoid clearing derived totals for finished matches so reconstructed summaries remain intact

## Testing
- npm --prefix apps/web test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d386bff23883238ff8d0778c53249a