### PR TITLE
Handle missing player match summaries

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -506,9 +506,9 @@ export default async function PlayerPage({
               <p className="mt-2 text-sm text-gray-600">
                 Record: {formatMatchRecord(matchSummary)}
               </p>
-            ) : stats === null ? (
+            ) : (
               <p className="mt-2 text-sm text-gray-600">Stats unavailable.</p>
-            ) : null}
+            )}
             {player.bio ? (
               <p
                 style={{

--- a/apps/web/src/lib/player-stats.test.ts
+++ b/apps/web/src/lib/player-stats.test.ts
@@ -47,7 +47,7 @@ describe("normalizeMatchSummary", () => {
     ).toBeNull();
   });
 
-  it("allows zero totals when no games have been played", () => {
+  it("treats empty summaries as missing", () => {
     expect(
       normalizeMatchSummary({
         wins: 0,
@@ -56,13 +56,7 @@ describe("normalizeMatchSummary", () => {
         total: 0,
         winPct: 0,
       })
-    ).toEqual({
-      wins: 0,
-      losses: 0,
-      draws: 0,
-      total: 0,
-      winPct: 0,
-    });
+    ).toBeNull();
   });
 
   it("returns null when a zero total includes wins or losses", () => {

--- a/apps/web/src/lib/player-stats.ts
+++ b/apps/web/src/lib/player-stats.ts
@@ -39,17 +39,12 @@ export function normalizeMatchSummary(
   }
   const normalizedDraws =
     typeof draws === "number" && Number.isFinite(draws) && draws > 0 ? draws : 0;
+  const hasResults = wins > 0 || losses > 0 || normalizedDraws > 0;
+  if (!hasResults) {
+    return null;
+  }
   if (total === 0) {
-    if (wins !== 0 || losses !== 0 || normalizedDraws !== 0) {
-      return null;
-    }
-    return {
-      wins: 0,
-      losses: 0,
-      draws: 0,
-      total: 0,
-      winPct: 0,
-    };
+    return null;
   }
   if (wins + losses + normalizedDraws > total) {
     return null;


### PR DESCRIPTION
## Summary
- treat all-zero match summaries as missing data during normalization
- show "Stats unavailable" on the player page when no summary is present
- update player stats tests to cover the new behavior

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c4b920588323a59f2be4c2b9a803