### PR TITLE
Add pagination to matches API and client load-more support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.3",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.3))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 20.11.30
         version: 20.11.30
@@ -495,6 +498,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -2571,6 +2580,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.3(@types/react@18.3.3)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@2.0.0': {}
 

--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -1,31 +1,35 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import HomePageClient from '../home-page-client';
+import * as apiModule from '../../lib/api';
+import * as matchesModule from '../../lib/matches';
+
+const defaultProps = {
+  sports: [],
+  matches: [],
+  sportError: false,
+  matchError: false,
+  initialLocale: 'en-US',
+  initialHasMore: false,
+  initialNextOffset: null,
+  initialPageSize: 5,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('HomePageClient error messages', () => {
   it('shows sports error message', () => {
-    render(
-      <HomePageClient
-        sports={[]}
-        matches={[]}
-        sportError={true}
-        matchError={false}
-      />
-    );
+    render(<HomePageClient {...defaultProps} sportError={true} />);
     expect(
       screen.getByText(/Unable to load sports\. Check connection\./i)
     ).toBeInTheDocument();
   });
 
   it('shows matches error message', () => {
-    render(
-      <HomePageClient
-        sports={[]}
-        matches={[]}
-        sportError={false}
-        matchError={true}
-      />
-    );
+    render(<HomePageClient {...defaultProps} matchError={true} />);
     expect(
       screen.getByText(/Unable to load matches\. Check connection\./i)
     ).toBeInTheDocument();
@@ -34,7 +38,7 @@ describe('HomePageClient error messages', () => {
   it('renders player names and match details link', () => {
     render(
       <HomePageClient
-        sports={[]}
+        {...defaultProps}
         matches={[
           {
             id: 'm1',
@@ -42,6 +46,7 @@ describe('HomePageClient error messages', () => {
             bestOf: 3,
             playedAt: null,
             location: null,
+            isFriendly: false,
             players: {
               A: [
                 { id: 'a1', name: 'A1' },
@@ -54,8 +59,6 @@ describe('HomePageClient error messages', () => {
             },
           },
         ]}
-        sportError={false}
-        matchError={false}
       />
     );
     expect(screen.getByText('A1')).toBeInTheDocument();
@@ -65,5 +68,114 @@ describe('HomePageClient error messages', () => {
     const link = screen.getByText('Match details');
     expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toBe('/matches/m1');
+  });
+
+  it('loads more matches when requested', async () => {
+    const apiFetchMock = vi
+      .spyOn(apiModule, 'apiFetch')
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              id: 'm2',
+              sport: 'padel',
+              bestOf: 3,
+              playedAt: null,
+              location: null,
+              isFriendly: false,
+            },
+          ],
+          limit: 5,
+          offset: 5,
+          hasMore: false,
+          nextOffset: null,
+        }),
+      } as unknown as Response);
+
+    vi.spyOn(matchesModule, 'enrichMatches').mockImplementation(async (rows) =>
+      rows.map((row) => ({
+        ...row,
+        players: {
+          A: [{ id: `${row.id}-a`, name: `${row.id} Player A` }],
+          B: [{ id: `${row.id}-b`, name: `${row.id} Player B` }],
+        },
+      }))
+    );
+
+    render(
+      <HomePageClient
+        {...defaultProps}
+        matches={[
+          {
+            id: 'm1',
+            sport: 'padel',
+            bestOf: 3,
+            playedAt: null,
+            location: null,
+            isFriendly: false,
+            players: {
+              A: [{ id: 'a1', name: 'A1' }],
+              B: [{ id: 'b1', name: 'B1' }],
+            },
+          },
+        ]}
+        initialHasMore={true}
+        initialNextOffset={5}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /load more matches/i });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/m2 Player A/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/v0/matches?limit=5&offset=5',
+      { cache: 'no-store' }
+    );
+    expect(screen.getByText(/View all matches/i)).toBeInTheDocument();
+  });
+
+  it('shows an error if loading more matches fails', async () => {
+    vi.spyOn(apiModule, 'apiFetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    render(
+      <HomePageClient
+        {...defaultProps}
+        matches={[
+          {
+            id: 'm1',
+            sport: 'padel',
+            bestOf: 3,
+            playedAt: null,
+            location: null,
+            isFriendly: false,
+            players: {
+              A: [{ id: 'a1', name: 'A1' }],
+              B: [{ id: 'b1', name: 'B1' }],
+            },
+          },
+        ]}
+        initialHasMore={true}
+        initialNextOffset={5}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /load more matches/i });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Unable to load more matches/i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,11 @@ export const dynamic = 'force-dynamic';
 
 import { apiFetch } from '../lib/api';
 import HomePageClient from './home-page-client';
-import { enrichMatches, type MatchRow, type EnrichedMatch } from '../lib/matches';
+import {
+  enrichMatches,
+  type EnrichedMatch,
+  type MatchRowPage,
+} from '../lib/matches';
 import { headers } from 'next/headers';
 import { parseAcceptLanguage } from '../lib/i18n';
 
@@ -11,13 +15,20 @@ type Sport = { id: string; name: string };
 export default async function HomePage() {
   let sports: Sport[] = [];
   let matches: EnrichedMatch[] = [];
+  let matchHasMore = false;
+  let matchNextOffset: number | null = null;
+  let matchPageSize = 5;
   let sportError = false;
   let matchError = false;
   const locale = parseAcceptLanguage(headers().get('accept-language'));
 
+  const MATCHES_LIMIT = 5;
+
   const [sportsResult, matchesResult] = await Promise.allSettled([
     apiFetch('/v0/sports', { next: { revalidate: 60 } }),
-    apiFetch('/v0/matches', { next: { revalidate: 60 } }),
+    apiFetch(`/v0/matches?limit=${MATCHES_LIMIT}`, {
+      next: { revalidate: 60 },
+    }),
   ]);
 
   if (sportsResult.status === 'fulfilled' && sportsResult.value.ok) {
@@ -28,8 +39,11 @@ export default async function HomePage() {
 
   if (matchesResult.status === 'fulfilled' && matchesResult.value.ok) {
     try {
-      const rows = (await matchesResult.value.json()) as MatchRow[];
-      matches = await enrichMatches(rows.slice(0, 5));
+      const page = (await matchesResult.value.json()) as MatchRowPage;
+      matches = await enrichMatches(page.items);
+      matchHasMore = page.hasMore;
+      matchNextOffset = page.nextOffset;
+      matchPageSize = page.limit ?? MATCHES_LIMIT;
     } catch {
       matchError = true;
     }
@@ -41,6 +55,9 @@ export default async function HomePage() {
     <HomePageClient
       sports={sports}
       matches={matches}
+      initialHasMore={matchHasMore}
+      initialNextOffset={matchNextOffset}
+      initialPageSize={matchPageSize}
       sportError={sportError}
       matchError={matchError}
       initialLocale={locale}

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -4,6 +4,15 @@ export type MatchRow = {
   bestOf: number | null;
   playedAt: string | null;
   location: string | null;
+  isFriendly: boolean;
+};
+
+export type MatchRowPage = {
+  items: MatchRow[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset: number | null;
 };
 
 export type Participant = {

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -604,6 +604,16 @@ class MatchSummaryOut(BaseModel):
     isFriendly: bool
 
 
+class MatchSummaryPageOut(BaseModel):
+    """Paginated collection of matches with navigation metadata."""
+
+    items: List[MatchSummaryOut] = Field(default_factory=list)
+    limit: int
+    offset: int
+    hasMore: bool = False
+    nextOffset: Optional[int] = None
+
+
 class ParticipantOut(BaseModel):
     """Participant information for a match."""
 

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -457,13 +457,16 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
   with TestClient(app) as client:
     resp = client.get("/matches")
     assert resp.status_code == 200
-    matches = resp.json()
+    data = resp.json()
+    matches = data["items"]
     ids = [m["id"] for m in matches]
     sorted_ids = [
         m["id"]
         for m in sorted(matches, key=lambda m: m["playedAt"], reverse=True)
     ]
     assert ids == sorted_ids
+    assert data["hasMore"] is False
+    assert data["nextOffset"] is None
 
 
 @pytest.mark.anyio
@@ -500,7 +503,8 @@ async def test_list_matches_upcoming_filter(tmp_path):
     resp = client.get("/matches", params={"upcoming": True})
     assert resp.status_code == 200
     data = resp.json()
-    assert [m["id"] for m in data] == ["future"]
+    assert [m["id"] for m in data["items"]] == ["future"]
+    assert data["hasMore"] is False
 
 
 @pytest.mark.skip(reason="SQLite lacks ARRAY support for MatchParticipant")
@@ -569,8 +573,8 @@ def test_list_matches_filters_by_player(tmp_path):
     resp = client.get("/matches", params={"playerId": p1})
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data) == 1
-    assert data[0]["id"] == m1
+    assert len(data["items"]) == 1
+    assert data["items"][0]["id"] == m1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add limit/offset pagination to the matches router and schema, returning navigation metadata
- request paginated data on the Next.js home page and expose pagination controls on the client
- extend HomePageClient tests to cover fetching additional pages and failure states

## Testing
- pytest backend/tests/test_matches.py::test_list_matches_returns_most_recent_first backend/tests/test_matches.py::test_list_matches_upcoming_filter -q
- pnpm exec vitest run src/app/__tests__/home.page.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d605c1a9ec832389da0c85f973e715