### PR TITLE
Handle empty player summaries

### DIFF
--- a/apps/web/src/lib/player-stats.test.ts
+++ b/apps/web/src/lib/player-stats.test.ts
@@ -47,7 +47,7 @@ describe("normalizeMatchSummary", () => {
     ).toBeNull();
   });
 
-  it("treats empty summaries as missing", () => {
+  it("returns a zeroed summary when there are no matches", () => {
     expect(
       normalizeMatchSummary({
         wins: 0,
@@ -56,7 +56,7 @@ describe("normalizeMatchSummary", () => {
         total: 0,
         winPct: 0,
       })
-    ).toBeNull();
+    ).toEqual({ wins: 0, losses: 0, draws: 0, total: 0, winPct: 0 });
   });
 
   it("returns null when a zero total includes wins or losses", () => {

--- a/apps/web/src/lib/player-stats.ts
+++ b/apps/web/src/lib/player-stats.ts
@@ -41,6 +41,9 @@ export function normalizeMatchSummary(
     typeof draws === "number" && Number.isFinite(draws) && draws > 0 ? draws : 0;
   const hasResults = wins > 0 || losses > 0 || normalizedDraws > 0;
   if (!hasResults) {
+    if (total === 0) {
+      return { wins: 0, losses: 0, draws: 0, total: 0, winPct: 0 };
+    }
     return null;
   }
   if (total === 0) {


### PR DESCRIPTION
## Summary
- allow `normalizeMatchSummary` to return a zeroed summary when stats contain no results
- adjust the unit test to cover the zero-match scenario

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d3d2ad1d988323b1524e8c2d8c76cb