### PR TITLE
Allow tied set scores for non-racket sports

### DIFF
--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -147,7 +147,13 @@ async def create_match(
                 raise ValidationError("Set scores must include values for sides A and B.")
             for pair in candidate_pairs:
                 normalized_sets.append({"A": pair[0], "B": pair[1]})
-            validate_set_scores(normalized_sets)
+            is_racket_sport = match.sport_id in ("padel", "tennis")
+            max_sets = match.best_of if match.best_of else (5 if is_racket_sport else None)
+            validate_set_scores(
+                normalized_sets,
+                max_sets=max_sets,
+                allow_ties=not is_racket_sport,
+            )
         except ValidationError as e:
             raise HTTPException(status_code=422, detail=str(e))
         except Exception:

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 class ValidationError(Exception):
     """Raised when submitted set scores are invalid."""
@@ -8,20 +8,25 @@ class ValidationError(Exception):
         self.detail = detail
 
 
-def validate_set_scores(sets: List[Dict[str, Any]], max_sets: int = 5) -> None:
+def validate_set_scores(
+    sets: List[Dict[str, Any]],
+    *,
+    max_sets: Optional[int] = 5,
+    allow_ties: bool = False,
+) -> None:
     """Validate a list of set score dictionaries.
 
     Rules:
     - At least one set is required
-    - Number of sets must be <= ``max_sets``
+    - Number of sets must be <= ``max_sets`` (if provided)
     - Each set must be an object ``{A, B}``
     - ``A`` and ``B`` must be integers >= 0 (booleans are rejected)
-    - Ties are not allowed (``A`` != ``B``)
+    - Ties are not allowed (``A`` != ``B``) unless ``allow_ties`` is ``True``
     """
 
     if not isinstance(sets, list) or len(sets) == 0:
         raise ValidationError("At least one set is required.")
-    if len(sets) > max_sets:
+    if max_sets is not None and len(sets) > max_sets:
         raise ValidationError(f"Too many sets. Max allowed is {max_sets}.")
 
     for i, s in enumerate(sets, start=1):
@@ -44,7 +49,7 @@ def validate_set_scores(sets: List[Dict[str, Any]], max_sets: int = 5) -> None:
 
         if a < 0 or b < 0:
             raise ValidationError(f"Set #{i} scores must be >= 0.")
-        if a == b:
+        if not allow_ties and a == b:
             raise ValidationError(f"Set #{i} cannot be a tie.")
 
     return None

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -6,6 +6,13 @@ def test_accepts_valid_sets() -> None:
     validate_set_scores([{"A": 11, "B": 9}, {"A": 9, "B": 11}])
 
 
+def test_accepts_ties_when_allowed() -> None:
+    validate_set_scores(
+        [{"A": 120, "B": 120}],
+        allow_ties=True,
+    )
+
+
 @pytest.mark.parametrize(
     "sets, msg",
     [
@@ -36,4 +43,11 @@ def test_rejects_invalid_sets(sets, msg) -> None:
 def test_rejects_too_many_sets() -> None:
     with pytest.raises(ValidationError):
         validate_set_scores([{"A": 1, "B": 0}] * 6, max_sets=5)
+
+
+def test_allows_unbounded_set_counts_when_max_not_set() -> None:
+    validate_set_scores(
+        [{"A": 1, "B": 0}] * 6,
+        max_sets=None,
+    )
 


### PR DESCRIPTION
## Summary
- update set score validation to support optional tie allowances and configurable set limits
- scope strict set validation to racket sports during match creation so non-racket matches can record ties and longer series
- expand validation tests to cover the new options

## Testing
- pytest backend/tests/test_validation.py backend/tests/test_scoring.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a934e5f88323b18416ad5070c35c