### PR TITLE
Fix match participant layout and finished summaries

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -476,6 +476,13 @@ textarea {
   gap: 0.35rem;
 }
 
+.match-participants__entry-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
 .match-participants__entry {
   display: inline-flex;
   align-items: center;
@@ -487,6 +494,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .match-participants__separator {
@@ -588,6 +596,14 @@ textarea {
   justify-content: space-between;
   gap: 12px;
   font-weight: 600;
+}
+
+.live-summary-final-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  color: rgba(10, 31, 68, 0.7);
 }
 
 .live-summary-overall {

--- a/apps/web/src/components/MatchParticipants.tsx
+++ b/apps/web/src/components/MatchParticipants.tsx
@@ -38,33 +38,51 @@ export default function MatchParticipants<
 
   return (
     <Component className={classes} {...rest}>
-      {sides.map((side, sideIndex) => (
-        <span key={sideIndex} className="match-participants__side-wrapper">
-          {sideIndex > 0 && (
-            <span
-              className="match-participants__versus"
-              aria-label={versusLabel || undefined}
-            >
-              {` ${versusSymbol} `}
-            </span>
-          )}
-          <span className="match-participants__side">
-            {side.map((player, playerIndex) => (
+      {sides.map((side, sideIndex) => {
+        const renderedSide: Array<JSX.Element> = [];
+
+        side.forEach((player, playerIndex) => {
+          if (playerIndex === 0) {
+            renderedSide.push(
               <span key={player.id} className="match-participants__entry">
-                {playerIndex > 0 && (
-                  <span
-                    className="match-participants__separator"
-                    aria-label={separatorLabel || undefined}
-                  >
-                    {` ${separatorSymbol} `}
-                  </span>
-                )}
                 <PlayerName player={player} />
               </span>
-            ))}
+            );
+            return;
+          }
+
+          renderedSide.push(
+            <span
+              key={`${player.id}-group-${playerIndex}`}
+              className="match-participants__entry-group"
+            >
+              <span
+                className="match-participants__separator"
+                aria-label={separatorLabel || undefined}
+              >
+                {` ${separatorSymbol} `}
+              </span>
+              <span className="match-participants__entry">
+                <PlayerName player={player} />
+              </span>
+            </span>
+          );
+        });
+
+        return (
+          <span key={sideIndex} className="match-participants__side-wrapper">
+            {sideIndex > 0 && (
+              <span
+                className="match-participants__versus"
+                aria-label={versusLabel || undefined}
+              >
+                {` ${versusSymbol} `}
+              </span>
+            )}
+            <span className="match-participants__side">{renderedSide}</span>
           </span>
-        </span>
-      ))}
+        );
+      })}
     </Component>
   );
 }


### PR DESCRIPTION
## Summary
- keep participant separators grouped with player names using flex containers to avoid awkward wraps
- hide live polling indicator for finished matches and ignore placeholder status/ruleset labels so real data is shown

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b41c6ea48323bbc31d789f8ef240