### PR TITLE
Improve leaderboard empty states and URL canonicalization

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -15,6 +15,7 @@ describe("Leaderboard", () => {
   beforeEach(() => {
     mockPathname = "/leaderboard";
     replaceMock.mockReset();
+    window.history.replaceState(null, "", "/leaderboard");
   });
 
   afterEach(() => {
@@ -82,6 +83,32 @@ describe("Leaderboard", () => {
     );
   });
 
+  it("explains when a sport has no recorded matches", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="disc_golf" />);
+
+    await screen.findByText(
+      "No Disc Golf matches have been recorded yet. Check back soon!",
+    );
+  });
+
+  it("mentions when no matches exist for the selected region", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="badminton" country="SE" />);
+
+    await screen.findByText(
+      "No Badminton matches have been recorded for this region yet. Try clearing the filters or check back soon.",
+    );
+  });
+
   it("shows an error message when fetching fails", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("boom"));
     global.fetch = fetchMock as typeof fetch;
@@ -91,5 +118,19 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     await screen.findByText("We couldn't load the leaderboard right now.");
+  });
+
+  it("normalizes a trailing slash when syncing filters", async () => {
+    window.history.replaceState(null, "", "/leaderboard/");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="padel" />);
+
+    await waitFor(() =>
+      expect(replaceMock).toHaveBeenCalledWith("/leaderboard", { scroll: false })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add user-friendly empty-state messaging on the leaderboard when no sport data is available
- normalize trailing slashes before syncing leaderboard filter query parameters
- cover the new behaviour with unit tests for empty states and trailing-slash handling

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c2e9c7c4832390c8dbe57c128ab3