### PR TITLE
Preserve local dates for date-only match submissions

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
 import { getDatePlaceholder } from "../../../lib/i18n";
+import { buildPlayedAtISOString } from "../../../lib/datetime";
 import {
   summarizeBowlingInput,
   previewBowlingInput,
@@ -474,11 +475,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
 
       try {
         setSubmitting(true);
-        const playedAt = date
-          ? (time
-              ? new Date(`${date}T${time}`).toISOString()
-              : `${date}T00:00:00Z`)
-          : undefined;
+        const playedAt = buildPlayedAtISOString(date, time);
 
         const payload = {
           sport,
@@ -534,11 +531,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
 
     try {
       setSubmitting(true);
-      const playedAt = date
-        ? (time
-            ? new Date(`${date}T${time}`).toISOString()
-            : `${date}T00:00:00Z`)
-        : undefined;
+      const playedAt = buildPlayedAtISOString(date, time);
 
       const payload = {
         sport,

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
 import { getDatePlaceholder } from "../../../lib/i18n";
+import { buildPlayedAtISOString } from "../../../lib/datetime";
 
 interface Player {
   id: string;
@@ -163,10 +164,9 @@ export default function RecordPadelPage() {
         participants,
         bestOf: Number(bestOf),
       };
-      if (date) {
-        payload.playedAt = time
-          ? new Date(`${date}T${time}`).toISOString()
-          : `${date}T00:00:00Z`;
+      const playedAt = buildPlayedAtISOString(date, time);
+      if (playedAt) {
+        payload.playedAt = playedAt;
       }
       if (location) {
         payload.location = location;

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -1,0 +1,13 @@
+export function buildPlayedAtISOString(
+  date?: string,
+  time?: string,
+): string | undefined {
+  if (!date) {
+    return undefined;
+  }
+
+  const trimmedTime = time?.trim();
+  const isoInput = trimmedTime ? `${date}T${trimmedTime}` : `${date}T00:00`;
+
+  return new Date(isoInput).toISOString();
+}


### PR DESCRIPTION
## Summary
- add a shared helper to turn date and optional time inputs into local ISO timestamps
- use the helper when submitting match records so date-only entries keep the intended day

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d5f9261e7c83239b06cbedd4070a84