### PR TITLE
Improve locale detection and record form UX

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang={locale}>
       <body>
-        <LocaleProvider locale={locale}>
+        <LocaleProvider locale={locale} acceptLanguage={acceptLanguage}>
           <ToastProvider>
             <ChunkErrorReload />
             <Header />

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -14,6 +14,10 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("RecordSportPage", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
   afterEach(() => {
     router.push.mockReset();
     router.replace.mockReset();

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -27,6 +27,20 @@ describe('LocaleProvider', () => {
     expect(localeDisplay).toHaveTextContent('en-AU');
   });
 
+  it('uses the accept-language header when provided', async () => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-US']);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US" acceptLanguage="en-AU,en;q=0.9">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('en-AU');
+  });
+
   it('falls back to navigator.language when languages is empty', async () => {
     vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
     vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-GB');

--- a/apps/web/src/lib/bowlingSummary.test.ts
+++ b/apps/web/src/lib/bowlingSummary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { summarizeBowlingInput } from "./bowlingSummary";
+import { previewBowlingInput, summarizeBowlingInput } from "./bowlingSummary";
 
 describe("summarizeBowlingInput", () => {
   it("produces cumulative frame totals for a perfect game", () => {
@@ -41,5 +41,62 @@ describe("summarizeBowlingInput", () => {
 
     expect(result.frameScores).toEqual([9, 22, 29, 29, 29, 29, 29, 29, 29, 29]);
     expect(result.total).toBe(29);
+  });
+});
+
+describe("previewBowlingInput", () => {
+  it("computes running totals when future rolls are available", () => {
+    const frames: string[][] = [
+      ["9", "0"],
+      ["10", ""],
+      ["7", "2"],
+      ["3", "4"],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+    ];
+
+    const preview = previewBowlingInput(frames);
+
+    expect(preview.frameTotals.slice(0, 4)).toEqual([9, 28, 37, 44]);
+    expect(preview.total).toBe(44);
+  });
+
+  it("returns null for frames that need additional rolls", () => {
+    const frames: string[][] = [
+      ["10", ""],
+      ["7", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+      ["", ""],
+    ];
+
+    const preview = previewBowlingInput(frames);
+
+    expect(preview.frameTotals[0]).toBeNull();
+    expect(preview.total).toBeNull();
+  });
+
+  it("waits for the final frame bonus before finishing the score", () => {
+    const frames: string[][] = Array.from({ length: 9 }, () => ["10", ""]);
+    frames.push(["10", "10", ""]);
+
+    const preview = previewBowlingInput(frames);
+
+    expect(preview.frameTotals[9]).toBeNull();
+
+    frames[9][2] = "10";
+    const completed = previewBowlingInput(frames);
+
+    expect(completed.frameTotals[9]).toBe(300);
+    expect(completed.total).toBe(300);
   });
 });

--- a/apps/web/src/lib/sportCopy.ts
+++ b/apps/web/src/lib/sportCopy.ts
@@ -1,0 +1,106 @@
+export interface SportCopy {
+  matchDetailsHint?: string;
+  timeHint?: string;
+  playersHint?: string;
+  scoringHint?: string;
+  confirmationMessage?: string;
+}
+
+const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
+  bowling: {
+    default: {
+      matchDetailsHint:
+        'Record when and where the game took place so everyone can follow the series.',
+      timeHint: 'Use local 24-hour time (e.g. 18:30) if the picker does not show AM/PM.',
+      playersHint: 'Assign each scorecard to the correct bowler before entering their frames.',
+      scoringHint:
+        'Enter each roll per frame. Leave roll 2 empty after a strike and only fill roll 3 in the final frame when it is earned. Running totals update as you go.',
+      confirmationMessage: 'Save this bowling scorecard?',
+    },
+    'en-au': {
+      matchDetailsHint:
+        'Capture the session details so your mates can see when the round was played.',
+      confirmationMessage: 'Ready to save this bowling scorecard?',
+    },
+  },
+  padel: {
+    default: {
+      matchDetailsHint:
+        'Note the match date, time and venue so partners can find the fixture later.',
+      timeHint: 'Enter the local start time using 24-hour format (e.g. 19:15).',
+      playersHint:
+        'Pick the players for sides A and B. Leave a spot blank if a walkover occurred.',
+      scoringHint:
+        'Use the final set tally for each team (for example 6-3, 4-6, 6-4 → enter 2 and 1).',
+      confirmationMessage: 'Save this padel match result?',
+    },
+    'en-au': {
+      matchDetailsHint:
+        'Log the match details so clubmates back in Australia know when you played.',
+      confirmationMessage: 'Lock in this padel result?',
+    },
+  },
+  pickleball: {
+    default: {
+      matchDetailsHint:
+        'Add the match timing and venue so partners can look back on the session.',
+      timeHint: 'Record the local start time in 24-hour format (e.g. 08:30).',
+      playersHint:
+        'Choose the lineup for each side. Leave the second slot empty for singles games.',
+      scoringHint:
+        'Enter the winning game totals for teams A and B (best of three unless noted).',
+      confirmationMessage: 'Save this pickleball match?',
+    },
+    'en-au': {
+      matchDetailsHint:
+        'Keep track of when you hit the court so Aussie teammates can follow along.',
+      confirmationMessage: 'Happy to save this pickleball result?',
+    },
+  },
+  table_tennis: {
+    default: {
+      matchDetailsHint:
+        'Record the session details so training partners can review the fixture later.',
+      timeHint: 'Enter the start time using 24-hour time (e.g. 20:05).',
+      playersHint:
+        'Select the competitors for each side. Leave unused slots blank for forfeits.',
+      scoringHint:
+        'Enter the number of games won by each side (first to three in most matches).',
+      confirmationMessage: 'Save this table tennis result?',
+    },
+    'en-au': {
+      matchDetailsHint:
+        'Log the hit-up details so mates back home know when you played.',
+      confirmationMessage: 'Lock this table tennis result into the records?',
+    },
+  },
+};
+
+function getLocaleChain(locale: string): string[] {
+  const lower = (locale ?? '').toLowerCase();
+  const parts = lower.split('-').filter(Boolean);
+  const chain = ['default'];
+  if (parts[0]) {
+    chain.push(parts[0]);
+  }
+  if (parts.length > 1) {
+    chain.push(lower);
+  }
+  return chain;
+}
+
+export function getSportCopy(sportId: string, locale: string): SportCopy {
+  const sportKey = sportId.toLowerCase();
+  const buckets = SPORT_COPY[sportKey] ?? {};
+  const chain = getLocaleChain(locale);
+  const result: SportCopy = {};
+
+  for (const key of chain) {
+    const copy = buckets[key];
+    if (copy) {
+      Object.assign(result, copy);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- ensure the locale context honours the Accept-Language header before falling back to browser defaults
- surface localized help copy, time guidance, and a confirmation dialog on the dynamic record form while showing bowling running totals live
- add a reusable sport copy helper plus preview calculations and unit tests for locale detection and bowling previews

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52fd990048323960595a1f7858163