### PR TITLE
Adjust checkbox spacing for friendly match toggle

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -133,6 +133,11 @@ img {
   gap: 0.5rem;
 }
 
+.form-field--checkbox input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
 .form-label {
   font-size: 0.9rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- set checkbox inputs within form-field--checkbox to auto width and remove default margins to bring the label closer

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d6004a0b3083238a09e6d5866df97a