### PR TITLE
Add admin player hiding controls

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -506,17 +506,44 @@ textarea {
   max-width: 220px;
 }
 
-.player-list__delete {
-  margin-left: auto;
+.player-list__action {
   background: transparent;
   border: 1px solid rgba(10, 31, 68, 0.2);
   padding: 0.4rem 0.75rem;
   border-radius: 6px;
   cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.player-list__action:hover {
+  background: rgba(26, 115, 232, 0.08);
+}
+
+.player-list__action[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.player-list__toggle {
+  margin-left: auto;
+}
+
+.player-list__delete {
+  border-color: rgba(185, 28, 28, 0.4);
+  color: #9f1239;
 }
 
 .player-list__delete:hover {
-  background: rgba(26, 115, 232, 0.08);
+  background: rgba(185, 28, 28, 0.08);
+}
+
+.player-list__status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #92400e;
+  background: #fef3c7;
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
 }
 
 .player-list__error {

--- a/backend/alembic/versions/0022_player_hidden_flag.py
+++ b/backend/alembic/versions/0022_player_hidden_flag.py
@@ -1,0 +1,23 @@
+"""Add hidden flag to player"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0022_player_hidden_flag"
+down_revision = "0021_player_bio"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "player",
+        sa.Column("hidden", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute(sa.text("UPDATE player SET hidden = FALSE WHERE hidden IS NULL"))
+    op.alter_column("player", "hidden", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("player", "hidden")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,6 +45,7 @@ class Player(Base):
     country_code = Column(String(2), nullable=True)
     region_code = Column(String(3), nullable=True)
     ranking = Column(Integer, nullable=True)
+    hidden = Column(Boolean, nullable=False, default=False)
     deleted_at = Column(DateTime, nullable=True)
 
     social_links = relationship(

--- a/backend/app/routes/player.py
+++ b/backend/app/routes/player.py
@@ -33,6 +33,7 @@ async def player_profile(
         country_code=player.country_code,
         region_code=player.region_code,
         ranking=player.ranking,
+        hidden=player.hidden,
     )
 
     stats = await player_stats(player_id, session=session)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -223,6 +223,7 @@ class PlayerOut(BaseModel):
     ranking: Optional[int] = None
     country_code: Optional[str] = None
     region_code: Optional[str] = None
+    hidden: bool = False
     metrics: Optional[Dict[str, Dict[str, int]]] = None
     milestones: Optional[Dict[str, List[str]]] = None
     badges: List[BadgeOut] = Field(default_factory=list)
@@ -257,6 +258,10 @@ class PlayerListOut(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class PlayerVisibilityUpdate(BaseModel):
+    hidden: bool
 
 class LeaderboardEntryOut(BaseModel):
     rank: int


### PR DESCRIPTION
## Summary
- add a hidden flag to players and expose admin-only visibility controls in the API
- surface player visibility toggles and hidden badges in the players list UI for admins
- replace passlib bcrypt context with direct bcrypt helpers and cover the new behavior with backend/frontend tests

## Testing
- pytest
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d5eca4ccd48323a63726350eae97b9