### PR TITLE
Handle incomplete bowling frames when summarizing

### DIFF
--- a/apps/web/src/lib/bowlingSummary.test.ts
+++ b/apps/web/src/lib/bowlingSummary.test.ts
@@ -42,6 +42,36 @@ describe("summarizeBowlingInput", () => {
     expect(result.frameScores).toEqual([9, 22, 29, 29, 29, 29, 29, 29, 29, 29]);
     expect(result.total).toBe(29);
   });
+
+  it("fills missing rolls with zeros when normalization is requested", () => {
+    const frames: string[][] = Array.from({ length: 9 }, () => ["", ""]);
+    frames.push(["", "", ""]);
+
+    const result = summarizeBowlingInput(frames, {
+      playerLabel: "Test",
+      normalizeIncompleteFrames: true,
+    });
+
+    expect(result.frames).toEqual(
+      Array.from({ length: 10 }, () => [0, 0]),
+    );
+    expect(result.frameScores).toEqual(Array.from({ length: 10 }, () => 0));
+    expect(result.total).toBe(0);
+  });
+
+  it("normalizes tenth frame bonuses when they are missing", () => {
+    const frames: string[][] = Array.from({ length: 9 }, () => ["", ""]);
+    frames.push(["10", "", ""]);
+
+    const result = summarizeBowlingInput(frames, {
+      playerLabel: "Test",
+      normalizeIncompleteFrames: true,
+    });
+
+    expect(result.frames[9]).toEqual([10, 0, 0]);
+    expect(result.frameScores[9]).toBe(10);
+    expect(result.total).toBe(10);
+  });
 });
 
 describe("previewBowlingInput", () => {


### PR DESCRIPTION
## Summary
- add normalization helpers so bowling summaries can fill in incomplete frame inputs before scoring
- support an optional `normalizeIncompleteFrames` flag on `summarizeBowlingInput` and use it when recording bowling matches
- cover the new behavior with unit tests for empty games and unfinished tenth-frame bonuses

## Testing
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d547f4a8b0832389d1e9fbebda0199