### PR TITLE
Fix trailing slash redirect for nested paths

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -17,7 +17,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/:path((?!_next|api).+)/',
+        // Use a catch-all pattern so nested segments like `/players/123/`
+        // also redirect to their non-trailing-slash form.
+        source: '/:path((?!_next|api).*)/',
         destination: '/:path',
         permanent: true,
       },


### PR DESCRIPTION
## Summary
- update the trailing-slash redirect to use a catch-all path so nested routes also redirect to their canonical form
- document the intent of the redirect so deeper paths like `/players/123/` are covered

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b7d8f6e48323a018db1ae8e4f9cd