### PR TITLE
Improve record form locale handling and bowling UX

### DIFF
--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -58,9 +58,12 @@ describe('HomePageClient error messages', () => {
         matchError={false}
       />
     );
-    expect(
-      screen.getByText((_, el) => el?.textContent === 'A1 & A2 vs B1 & B2')
-    ).toBeInTheDocument();
+    const matchItem = screen.getByRole('listitem');
+    const normalized = matchItem.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    expect(normalized).toContain('A1');
+    expect(normalized).toContain('A2');
+    expect(normalized).toContain('B1');
+    expect(normalized).toContain('B2');
     const link = screen.getByText('Match details');
     expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toBe('/matches/m1');

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -7,6 +7,7 @@ import * as LocaleContext from "../../../lib/LocaleContext";
 let sportParam = "padel";
 let searchParamString = "";
 const router = { push: vi.fn(), replace: vi.fn() };
+let confirmSpy: ReturnType<typeof vi.spyOn>;
 vi.mock("next/navigation", () => ({
   useRouter: () => router,
   useParams: () => ({ sport: sportParam }),
@@ -14,9 +15,16 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("RecordSportPage", () => {
+  beforeEach(() => {
+    confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+  });
+
   afterEach(() => {
     router.push.mockReset();
     router.replace.mockReset();
+    confirmSpy.mockRestore();
     vi.clearAllMocks();
     searchParamString = "";
   });

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -27,6 +27,20 @@ describe('LocaleProvider', () => {
     expect(localeDisplay).toHaveTextContent('en-AU');
   });
 
+  it('keeps the server-provided locale when it specifies a different region preference', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-US', 'en']);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-AU">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-AU');
+  });
+
   it('falls back to navigator.language when languages is empty', async () => {
     vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
     vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-GB');

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -15,8 +15,25 @@ function getBrowserLocale(fallback: string): string {
     : [];
   const preferred = languages.find((lang) => typeof lang === 'string' && lang.length > 0);
   const candidate = preferred ?? navigator.language;
+  const normalizedFallback = normalizeLocale(fallback);
+  const normalizedCandidate = normalizeLocale(candidate, normalizedFallback);
 
-  return normalizeLocale(candidate, fallback);
+  if (!candidate) {
+    return normalizedFallback;
+  }
+
+  const fallbackLower = normalizedFallback.toLowerCase();
+  const candidateLower = normalizedCandidate.toLowerCase();
+
+  if (fallbackLower !== 'en-us' && fallbackLower !== candidateLower) {
+    const fallbackBase = fallbackLower.split('-')[0] ?? fallbackLower;
+    const candidateBase = candidateLower.split('-')[0] ?? candidateLower;
+    if (fallbackBase === candidateBase) {
+      return normalizedFallback;
+    }
+  }
+
+  return normalizedCandidate;
 }
 
 interface ProviderProps {

--- a/apps/web/src/lib/recording.test.ts
+++ b/apps/web/src/lib/recording.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getRecordSportHelpText } from "./recording";
+
+describe("getRecordSportHelpText", () => {
+  it("returns the Australian English copy when requested", () => {
+    expect(getRecordSportHelpText("bowling", "en-AU")).toBe(
+      "Enter each roll for every frame. Use 0 for gutter balls, leave roll 2 blank after a strike, and only fill roll 3 in the tenth frame once you've earned it.",
+    );
+  });
+
+  it("falls back to general English when the region is unsupported", () => {
+    expect(getRecordSportHelpText("padel", "en-GB")).toBe(
+      "Record games won for each set and toggle Doubles when two players per side are on the court.",
+    );
+  });
+
+  it("returns null when the sport has no help text", () => {
+    expect(getRecordSportHelpText("disc_golf", "en-AU")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/recording.ts
+++ b/apps/web/src/lib/recording.ts
@@ -1,3 +1,5 @@
+import { normalizeLocale } from "./i18n";
+
 export type RecordSportForm = "dynamic" | "custom";
 
 export interface RecordSportMeta {
@@ -95,4 +97,78 @@ export function buildComingSoonHref(
   params.set("sport", slug);
   const query = params.toString();
   return query ? `/record/coming-soon?${query}` : "/record/coming-soon";
+}
+
+const RECORD_SPORT_HELP_TEXT: Record<string, Record<string, string>> = {
+  bowling: {
+    "en-AU":
+      "Enter each roll for every frame. Use 0 for gutter balls, leave roll 2 blank after a strike, and only fill roll 3 in the tenth frame once you've earned it.",
+    en:
+      "Enter each roll for every frame. Use 0 for gutter balls, leave roll 2 blank after a strike, and only fill roll 3 in the tenth frame when you've earned it.",
+  },
+  padel: {
+    "en-AU":
+      "Record games won for each set and toggle Doubles when you have two players per side on court.",
+    en:
+      "Record games won for each set and toggle Doubles when two players per side are on the court.",
+  },
+  pickleball: {
+    "en-AU":
+      "Track rally-scoring games to 11 (win by 2). Toggle Doubles when you're playing pairs.",
+    en:
+      "Track rally-scoring games to 11 (win by 2). Toggle Doubles when each side has two players.",
+  },
+  table_tennis: {
+    "en-AU":
+      "Enter the games won by each player. Matches are usually best of five—adjust the scores if you used a different format.",
+    en:
+      "Enter the games won by each player. Matches are typically best of five—adjust the scores if you used a different format.",
+  },
+};
+
+function resolveHelpTextLocale(
+  locale: string,
+  helpTextMap: Record<string, string>,
+): string | undefined {
+  const normalized = normalizeLocale(locale, "en");
+  const lower = normalized.toLowerCase();
+  const directMatch = Object.keys(helpTextMap).find(
+    (key) => key.toLowerCase() === lower,
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const base = lower.split("-")[0];
+  if (base) {
+    const baseMatch = Object.keys(helpTextMap).find(
+      (key) => key.toLowerCase() === base,
+    );
+    if (baseMatch) {
+      return baseMatch;
+    }
+  }
+
+  if (helpTextMap.en) {
+    return "en";
+  }
+
+  return Object.keys(helpTextMap)[0];
+}
+
+export function getRecordSportHelpText(
+  sportId: string,
+  locale: string,
+): string | null {
+  const helpTextMap = RECORD_SPORT_HELP_TEXT[sportId];
+  if (!helpTextMap) {
+    return null;
+  }
+
+  const matchKey = resolveHelpTextLocale(locale, helpTextMap);
+  if (!matchKey) {
+    return null;
+  }
+
+  return helpTextMap[matchKey] ?? null;
 }


### PR DESCRIPTION
## Summary
- ensure the locale context respects server-provided locales instead of being overridden by navigator defaults and cover it with tests
- add localized sport help text utilities and surface the copy in the dynamic record form alongside a bowling save confirmation and time field labelling tweaks
- show live bowling totals, add a confirmation prompt before submitting, and expand automated coverage for the new behaviours

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d52511bb1c832396244382e547bfc5