### PR TITLE
Fix leaderboard redirect typing and handle null set scores

### DIFF
--- a/apps/web/src/app/leaderboard/[sport]/page.tsx
+++ b/apps/web/src/app/leaderboard/[sport]/page.tsx
@@ -37,9 +37,9 @@ export default function LeaderboardSportPage({
   const country = toSingleValue(searchParams?.country);
   const clubId = toSingleValue(searchParams?.clubId);
 
-  if (!isLeaderboardSport(sport)) {
-    redirectToLeaderboard(undefined, country, clubId);
+  if (isLeaderboardSport(sport)) {
+    redirectToLeaderboard(sport, country, clubId);
   }
 
-  redirectToLeaderboard(sport, country, clubId);
+  redirectToLeaderboard(undefined, country, clubId);
 }

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -29,7 +29,7 @@ function sanitizeStatus(value?: string | null): string | undefined {
 }
 
 function deriveRacketTotals(
-  setScores?: SetScores
+  setScores?: SetScores | null
 ): { sets?: Record<string, number>; games?: Record<string, number> } | null {
   if (!Array.isArray(setScores) || setScores.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- ensure the leaderboard sport redirect only forwards validated sports
- allow racket set score derivation helper to accept nullable set score data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38f150d708323ac4b244b25fdac19