### PR TITLE
Fix Next.js routing inconsistencies from trailing slashes

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,28 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Ensure both `/` and `/index/` resolve correctly on static hosts.
-  trailingSlash: true,
+  // Keep URLs canonical (no trailing slash) so both `/players` and `/players/`
+  // hit the same route even on static hosts.
+  trailingSlash: false,
+  async redirects() {
+    return [
+      {
+        source: '/index',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/index/',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/:path((?!_next|api).+)/',
+        destination: '/:path',
+        permanent: true,
+      },
+    ];
+  },
   eslint: {
     // Allow production builds to complete even if there are ESLint errors.
     ignoreDuringBuilds: true,


### PR DESCRIPTION
## Summary
- disable forced trailing slashes so canonical URLs work across static and server deployments
- add redirects to collapse trailing-slash variants onto their canonical paths and keep `/index` pointing at the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b522f4248323ac8b48b5969fce64