### PR TITLE
Add Next.js health check endpoint

### DIFF
--- a/apps/web/src/app/healthz/route.ts
+++ b/apps/web/src/app/healthz/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' }, { status: 200 });
+}
+
+export function HEAD() {
+  return new Response(null, { status: 200 });
+}


### PR DESCRIPTION
## Summary
- add a route handler at /healthz in the Next.js app so web health probes receive HTTP 200
- return a simple {"status":"ok"} payload for GET and support HEAD probes as well

## Testing
- npm --prefix apps/web run lint *(fails: existing lint issues in players pages and ToastProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68d412317d448323ad4842797aee363a