### PR TITLE
Preserve record redirect query params

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -5,10 +5,12 @@ import RecordSportPage from "./page";
 import * as LocaleContext from "../../../lib/LocaleContext";
 
 let sportParam = "padel";
+let searchParamString = "";
 const router = { push: vi.fn(), replace: vi.fn() };
 vi.mock("next/navigation", () => ({
   useRouter: () => router,
   useParams: () => ({ sport: sportParam }),
+  useSearchParams: () => new URLSearchParams(searchParamString),
 }));
 
 describe("RecordSportPage", () => {
@@ -16,6 +18,7 @@ describe("RecordSportPage", () => {
     router.push.mockReset();
     router.replace.mockReset();
     vi.clearAllMocks();
+    searchParamString = "";
   });
 
   it("redirects to the coming soon page when a sport is not implemented", async () => {
@@ -33,15 +36,16 @@ describe("RecordSportPage", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("redirects to the disc golf form when the slug uses underscores", async () => {
+  it("redirects to the disc golf form when the slug uses underscores, preserving query params", async () => {
     sportParam = "disc_golf";
+    searchParamString = "mid=123";
     const fetchMock = vi.fn();
     global.fetch = fetchMock as typeof fetch;
 
     render(<RecordSportPage />);
 
     await waitFor(() => {
-      expect(router.replace).toHaveBeenCalledWith("/record/disc-golf/");
+      expect(router.replace).toHaveBeenCalledWith("/record/disc-golf/?mid=123");
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/recording.ts
+++ b/apps/web/src/lib/recording.ts
@@ -84,10 +84,15 @@ export function getImplementedRecordSportIds(): string[] {
     .map((meta) => meta.id);
 }
 
-export function buildComingSoonHref(slugOrId: string): string {
+export function buildComingSoonHref(
+  slugOrId: string,
+  existingQuery?: string | null,
+): string {
   const slug = slugOrId.includes("-")
     ? slugOrId
     : canonicalRecordSportSlug(slugOrId);
-  const params = new URLSearchParams({ sport: slug });
-  return `/record/coming-soon?${params.toString()}`;
+  const params = new URLSearchParams(existingQuery ?? undefined);
+  params.set("sport", slug);
+  const query = params.toString();
+  return query ? `/record/coming-soon?${query}` : "/record/coming-soon";
 }


### PR DESCRIPTION
## Summary
- forward existing search params when redirecting record routes to canonical or custom sport pages
- reuse the current query string when sending users to the coming soon page
- update record page tests to cover query preservation for disc golf

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d51474e8e08323bf5fedf5cd3ab699