### PR TITLE
Add signup feedback messaging and tests

### DIFF
--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoginPage from '../login/page';
+import { apiFetch, currentUsername, persistSession } from '../../lib/api';
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>(
+    '../../lib/api'
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+    currentUsername: vi.fn(),
+    persistSession: vi.fn(),
+    logout: vi.fn(),
+  };
+});
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<typeof import('next/navigation')>(
+    'next/navigation'
+  );
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushMock,
+    }),
+  };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedCurrentUsername = vi.mocked(currentUsername);
+const mockedPersistSession = vi.mocked(persistSession);
+
+const makeResponse = (
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {}
+): Response => {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 400);
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    clone() {
+      return makeResponse(body, { ok, status });
+    },
+  } as Response;
+};
+
+describe('LoginPage signup feedback', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedCurrentUsername.mockReset();
+    mockedPersistSession.mockReset();
+    pushMock.mockReset();
+    mockedCurrentUsername.mockReturnValue(null);
+  });
+
+  it('shows a success message when signup succeeds', async () => {
+    mockedApiFetch.mockResolvedValueOnce(
+      makeResponse({ access_token: 'token', refresh_token: 'refresh' })
+    );
+
+    render(<LoginPage />);
+
+    const [, signupUsername] = screen.getAllByLabelText('Username');
+    const signupPassword = screen.getAllByLabelText('Password')[1];
+    const confirmPassword = screen.getByLabelText('Confirm Password');
+
+    fireEvent.change(signupUsername, { target: { value: 'NewUser' } });
+    fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
+    fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        '/v0/auth/signup',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    expect(mockedPersistSession).toHaveBeenCalledWith({
+      access_token: 'token',
+      refresh_token: 'refresh',
+    });
+    expect(pushMock).toHaveBeenCalledWith('/');
+
+    expect(
+      await screen.findByText(/Account created successfully! Redirecting.../i)
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces signup failure reasons from the server', async () => {
+    mockedApiFetch.mockResolvedValueOnce(
+      makeResponse(
+        { detail: 'username exists' },
+        { ok: false, status: 400 }
+      )
+    );
+
+    render(<LoginPage />);
+
+    const [, signupUsername] = screen.getAllByLabelText('Username');
+    const signupPassword = screen.getAllByLabelText('Password')[1];
+    const confirmPassword = screen.getByLabelText('Confirm Password');
+
+    fireEvent.change(signupUsername, { target: { value: 'Existing' } });
+    fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
+    fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(
+      within(alert).getByText(/Signup failed: That username is already in use\./i)
+    ).toBeInTheDocument();
+    expect(mockedPersistSession).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -540,6 +540,10 @@ textarea {
   color: var(--color-accent-red);
 }
 
+.success {
+  color: var(--color-accent-blue);
+}
+
 /* Skeleton loading placeholders */
 @keyframes skeleton-shimmer {
   100% {

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -13,12 +13,106 @@ const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const USERNAME_REGEX = /^[A-Za-z0-9_.-]+$/;
 
+const SIGNUP_ERROR_DETAILS: Record<string, string> = {
+  "username exists": "That username is already in use.",
+  "player exists": "That player already has an account.",
+  "invalid admin secret": "Invalid admin secret provided.",
+  "too many requests": "Too many signup attempts. Please try again later.",
+};
+
 function normalizeErrorMessage(err: unknown, fallback: string): string {
   if (err instanceof Error) {
     const cleaned = err.message.replace(/^HTTP \d+:\s*/, "").trim();
     return cleaned.length > 0 ? cleaned : fallback;
   }
   return fallback;
+}
+
+function humanizeSignupDetail(message: string): string {
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return "Unknown signup error.";
+  }
+  const mapped = SIGNUP_ERROR_DETAILS[trimmed.toLowerCase()];
+  if (mapped) {
+    return mapped;
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+async function extractSignupErrors(response: Response): Promise<string[]> {
+  try {
+    const data = await response.clone().json();
+    const messages: string[] = [];
+    if (typeof data === "string") {
+      if (data.trim().length > 0) {
+        messages.push(humanizeSignupDetail(data));
+      }
+    } else if (Array.isArray(data)) {
+      for (const item of data) {
+        if (typeof item === "string" && item.trim().length > 0) {
+          messages.push(humanizeSignupDetail(item));
+        } else if (item && typeof item === "object") {
+          const msg = (item as Record<string, unknown>).msg;
+          if (typeof msg === "string" && msg.trim().length > 0) {
+            messages.push(humanizeSignupDetail(msg));
+          }
+        }
+      }
+    } else if (data && typeof data === "object") {
+      const record = data as Record<string, unknown>;
+      const detail = record.detail;
+      if (typeof detail === "string") {
+        messages.push(humanizeSignupDetail(detail));
+      } else if (Array.isArray(detail)) {
+        for (const item of detail) {
+          if (typeof item === "string" && item.trim().length > 0) {
+            messages.push(humanizeSignupDetail(item));
+          } else if (item && typeof item === "object") {
+            const msg = (item as Record<string, unknown>).msg;
+            if (typeof msg === "string" && msg.trim().length > 0) {
+              messages.push(humanizeSignupDetail(msg));
+            }
+          }
+        }
+      } else if (detail && typeof detail === "object") {
+        const msg = (detail as Record<string, unknown>).msg;
+        if (typeof msg === "string" && msg.trim().length > 0) {
+          messages.push(humanizeSignupDetail(msg));
+        }
+      }
+
+      const fallbackFields: Array<[unknown, boolean]> = [
+        [record.message, typeof record.message === "string"],
+        [record.title, typeof record.title === "string"],
+        [record.error, typeof record.error === "string"],
+      ];
+      for (const [value, isString] of fallbackFields) {
+        if (isString) {
+          const text = (value as string).trim();
+          if (text.length > 0) {
+            messages.push(humanizeSignupDetail(text));
+          }
+        }
+      }
+    }
+    if (messages.length > 0) {
+      return messages;
+    }
+  } catch {
+    // Ignore JSON parsing errors and fall back to reading text.
+  }
+
+  try {
+    const text = (await response.text()).trim();
+    if (text.length > 0) {
+      return [humanizeSignupDetail(text)];
+    }
+  } catch {
+    // Ignore body read errors and fall back to generic message.
+  }
+
+  return ["Signup failed. Please try again."];
 }
 
 export default function LoginPage() {
@@ -30,10 +124,12 @@ export default function LoginPage() {
   const [newPass, setNewPass] = useState("");
   const [confirmPass, setConfirmPass] = useState("");
   const [errors, setErrors] = useState<string[]>([]);
+  const [signupMessage, setSignupMessage] = useState<string | null>(null);
 
   const handleLogin = async (e: FormEvent) => {
     e.preventDefault();
     setErrors([]);
+    setSignupMessage(null);
     try {
       const res = await apiFetch("/v0/auth/login", {
         method: "POST",
@@ -55,6 +151,7 @@ export default function LoginPage() {
   const handleSignup = async (e: FormEvent) => {
     e.preventDefault();
     setErrors([]);
+    setSignupMessage(null);
     const trimmedUser = newUser.trim();
     const validationErrors: string[] = [];
 
@@ -97,9 +194,17 @@ export default function LoginPage() {
       if (res.ok) {
         const data = await res.json();
         persistSession(data);
+        setSignupMessage("Account created successfully! Redirecting...");
+        setErrors([]);
+        setNewPass("");
+        setConfirmPass("");
         router.push("/");
       } else {
-        setErrors(["Signup failed. Please try again."]);
+        const messages = await extractSignupErrors(res);
+        const contextualized = messages.map((msg) =>
+          msg.toLowerCase().startsWith("signup") ? msg : `Signup failed: ${msg}`
+        );
+        setErrors(contextualized);
       }
     } catch (err) {
       setErrors([normalizeErrorMessage(err, "Signup failed. Please try again.")]);
@@ -198,6 +303,12 @@ export default function LoginPage() {
         </div>
         <button type="submit">Sign Up</button>
       </form>
+
+      {signupMessage && (
+        <div role="status" className="success">
+          {signupMessage}
+        </div>
+      )}
 
       {errors.length > 0 && (
         <div role="alert" className="error">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -469,7 +469,7 @@ export default function ProfilePage() {
             placeholder="Search for a club"
             searchInputId="profile-club-search"
             selectId="profile-club-select"
-            searchLabel="Search favorite club"
+            searchLabel="Favorite club"
             name="club_id"
           />
         </div>


### PR DESCRIPTION
## Summary
- show signup success messages and surface detailed API failure reasons on the login page
- style positive notifications with a new `.success` utility class
- cover the new behavior with login page tests and align the profile club search label for accessibility

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d3e68364108323a9e0a7af1c17a92f