### PR TITLE
Guard record forms for unsupported sports

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -5,7 +5,7 @@ import RecordSportPage from "./page";
 import * as LocaleContext from "../../../lib/LocaleContext";
 
 let sportParam = "padel";
-const router = { push: vi.fn() };
+const router = { push: vi.fn(), replace: vi.fn() };
 vi.mock("next/navigation", () => ({
   useRouter: () => router,
   useParams: () => ({ sport: sportParam }),
@@ -14,7 +14,36 @@ vi.mock("next/navigation", () => ({
 describe("RecordSportPage", () => {
   afterEach(() => {
     router.push.mockReset();
+    router.replace.mockReset();
     vi.clearAllMocks();
+  });
+
+  it("redirects to the coming soon page when a sport is not implemented", async () => {
+    sportParam = "badminton";
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordSportPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(
+        "/record/coming-soon?sport=badminton",
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the disc golf form when the slug uses underscores", async () => {
+    sportParam = "disc_golf";
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<RecordSportPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/record/disc-golf/");
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rejects duplicate player selections", async () => {

--- a/apps/web/src/app/record/coming-soon/page.tsx
+++ b/apps/web/src/app/record/coming-soon/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+function formatSportName(slug: string): string {
+  if (!slug) {
+    return "This sport";
+  }
+  return slug
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+interface ComingSoonPageProps {
+  searchParams?: { sport?: string };
+}
+
+export default function RecordComingSoonPage({
+  searchParams,
+}: ComingSoonPageProps) {
+  const slug = typeof searchParams?.sport === "string" ? searchParams.sport : "";
+  const sportName = formatSportName(slug);
+
+  return (
+    <main className="container">
+      <h1 className="heading">Recording coming soon</h1>
+      <p>
+        {sportName} recording isn&apos;t available yet. Check back later or let us
+        know if you&apos;d like to help build it.
+      </p>
+      <p>
+        <Link className="button-secondary" href="/record">
+          Back to sport list
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 import { recordPathForSport } from "../../lib/routes";
+import { isSportIdImplementedForRecording } from "../../lib/recording";
 
 export const dynamic = "force-dynamic";
 
@@ -17,14 +18,18 @@ export default async function RecordPage() {
     // ignore errors
   }
 
+  const implementedSports = sports.filter((s) =>
+    isSportIdImplementedForRecording(s.id),
+  );
+
   return (
     <main className="container">
       <h1 className="heading">Record Match</h1>
-      {sports.length === 0 ? (
+      {implementedSports.length === 0 ? (
         <p className="text-gray-600">No sports found.</p>
       ) : (
         <ul className="sport-list">
-          {sports.map((s) => (
+          {implementedSports.map((s) => (
             <li key={s.id} className="sport-item">
               <Link href={recordPathForSport(s.id)}>{s.name}</Link>
             </li>

--- a/apps/web/src/lib/recording.ts
+++ b/apps/web/src/lib/recording.ts
@@ -1,0 +1,93 @@
+export type RecordSportForm = "dynamic" | "custom";
+
+export interface RecordSportMeta {
+  id: string;
+  slug: string;
+  form: RecordSportForm;
+  implemented: boolean;
+  redirectPath?: string;
+}
+
+const RECORD_SPORTS: Record<string, RecordSportMeta> = {
+  bowling: {
+    id: "bowling",
+    slug: "bowling",
+    form: "dynamic",
+    implemented: true,
+  },
+  padel: {
+    id: "padel",
+    slug: "padel",
+    form: "dynamic",
+    implemented: true,
+  },
+  pickleball: {
+    id: "pickleball",
+    slug: "pickleball",
+    form: "dynamic",
+    implemented: true,
+  },
+  table_tennis: {
+    id: "table_tennis",
+    slug: "table-tennis",
+    form: "dynamic",
+    implemented: true,
+  },
+  disc_golf: {
+    id: "disc_golf",
+    slug: "disc-golf",
+    form: "custom",
+    implemented: true,
+    redirectPath: "/record/disc-golf/",
+  },
+};
+
+export function normalizeRecordSportSlug(slug: string): string {
+  return slug.replace(/-/g, "_");
+}
+
+export function canonicalRecordSportSlug(id: string): string {
+  const meta = RECORD_SPORTS[id];
+  if (meta) {
+    return meta.slug;
+  }
+  return id.replace(/_/g, "-");
+}
+
+export function getRecordSportMetaById(id: string): RecordSportMeta | null {
+  return RECORD_SPORTS[id] ?? null;
+}
+
+export function getRecordSportMetaBySlug(slug: string): RecordSportMeta | null {
+  const id = normalizeRecordSportSlug(slug);
+  return getRecordSportMetaById(id);
+}
+
+export function isSportIdImplementedForRecording(id: string): boolean {
+  const meta = getRecordSportMetaById(id);
+  return Boolean(meta?.implemented);
+}
+
+export function isSportSlugImplementedForRecording(slug: string): boolean {
+  const id = normalizeRecordSportSlug(slug);
+  return isSportIdImplementedForRecording(id);
+}
+
+export function isSportHandledByDynamicRecordForm(id: string): boolean {
+  const meta = getRecordSportMetaById(id);
+  return Boolean(meta && meta.implemented && meta.form === "dynamic");
+}
+
+export function getImplementedRecordSportIds(): string[] {
+  return Object.values(RECORD_SPORTS)
+    .filter((meta) => meta.implemented)
+    .map((meta) => meta.id);
+}
+
+export function buildComingSoonHref(slugOrId: string): string {
+  const slug = slugOrId.includes("-")
+    ? slugOrId
+    : canonicalRecordSportSlug(slugOrId);
+  const params = new URLSearchParams({ sport: slug });
+  return `/record/coming-soon?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- add shared metadata describing which sports have record forms and how they are routed
- guard the dynamic record page against unsupported sports, redirecting to custom or coming-soon pages
- filter the record index to implemented sports and cover the new redirects with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b448bf008323a08eae71a8a7582c