### PR TITLE
Hide admin player tools from non-admin users

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -54,9 +54,34 @@ export default function PlayersPage() {
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [updatingLocation, setUpdatingLocation] = useState<string | null>(null);
   const [statsError, setStatsError] = useState(false);
+  const [admin, setAdmin] = useState(() => isAdmin());
   const statsToastShown = useRef(false);
-  const admin = isAdmin();
+  const adminControlsRef = useRef<HTMLDivElement | null>(null);
   const { showToast } = useToast();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const updateAdmin = () => {
+      setAdmin(isAdmin());
+    };
+    updateAdmin();
+    window.addEventListener("storage", updateAdmin);
+    return () => {
+      window.removeEventListener("storage", updateAdmin);
+    };
+  }, []);
+
+  useEffect(() => {
+    const node = adminControlsRef.current;
+    if (!node) return;
+    if (admin) {
+      node.removeAttribute("inert");
+    } else {
+      node.setAttribute("inert", "");
+    }
+  }, [admin]);
 
   const trimmedName = name.trim();
   const nameIsValid = NAME_REGEX.test(trimmedName);
@@ -192,6 +217,9 @@ export default function PlayersPage() {
   }, [players, showToast]);
 
   async function create() {
+    if (!admin) {
+      return;
+    }
     if (!nameIsValid) {
       return;
     }
@@ -240,6 +268,9 @@ export default function PlayersPage() {
   }
 
   async function handleDelete(id: string) {
+    if (!admin) {
+      return;
+    }
     try {
       await apiFetch(`/v0/players/${id}`, { method: "DELETE" });
       await load();
@@ -249,6 +280,9 @@ export default function PlayersPage() {
   }
 
   async function handleCountryChange(player: Player, nextValue: string) {
+    if (!admin) {
+      return;
+    }
     const normalizedValue = nextValue === "" ? null : nextValue;
     if ((player.country_code ?? null) === normalizedValue) {
       return;
@@ -369,49 +403,53 @@ export default function PlayersPage() {
           )}
         </>
       )}
-      {admin ? (
-        <>
-          <div className="form-field">
-            <label htmlFor="player-name" className="form-label">
-              Player name
-            </label>
-            <input
-              id="player-name"
-              className="input"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Enter player name"
-              autoComplete="name"
-            />
+      <div
+        ref={adminControlsRef}
+        data-testid="player-create-controls"
+        hidden={!admin}
+        aria-hidden={!admin}
+      >
+        <div className="form-field">
+          <label htmlFor="player-name" className="form-label">
+            Player name
+          </label>
+          <input
+            id="player-name"
+            className="input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Enter player name"
+            autoComplete="name"
+          />
+        </div>
+        {!nameIsValid && trimmedName !== "" && (
+          <div className="text-red-500 mt-2">
+            Name must be 1-50 characters and contain only letters,
+            numbers, spaces, hyphens, or apostrophes.
           </div>
-          {!nameIsValid && trimmedName !== "" && (
-            <div className="text-red-500 mt-2">
-              Name must be 1-50 characters and contain only letters,
-              numbers, spaces, hyphens, or apostrophes.
-            </div>
-          )}
-          <div className="form-field">
-            <label htmlFor="player-photo" className="form-label">
-              Upload profile photo (optional)
-            </label>
-            <input
-              id="player-photo"
-              type="file"
-              accept="image/*"
-              onChange={(e) => setPhotoFile(e.target.files?.[0] ?? null)}
-              className="input"
-            />
-          </div>
-          <button
-            className="button"
-            onClick={create}
-            disabled={creating || name.trim() === ""}
-          >
-            {creating ? "Saving…" : "Add"}
-          </button>
-          {success && <div className="text-green-600 mt-2">{success}</div>}
-        </>
-      ) : (
+        )}
+        <div className="form-field">
+          <label htmlFor="player-photo" className="form-label">
+            Upload profile photo (optional)
+          </label>
+          <input
+            id="player-photo"
+            type="file"
+            accept="image/*"
+            onChange={(e) => setPhotoFile(e.target.files?.[0] ?? null)}
+            className="input"
+          />
+        </div>
+        <button
+          className="button"
+          onClick={create}
+          disabled={creating || name.trim() === ""}
+        >
+          {creating ? "Saving…" : "Add"}
+        </button>
+        {success && <div className="text-green-600 mt-2">{success}</div>}
+      </div>
+      {!admin && (
         <p className="player-list__admin-note">
           Only administrators can add new players.
         </p>


### PR DESCRIPTION
## Summary
- update the players page to track admin status reactively and hide the create controls with hidden/aria-hidden/inert when not allowed
- harden admin-only actions by guarding create/delete/location updates and keep the DOM accessible
- expand players page tests to assert that admin controls stay hidden for regular users and surface correctly for admins

## Testing
- `npm test -- players/page.test.tsx`
- `npm run lint` *(fails: pre-existing lint errors in apps/web/src/app/players/[id]/error.tsx and warnings in ToastProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eababb248323b9ff5ec49171446b