### PR TITLE
Use API labels for match header metadata

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -152,6 +152,42 @@ describe("MatchDetailPage", () => {
     expect(meta).toHaveTextContent("Bowling · — · —");
   });
 
+  it("prefers API-provided ruleset and status labels", async () => {
+    const match = {
+      id: "m5",
+      sport: "padel",
+      rulesetId: "padel_standard",
+      ruleset: { id: "padel_standard", name: "Premier Padel" },
+      summary: {},
+      status: { label: "In Progress" },
+      playedAt: null,
+      participants: [],
+    };
+
+    apiFetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => match })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "padel", name: "Padel" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "padel_standard", name: "World Padel Tour" },
+        ],
+      });
+
+    render(await MatchDetailPage({ params: { mid: "m5" } }));
+
+    const meta = screen.getByText(
+      (text, element) =>
+        element?.classList.contains("match-meta") && text.includes("Padel")
+    );
+    expect(meta).toHaveTextContent(
+      "Padel · Premier Padel · In Progress"
+    );
+  });
+
   it("renders racket sport summary with detailed scoreboard", async () => {
     const match = {
       id: "m3",


### PR DESCRIPTION
## Summary
- normalize match ruleset and status metadata from API responses before falling back to placeholders
- prefer provided ruleset names or identifiers and extract status labels when rendering the match header
- cover the header behavior with a regression test that verifies API labels appear instead of placeholder dashes

## Testing
- pnpm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d3ebe7ac6083238b43104c57440938