### PR TITLE
Fix player icon alignment in match participants

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -438,6 +438,21 @@ textarea {
   margin-bottom: 8px;
 }
 
+.player-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.player-name__avatar {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
 .match-participants {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/components/PlayerName.tsx
+++ b/apps/web/src/components/PlayerName.tsx
@@ -12,15 +12,15 @@ export default function PlayerName({ player }: { player: PlayerInfo }) {
       ? ensureAbsoluteApiUrl(player.photo_url)
       : null;
   return (
-    <span className="player-name" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+    <span className="player-name">
       {photoUrl && (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={photoUrl}
-          alt={player.name}
+          alt=""
           width={24}
           height={24}
-          style={{ borderRadius: '50%', objectFit: 'cover' }}
+          className="player-name__avatar"
         />
       )}
       {player.name}


### PR DESCRIPTION
## Summary
- hide decorative alt text on player avatars so broken images no longer inject stray characters
- add reusable CSS to keep player icons aligned with the adjacent names across match listings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d1976ddc83239ba9e96982babed1