### PR TITLE
Fix Next.js record page export for dynamic sport route

### DIFF
--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import * as bowlingSummary from "../../../lib/bowlingSummary";
 import * as LocaleContext from "../../../lib/LocaleContext";
 import RecordSportForm from "./RecordSportForm";
-import { resolveRecordSportRoute } from "./page";
+import { resolveRecordSportRoute } from "./resolveRecordSportRoute";
 
 const router = { push: vi.fn() };
 

--- a/apps/web/src/app/record/[sport]/page.tsx
+++ b/apps/web/src/app/record/[sport]/page.tsx
@@ -1,96 +1,10 @@
 import { redirect, notFound } from "next/navigation";
+
 import RecordSportForm from "./RecordSportForm";
 import {
-  buildComingSoonHref,
-  canonicalRecordSportSlug,
-  getRecordSportMetaBySlug,
-  isSportHandledByDynamicRecordForm,
-} from "../../../lib/recording";
-import { ensureTrailingSlash } from "../../../lib/routes";
-
-interface RecordSportPageProps {
-  params: { sport?: string | string[] };
-  searchParams?: Record<string, string | string[] | undefined>;
-}
-
-type RouteResolution =
-  | { type: "render"; sportId: string }
-  | { type: "redirect"; destination: string }
-  | { type: "not-found" };
-
-function buildSearchString(
-  searchParams?: Record<string, string | string[] | undefined>,
-): string {
-  const params = new URLSearchParams();
-  if (!searchParams) {
-    return "";
-  }
-  for (const [key, value] of Object.entries(searchParams)) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item != null) {
-          params.append(key, item);
-        }
-      }
-    } else if (typeof value === "string") {
-      params.append(key, value);
-    }
-  }
-  return params.toString();
-}
-
-export function resolveRecordSportRoute({
-  params,
-  searchParams,
-}: RecordSportPageProps): RouteResolution {
-  const rawParam = params?.sport;
-  const rawSport = typeof rawParam === "string" ? rawParam : "";
-  if (!rawSport) {
-    return { type: "not-found" };
-  }
-
-  const sportMeta = getRecordSportMetaBySlug(rawSport);
-  if (!sportMeta) {
-    return { type: "not-found" };
-  }
-
-  const search = buildSearchString(searchParams);
-
-  if (!sportMeta.implemented) {
-    return {
-      type: "redirect",
-      destination: buildComingSoonHref(sportMeta.slug, search),
-    };
-  }
-
-  const canonicalSlug = canonicalRecordSportSlug(sportMeta.id);
-  if (canonicalSlug !== rawSport) {
-    const target = ensureTrailingSlash(`/record/${canonicalSlug}`);
-    const destination = search ? `${target}?${search}` : target;
-    return { type: "redirect", destination };
-  }
-
-  if (sportMeta.form === "custom") {
-    const basePath = ensureTrailingSlash(
-      sportMeta.redirectPath ?? `/record/${sportMeta.slug}`,
-    );
-    const destination = search
-      ? basePath.includes("?")
-        ? `${basePath}&${search}`
-        : `${basePath}?${search}`
-      : basePath;
-    return { type: "redirect", destination };
-  }
-
-  if (!isSportHandledByDynamicRecordForm(sportMeta.id)) {
-    return {
-      type: "redirect",
-      destination: buildComingSoonHref(sportMeta.slug, search),
-    };
-  }
-
-  return { type: "render", sportId: sportMeta.id };
-}
+  resolveRecordSportRoute,
+  type RecordSportPageProps,
+} from "./resolveRecordSportRoute";
 
 export default function RecordSportPage(props: RecordSportPageProps) {
   const resolution = resolveRecordSportRoute(props);

--- a/apps/web/src/app/record/[sport]/resolveRecordSportRoute.ts
+++ b/apps/web/src/app/record/[sport]/resolveRecordSportRoute.ts
@@ -1,0 +1,93 @@
+import {
+  buildComingSoonHref,
+  canonicalRecordSportSlug,
+  getRecordSportMetaBySlug,
+  isSportHandledByDynamicRecordForm,
+} from "../../../lib/recording";
+import { ensureTrailingSlash } from "../../../lib/routes";
+
+export interface RecordSportPageProps {
+  params: { sport?: string | string[] };
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export type RouteResolution =
+  | { type: "render"; sportId: string }
+  | { type: "redirect"; destination: string }
+  | { type: "not-found" };
+
+function buildSearchString(
+  searchParams?: Record<string, string | string[] | undefined>,
+): string {
+  if (!searchParams) {
+    return "";
+  }
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null) {
+          params.append(key, item);
+        }
+      }
+    } else if (typeof value === "string") {
+      params.append(key, value);
+    }
+  }
+
+  return params.toString();
+}
+
+export function resolveRecordSportRoute({
+  params,
+  searchParams,
+}: RecordSportPageProps): RouteResolution {
+  const rawParam = params?.sport;
+  const rawSport = typeof rawParam === "string" ? rawParam : "";
+  if (!rawSport) {
+    return { type: "not-found" };
+  }
+
+  const sportMeta = getRecordSportMetaBySlug(rawSport);
+  if (!sportMeta) {
+    return { type: "not-found" };
+  }
+
+  const search = buildSearchString(searchParams);
+
+  if (!sportMeta.implemented) {
+    return {
+      type: "redirect",
+      destination: buildComingSoonHref(sportMeta.slug, search),
+    };
+  }
+
+  const canonicalSlug = canonicalRecordSportSlug(sportMeta.id);
+  if (canonicalSlug !== rawSport) {
+    const target = ensureTrailingSlash(`/record/${canonicalSlug}`);
+    const destination = search ? `${target}?${search}` : target;
+    return { type: "redirect", destination };
+  }
+
+  if (sportMeta.form === "custom") {
+    const basePath = ensureTrailingSlash(
+      sportMeta.redirectPath ?? `/record/${sportMeta.slug}`,
+    );
+    const destination = search
+      ? basePath.includes("?")
+        ? `${basePath}&${search}`
+        : `${basePath}?${search}`
+      : basePath;
+    return { type: "redirect", destination };
+  }
+
+  if (!isSportHandledByDynamicRecordForm(sportMeta.id)) {
+    return {
+      type: "redirect",
+      destination: buildComingSoonHref(sportMeta.slug, search),
+    };
+  }
+
+  return { type: "render", sportId: sportMeta.id };
+}


### PR DESCRIPTION
## Summary
- move the route resolution logic from the Next.js page component into a dedicated module so the page no longer exports unsupported fields
- update the page component to consume the shared resolver and adjust tests to import from the new module

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d545b7d3488323b5d0bfeaa9ad7902