### PR TITLE
Populate match summaries when creating matches with set scores

### DIFF
--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -228,7 +228,10 @@ async def test_create_match_with_sets(tmp_path):
     admin = User(id="u1", username="admin", password_hash="", is_admin=True)
     resp = await create_match(body, session, user=admin)
     m = await session.get(Match, resp.id)
-    assert m.details == {"score": {"A": 120, "B": 100}}
+    assert m.details is not None
+    assert m.details.get("score") == {"A": 120, "B": 100}
+    assert m.details.get("set_scores") == [{"A": 120, "B": 100}]
+    assert m.details.get("sets") == {"A": 1, "B": 0}
 
 
 @pytest.mark.anyio
@@ -297,7 +300,10 @@ async def test_create_match_by_name_with_sets(tmp_path):
     admin = User(id="u1", username="admin", password_hash="", is_admin=True)
     resp = await create_match_by_name(body, session, user=admin)
     m = await session.get(Match, resp.id)
-    assert m.details == {"score": {"A": 120, "B": 100}}
+    assert m.details is not None
+    assert m.details.get("score") == {"A": 120, "B": 100}
+    assert m.details.get("set_scores") == [{"A": 120, "B": 100}]
+    assert m.details.get("sets") == {"A": 1, "B": 0}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- build racket-style summaries when POST /matches receives set scores
- reuse the scoring engines to emit ScoreEvent rows and totals during creation
- extend tests to cover the enriched match.details payload

## Testing
- pytest backend/tests/test_matches.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d4a04c40cc8323a017ed56a57d5ba3