### PR TITLE
Improve localization of record forms

### DIFF
--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -1,11 +1,12 @@
 // apps/web/src/app/record/[sport]/page.tsx
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { flushSync } from "react-dom";
 import { useRouter, useParams } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
+import { getDatePlaceholder } from "../../../lib/i18n";
 import {
   summarizeBowlingInput,
   type BowlingSummaryResult,
@@ -201,6 +202,10 @@ export default function RecordSportPage() {
   const [doubles, setDoubles] = useState(isPadel);
   const [submitting, setSubmitting] = useState(false);
   const locale = useLocale();
+  const datePlaceholder = useMemo(
+    () => getDatePlaceholder(locale),
+    [locale],
+  );
 
   useEffect(() => {
     async function loadPlayers() {
@@ -569,18 +574,21 @@ export default function RecordSportPage() {
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 lang={locale}
+                placeholder={datePlaceholder}
+                aria-describedby="record-date-format"
               />
+              <span id="record-date-format" className="form-hint">
+                Format: {datePlaceholder}
+              </span>
             </label>
             <label className="form-field" htmlFor="record-time">
-              <span className="form-label" id="record-time-label">
-                Start time
-              </span>
+              <span className="form-label">Start time</span>
               <input
                 id="record-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                aria-labelledby="record-time-label"
+                lang={locale}
               />
             </label>
           </div>
@@ -683,7 +691,7 @@ export default function RecordSportPage() {
                                       className="bowling-roll-label"
                                       htmlFor={inputId}
                                     >
-                                      R{rollIdx + 1}
+                                      Roll {rollIdx + 1}
                                     </label>
                                     <input
                                       id={inputId}

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import RecordPadelPage from "./page";
+import * as LocaleContext from "../../../lib/LocaleContext";
 
 const router = { push: vi.fn() };
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
@@ -102,6 +103,27 @@ describe("RecordPadelPage", () => {
         { A: 6, B: 2 },
       ],
     });
+  });
+
+  it("shows an Australian date format when the locale is en-AU", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ players: [] }) });
+    global.fetch = fetchMock as typeof fetch;
+
+    const localeSpy = vi
+      .spyOn(LocaleContext, "useLocale")
+      .mockReturnValue("en-AU");
+
+    try {
+      render(<RecordPadelPage />);
+
+      const dateInput = await screen.findByLabelText(/date/i);
+      expect(dateInput).toHaveAttribute("placeholder", "dd/mm/yyyy");
+      expect(screen.getByText("Format: dd/mm/yyyy")).toBeInTheDocument();
+    } finally {
+      localeSpy.mockRestore();
+    }
   });
 
   it("rejects submission with empty sides", async () => {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
+import { getDatePlaceholder } from "../../../lib/i18n";
 
 interface Player {
   id: string;
@@ -85,22 +86,10 @@ export default function RecordPadelPage() {
     setSetErrors((prev) => [...prev, ""]);
   };
 
-  const datePlaceholder = useMemo(() => {
-    const formatter = new Intl.DateTimeFormat(locale, {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-    });
-    const parts = formatter.formatToParts(new Date(2001, 10, 21));
-    return parts
-      .map((part) => {
-        if (part.type === "day") return "dd";
-        if (part.type === "month") return "mm";
-        if (part.type === "year") return "yyyy";
-        return part.value;
-      })
-      .join("");
-  }, [locale]);
+  const datePlaceholder = useMemo(
+    () => getDatePlaceholder(locale),
+    [locale],
+  );
 
   const validateSets = () => {
     const errors = sets.map(() => "");
@@ -233,15 +222,13 @@ export default function RecordPadelPage() {
               </span>
             </label>
             <label className="form-field" htmlFor="padel-time">
-              <span className="form-label" id="padel-time-label">
-                Start time
-              </span>
+              <span className="form-label">Start time</span>
               <input
                 id="padel-time"
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                aria-labelledby="padel-time-label"
+                lang={locale}
               />
             </label>
           </div>

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -17,6 +17,46 @@ export function normalizeLocale(
   return typeof locale === 'string' && locale.length > 0 ? locale : fallback;
 }
 
+const SAMPLE_DATE = new Date(2001, 10, 21);
+
+export function getDatePlaceholder(
+  locale: string | null | undefined,
+): string {
+  const normalized = normalizeLocale(locale);
+  const lower = normalized.toLowerCase();
+  const isAustralian = lower === 'en-au' || lower.startsWith('en-au-');
+  const australianFallback = 'dd/mm/yyyy';
+
+  try {
+    const formatter = new Intl.DateTimeFormat(normalized, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+    const parts = formatter.formatToParts(SAMPLE_DATE);
+    const placeholder = parts
+      .map((part) => {
+        if (part.type === 'day') return 'dd';
+        if (part.type === 'month') return 'mm';
+        if (part.type === 'year') return 'yyyy';
+        return part.value;
+      })
+      .join('');
+
+    if (isAustralian) {
+      const monthIndex = placeholder.indexOf('mm');
+      const dayIndex = placeholder.indexOf('dd');
+      if (monthIndex !== -1 && dayIndex !== -1 && monthIndex < dayIndex) {
+        return australianFallback;
+      }
+    }
+
+    return placeholder;
+  } catch {
+    return isAustralian ? australianFallback : 'yyyy-mm-dd';
+  }
+}
+
 export function formatDate(
   value: Date | string | number | null | undefined,
   locale: string,


### PR DESCRIPTION
## Summary
- derive localized date placeholders with an en-AU fallback and use them in the record forms
- localize padel and bowling date/time inputs with visible hints and labels
- make bowling roll labels clearer and add tests covering the new behaviour

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d3b99080088323aa6e3478ab42e056