### PR TITLE
Handle invalid match dates on player detail charts

### DIFF
--- a/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+vi.mock("../../../components/charts/WinRateChart", () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="win-rate">{JSON.stringify(data)}</div>
+  ),
+}));
+
+vi.mock("../../../components/charts/RankingHistoryChart", () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="ranking-history">{JSON.stringify(data)}</div>
+  ),
+}));
+
+vi.mock("../../../components/charts/MatchHeatmap", () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => (
+    <div data-testid="heatmap">{JSON.stringify(data)}</div>
+  ),
+}));
+
+vi.mock("../../../lib/LocaleContext", () => ({
+  useLocale: () => "en-US",
+}));
+
+import PlayerCharts from "./PlayerCharts";
+
+function readJson<T>(testId: string): T {
+  const element = screen.getByTestId(testId);
+  const raw = element.textContent ?? "null";
+  return JSON.parse(raw) as T;
+}
+
+describe("PlayerCharts", () => {
+  it("handles matches with invalid playedAt values", () => {
+    const matches = [
+      {
+        id: "m1",
+        sport: "padel",
+        bestOf: null,
+        playedAt: "not-a-date",
+        location: null,
+        players: {},
+        participants: [],
+        summary: undefined,
+        playerSide: null,
+        playerWon: true,
+      },
+      {
+        id: "m2",
+        sport: "padel",
+        bestOf: null,
+        playedAt: "2024-01-01T00:00:00Z",
+        location: null,
+        players: {},
+        participants: [],
+        summary: undefined,
+        playerSide: null,
+        playerWon: false,
+      },
+    ];
+
+    render(<PlayerCharts matches={matches} />);
+
+    const winRate = readJson<Array<{ date: string; winRate: number }>>("win-rate");
+    expect(winRate).toHaveLength(2);
+    expect(winRate[0].date).toBe("Match 1");
+
+    const ranking = readJson<Array<{ date: string; rank: number }>>("ranking-history");
+    expect(ranking).toHaveLength(2);
+    expect(ranking[0].date).toBe("Match 1");
+
+    const heatmap = readJson<Array<{ x: number; y: number; v: number }>>("heatmap");
+    expect(heatmap).toHaveLength(1);
+    expect(Number.isFinite(heatmap[0].x)).toBe(true);
+    expect(Number.isFinite(heatmap[0].y)).toBe(true);
+    expect(heatmap[0].v).toBe(1);
+  });
+});
+

--- a/apps/web/src/app/players/[id]/PlayerCharts.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.tsx
@@ -11,6 +11,12 @@ interface EnrichedMatch {
   playerWon?: boolean;
 }
 
+function parseMatchDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) {
   const locale = useLocale();
   const dateFormatter = useMemo(
@@ -18,8 +24,8 @@ export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) 
     [locale],
   );
   const sorted = [...matches].sort((a, b) => {
-    const da = a.playedAt ? new Date(a.playedAt).getTime() : 0;
-    const db = b.playedAt ? new Date(b.playedAt).getTime() : 0;
+    const da = parseMatchDate(a.playedAt)?.getTime() ?? 0;
+    const db = parseMatchDate(b.playedAt)?.getTime() ?? 0;
     return da - db;
   });
 
@@ -30,21 +36,21 @@ export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) 
   const heatmapMap = new Map<string, number>();
 
   sorted.forEach((m, i) => {
+    const playedDate = parseMatchDate(m.playedAt);
     if (m.playerWon) {
       wins += 1;
       rank = Math.max(rank - 1, 1);
     } else {
       rank += 1;
     }
-    const dateLabel = m.playedAt
-      ? dateFormatter.format(new Date(m.playedAt))
+    const dateLabel = playedDate
+      ? dateFormatter.format(playedDate)
       : `Match ${i + 1}`;
     winRateData.push({ date: dateLabel, winRate: wins / (i + 1) });
     rankingData.push({ date: dateLabel, rank });
 
-    if (m.playedAt) {
-      const d = new Date(m.playedAt);
-      const key = `${d.getDay()}-${d.getHours()}`;
+    if (playedDate) {
+      const key = `${playedDate.getDay()}-${playedDate.getHours()}`;
       heatmapMap.set(key, (heatmapMap.get(key) || 0) + 1);
     }
   });


### PR DESCRIPTION
## Summary
- guard PlayerCharts against invalid match timestamps by falling back to safe labels and skipping heatmap buckets
- add a unit test covering the behaviour when matches include malformed playedAt values

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d3b0263a8c8323b63708a287b64634