### PR TITLE
Reset stale status codes when live updates omit them

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -421,14 +421,16 @@ export default function LiveSummary({
   useEffect(() => {
     if (!event) return;
 
-    const incomingLabel = resolveStatusLabelFromUpdate(event);
+    const incomingLabel = sanitizeStatus(resolveStatusLabelFromUpdate(event));
     if (incomingLabel !== undefined) {
       setStatusLabel(incomingLabel);
     }
 
-    const incomingCode = resolveStatusCodeFromUpdate(event);
+    const incomingCode = sanitizeStatus(resolveStatusCodeFromUpdate(event));
     if (incomingCode !== undefined) {
       setStatusValue(incomingCode);
+    } else if (incomingLabel !== undefined) {
+      setStatusValue(undefined);
     }
 
     let nextSummary: SummaryData | undefined;


### PR DESCRIPTION
## Summary
- sanitize live update status labels and codes before storing them
- clear stale status codes when an update only includes a label so finished detection falls back correctly

## Testing
- npm --prefix apps/web test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d3f8b215c48323b3d77ce5a3ebc08c