### PR TITLE
Adjust finished match summary labeling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -524,6 +524,10 @@ textarea {
   background: #2ecc71;
 }
 
+.connection-indicator .dot-final {
+  background: var(--color-accent-blue);
+}
+
 .connection-indicator .dot-polling {
   background: #bbb;
 }

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -474,15 +474,30 @@ export default function LiveSummary({
   );
   const scoreline = useMemo(() => formatScoreline(effectiveSummary), [effectiveSummary]);
   const finished = isFinishedStatus(statusValue ?? statusLabel);
-
-  const indicatorLabel = connected ? "Live" : fallback ? "Polling" : "Offline";
-  const indicatorDotClass = connected ? "dot-live" : "dot-polling";
-  const showStatusSuffix = statusLabel ? ` · ${statusLabel}` : "";
+  const statusHeading = finished ? "Final score" : "Live summary";
+  const indicatorLabel = finished
+    ? statusLabel ?? "Final"
+    : connected
+      ? "Live"
+      : fallback
+        ? "Polling"
+        : "Offline";
+  const indicatorDotClass = finished
+    ? "dot-final"
+    : connected
+      ? "dot-live"
+      : "dot-polling";
+  const normalizedStatusLabel = statusLabel ?? "";
+  const showStatusSuffix =
+    normalizedStatusLabel &&
+    !(finished && normalizedStatusLabel.toLowerCase() === "final")
+      ? ` · ${normalizedStatusLabel}`
+      : "";
 
   return (
     <section className="live-summary-card" aria-labelledby="live-summary-heading">
       <div className="live-summary-header">
-        <span id="live-summary-heading">{`Live summary${showStatusSuffix}`}</span>
+        <span id="live-summary-heading">{`${statusHeading}${showStatusSuffix}`}</span>
         <span className="connection-indicator" aria-live="polite">
           <span className={`dot ${indicatorDotClass}`} aria-hidden="true" />
           <span>{indicatorLabel}</span>


### PR DESCRIPTION
## Summary
- show a "Final score" heading for completed matches and surface a final-state badge instead of "Offline"
- add a dedicated style for the final-state indicator dot

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d405b5660483238bbf2248ac367519