### PR TITLE
Improve profile UX when player record is missing

### DIFF
--- a/apps/web/src/components/ClubSelect.tsx
+++ b/apps/web/src/components/ClubSelect.tsx
@@ -129,6 +129,15 @@ export default function ClubSelect({
   }, [options, searchTerm, value]);
 
   useEffect(() => {
+    if (disabled) {
+      return;
+    }
+    if (status === "idle") {
+      void loadOptions();
+    }
+  }, [disabled, loadOptions, status]);
+
+  useEffect(() => {
     if (dirtySearch) {
       return;
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -498,6 +498,12 @@ export async function fetchMyPlayer(): Promise<PlayerMe> {
   return withAbsolutePhotoUrl(data);
 }
 
+export async function createMyPlayer(): Promise<PlayerMe> {
+  const res = await apiFetch("/v0/players/me", { method: "POST" });
+  const data = (await res.json()) as PlayerMe;
+  return withAbsolutePhotoUrl(data);
+}
+
 export async function updateMyPlayerLocation(
   data: PlayerLocationPayload
 ): Promise<PlayerMe> {


### PR DESCRIPTION
## Summary
- guard the profile UI when the viewer has no player record, add a create-player CTA, and add a confirm-password check before saving
- load club suggestions automatically from ClubSelect and expose createMyPlayer on the frontend API
- add a /players/me POST endpoint that can resurrect deleted players and extend the profile test suites on both the frontend and backend

## Testing
- npm test -- --run
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5262f5e04832383629f5f02bc8383