### PR TITLE
Fix routing slashes and clean up decorative icons

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,9 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Keep URLs canonical (no trailing slash) so both `/players` and `/players/`
-  // hit the same route even on static hosts.
-  trailingSlash: false,
+  // Generate routes with a trailing slash so static hosts can resolve nested
+  // paths like `/players/` without relying on custom rewrites.
+  trailingSlash: true,
   async redirects() {
     return [
       {
@@ -14,13 +14,6 @@ const nextConfig = {
       {
         source: '/index/',
         destination: '/',
-        permanent: true,
-      },
-      {
-        // Use a catch-all pattern so nested segments like `/players/123/`
-        // also redirect to their non-trailing-slash form.
-        source: '/:path((?!_next|api).*)/',
-        destination: '/:path',
         permanent: true,
       },
     ];

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -451,6 +451,8 @@ textarea {
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
+  font-size: 0;
+  color: transparent;
 }
 
 .match-participants {

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { currentUsername, isAdmin, logout } from '../lib/api';
+import { ensureTrailingSlash } from '../lib/routes';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -48,34 +49,52 @@ export default function Header() {
             </Link>
           </li>
           <li>
-            <Link href="/players" onClick={() => setOpen(false)}>
+            <Link
+              href={ensureTrailingSlash('/players')}
+              onClick={() => setOpen(false)}
+            >
               Players
             </Link>
           </li>
           <li>
-            <Link href="/matches" onClick={() => setOpen(false)}>
+            <Link
+              href={ensureTrailingSlash('/matches')}
+              onClick={() => setOpen(false)}
+            >
               Matches
             </Link>
           </li>
           <li>
-            <Link href="/record" onClick={() => setOpen(false)}>
+            <Link
+              href={ensureTrailingSlash('/record')}
+              onClick={() => setOpen(false)}
+            >
               Record
             </Link>
           </li>
           <li>
-            <Link href="/leaderboard" onClick={() => setOpen(false)}>
+            <Link
+              href={ensureTrailingSlash('/leaderboard')}
+              onClick={() => setOpen(false)}
+            >
               Leaderboards
             </Link>
           </li>
           {admin && (
             <>
               <li>
-                <Link href="/admin/matches" onClick={() => setOpen(false)}>
+                <Link
+                  href={ensureTrailingSlash('/admin/matches')}
+                  onClick={() => setOpen(false)}
+                >
                   Admin Matches
                 </Link>
               </li>
               <li>
-                <Link href="/admin/badges" onClick={() => setOpen(false)}>
+                <Link
+                  href={ensureTrailingSlash('/admin/badges')}
+                  onClick={() => setOpen(false)}
+                >
                   Admin Badges
                 </Link>
               </li>
@@ -84,7 +103,10 @@ export default function Header() {
           {user ? (
             <>
               <li>
-                <Link href="/profile" onClick={() => setOpen(false)}>
+                <Link
+                  href={ensureTrailingSlash('/profile')}
+                  onClick={() => setOpen(false)}
+                >
                   Profile
                 </Link>
               </li>
@@ -95,7 +117,10 @@ export default function Header() {
             </>
           ) : (
             <li>
-              <Link href="/login" onClick={() => setOpen(false)}>
+              <Link
+                href={ensureTrailingSlash('/login')}
+                onClick={() => setOpen(false)}
+              >
                 Login
               </Link>
             </li>

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from '../lib/api';
 import { enrichMatches, type MatchRow, type EnrichedMatch } from '../lib/matches';
 import MatchParticipants from '../components/MatchParticipants';
 import { useLocale } from '../lib/LocaleContext';
+import { ensureTrailingSlash, recordPathForSport } from '../lib/routes';
 
 interface Sport { id: string; name: string }
 
@@ -17,8 +18,6 @@ const sportIcons: Record<string, string> = {
   badminton: '🏸',
   table_tennis: '🏓',
 };
-
-const toRecordPath = (sportId: string) => `/record/${sportId.replace(/_/g, '-')}`;
 
 interface Props {
   sports: Sport[];
@@ -118,7 +117,7 @@ export default function HomePageClient({
           <ul className="sport-list" role="list">
             {sports.map((s) => {
               const icon = sportIcons[s.id];
-              const href = toRecordPath(s.id);
+              const href = recordPathForSport(s.id);
               return (
                 <li key={s.id} className="sport-item">
                   <Link href={href} className="sport-link">
@@ -175,7 +174,9 @@ export default function HomePageClient({
                   {m.location ? ` · ${m.location}` : ''}
                 </div>
                 <div>
-                  <Link href={`/matches/${m.id}`}>Match details</Link>
+                  <Link href={ensureTrailingSlash(`/matches/${m.id}`)}>
+                    Match details
+                  </Link>
                 </div>
               </li>
             ))}

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { apiUrl } from "../../lib/api";
+import { ensureTrailingSlash } from "../../lib/routes";
 import { loadUserSettings } from "../user-settings";
 import {
   ALL_SPORTS,
@@ -213,10 +214,12 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     return params.toString();
   }, [appliedCountry, appliedClubId]);
 
-  const withRegion = (base: string) =>
-    regionQueryString
-      ? `${base}${base.includes("?") ? "&" : "?"}${regionQueryString}`
-      : base;
+  const withRegion = (base: string) => {
+    const normalizedBase = ensureTrailingSlash(base);
+    return regionQueryString
+      ? `${normalizedBase}${normalizedBase.includes("?") ? "&" : "?"}${regionQueryString}`
+      : normalizedBase;
+  };
 
   const regionDescription = useMemo(() => {
     if (sport === MASTER_SPORT) {
@@ -347,7 +350,10 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   return (
     <main className="container">
       <div style={{ marginBottom: "1rem", fontSize: "0.9rem" }}>
-        <Link href="/matches" style={{ textDecoration: "underline" }}>
+        <Link
+          href={ensureTrailingSlash("/matches")}
+          style={{ textDecoration: "underline" }}
+        >
           ← Back to matches
         </Link>
       </div>

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -5,6 +5,7 @@ import LiveSummary from "./live-summary";
 import MatchParticipants from "../../../components/MatchParticipants";
 import { PlayerInfo } from "../../../components/PlayerName";
 import { formatDateTime, parseAcceptLanguage } from "../../../lib/i18n";
+import { ensureTrailingSlash } from "../../../lib/routes";
 import {
   type SummaryData,
   type ScoreEvent,
@@ -325,7 +326,10 @@ export default async function MatchDetailPage({
     return (
       <main className="container">
         <div className="text-sm">
-          <Link href="/matches" className="underline underline-offset-2">
+          <Link
+            href={ensureTrailingSlash('/matches')}
+            className="underline underline-offset-2"
+          >
             ← Back to matches
           </Link>
         </div>
@@ -334,10 +338,13 @@ export default async function MatchDetailPage({
           {matchError ?? MATCH_LOAD_ERROR_MESSAGE}
         </p>
         <div className="mt-4 flex flex-col items-start gap-3 md:flex-row md:items-center">
-          <Link href={`/matches/${params.mid}`} className="button">
+          <Link
+            href={ensureTrailingSlash(`/matches/${params.mid}`)}
+            className="button"
+          >
             Try again
           </Link>
-          <Link href="/matches" className="underline">
+          <Link href={ensureTrailingSlash('/matches')} className="underline">
             Back to matches
           </Link>
         </div>
@@ -426,7 +433,10 @@ export default async function MatchDetailPage({
   return (
     <main className="container">
       <div className="text-sm">
-        <Link href="/matches" className="underline underline-offset-2">
+        <Link
+          href={ensureTrailingSlash('/matches')}
+          className="underline underline-offset-2"
+        >
           ← Back to matches
         </Link>
       </div>

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -5,6 +5,7 @@ import Pager from "./pager";
 import { PlayerInfo } from "../../components/PlayerName";
 import MatchParticipants from "../../components/MatchParticipants";
 import { formatDate, parseAcceptLanguage } from "../../lib/i18n";
+import { ensureTrailingSlash } from "../../lib/routes";
 
 export const dynamic = "force-dynamic";
 
@@ -194,7 +195,9 @@ export default async function MatchesPage(
                   {m.location ?? "—"}
                 </div>
                 <div>
-                  <Link href={`/matches/${m.id}`}>More info</Link>
+                  <Link href={ensureTrailingSlash(`/matches/${m.id}`)}>
+                    More info
+                  </Link>
                 </div>
               </li>
             ))}

--- a/apps/web/src/app/matches/pager.tsx
+++ b/apps/web/src/app/matches/pager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { ensureTrailingSlash } from "../../lib/routes";
 
 interface PagerProps {
   limit: number;
@@ -18,13 +19,17 @@ export default function Pager({
   disableNext,
 }: PagerProps) {
   const router = useRouter();
+  const basePath = ensureTrailingSlash('/matches');
+
   return (
     <div className="pager">
       <button
         type="button"
         className="button"
         disabled={disablePrev}
-        onClick={() => router.push(`/matches?limit=${limit}&offset=${prevOffset}`)}
+        onClick={() =>
+          router.push(`${basePath}?limit=${limit}&offset=${prevOffset}`)
+        }
       >
         Previous
       </button>
@@ -32,7 +37,9 @@ export default function Pager({
         type="button"
         className="button"
         disabled={disableNext}
-        onClick={() => router.push(`/matches?limit=${limit}&offset=${nextOffset}`)}
+        onClick={() =>
+          router.push(`${basePath}?limit=${limit}&offset=${nextOffset}`)
+        }
       >
         Next
       </button>

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
+import { recordPathForSport } from "../../lib/routes";
 
 export const dynamic = "force-dynamic";
 
@@ -25,7 +26,7 @@ export default async function RecordPage() {
         <ul className="sport-list">
           {sports.map((s) => (
             <li key={s.id} className="sport-item">
-              <Link href={`/record/${s.id.replace('_', '-')}`}>{s.name}</Link>
+              <Link href={recordPathForSport(s.id)}>{s.name}</Link>
             </li>
           ))}
         </ul>

--- a/apps/web/src/components/PlayerName.tsx
+++ b/apps/web/src/components/PlayerName.tsx
@@ -21,6 +21,8 @@ export default function PlayerName({ player }: { player: PlayerInfo }) {
           width={24}
           height={24}
           className="player-name__avatar"
+          aria-hidden="true"
+          role="presentation"
         />
       )}
       {player.name}

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -1,0 +1,14 @@
+export function ensureTrailingSlash(path: string): string {
+  if (!path) return '/';
+  const [pathname, search = ''] = path.split('?');
+  const normalizedPath =
+    pathname === '/' || pathname.endsWith('/')
+      ? pathname
+      : `${pathname}/`;
+  return search ? `${normalizedPath}?${search}` : normalizedPath;
+}
+
+export function recordPathForSport(sportId: string): string {
+  const slug = sportId.replace(/_/g, '-');
+  return ensureTrailingSlash(`/record/${slug}`);
+}


### PR DESCRIPTION
## Summary
- enable trailing-slash routing so static hosts resolve paths like `/players/`
- add routing helpers and update navigation links and match pages to emit trailing slashes and consistent record URLs
- hide decorative avatar alt text via aria attributes and CSS to prevent stray initials

## Testing
- pnpm lint *(fails: pre-existing lint violations in players pages and ToastProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68d4afbd1e408323be084d32ad39bcb6