### PR TITLE
Highlight active header links

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -358,8 +358,29 @@ textarea {
   color: var(--color-nav-text);
   text-decoration: none;
 }
+.nav .nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    text-decoration-color 0.2s ease;
+}
 .nav a:hover {
   text-decoration: underline;
+}
+.nav .nav-link.is-active {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--color-nav-text);
+  font-weight: 600;
+}
+.nav .nav-link.is-active:hover {
+  text-decoration: none;
+}
+.nav a:focus-visible {
+  outline: 3px solid var(--color-accent-blue);
+  outline-offset: 2px;
 }
 .nav-links ul {
   display: flex;

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import { currentUsername, isAdmin, logout } from '../lib/api';
 import { ensureTrailingSlash } from '../lib/routes';
 
@@ -10,7 +10,27 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [user, setUser] = useState<string | null>(null);
   const [admin, setAdmin] = useState(false);
+  const pathname = usePathname();
   const router = useRouter();
+
+  const normalizedPathname = useMemo(
+    () => ensureTrailingSlash(pathname ?? '/'),
+    [pathname]
+  );
+
+  const isActivePath = (targetPath: string) => {
+    const normalizedTarget = ensureTrailingSlash(targetPath);
+    if (normalizedTarget === '/') {
+      return normalizedPathname === '/';
+    }
+    return normalizedPathname.startsWith(normalizedTarget);
+  };
+
+  const linkClassName = (targetPath: string) =>
+    `nav-link${isActivePath(targetPath) ? ' is-active' : ''}`;
+
+  const linkAriaCurrent = (targetPath: string) =>
+    isActivePath(targetPath) ? 'page' : undefined;
 
   useEffect(() => {
     const update = () => {
@@ -44,13 +64,20 @@ export default function Header() {
       <nav id="nav-menu" className={`nav-links ${open ? 'open' : ''}`}>
         <ul>
           <li>
-            <Link href="/" onClick={() => setOpen(false)}>
+            <Link
+              href="/"
+              className={linkClassName('/')}
+              aria-current={linkAriaCurrent('/')}
+              onClick={() => setOpen(false)}
+            >
               Home
             </Link>
           </li>
           <li>
             <Link
               href={ensureTrailingSlash('/players')}
+              className={linkClassName('/players')}
+              aria-current={linkAriaCurrent('/players')}
               onClick={() => setOpen(false)}
             >
               Players
@@ -59,6 +86,8 @@ export default function Header() {
           <li>
             <Link
               href={ensureTrailingSlash('/matches')}
+              className={linkClassName('/matches')}
+              aria-current={linkAriaCurrent('/matches')}
               onClick={() => setOpen(false)}
             >
               Matches
@@ -67,6 +96,8 @@ export default function Header() {
           <li>
             <Link
               href={ensureTrailingSlash('/record')}
+              className={linkClassName('/record')}
+              aria-current={linkAriaCurrent('/record')}
               onClick={() => setOpen(false)}
             >
               Record
@@ -75,6 +106,8 @@ export default function Header() {
           <li>
             <Link
               href={ensureTrailingSlash('/leaderboard?sport=all')}
+              className={linkClassName('/leaderboard')}
+              aria-current={linkAriaCurrent('/leaderboard')}
               onClick={() => setOpen(false)}
             >
               Leaderboards
@@ -85,6 +118,8 @@ export default function Header() {
               <li>
                 <Link
                   href={ensureTrailingSlash('/admin/matches')}
+                  className={linkClassName('/admin/matches')}
+                  aria-current={linkAriaCurrent('/admin/matches')}
                   onClick={() => setOpen(false)}
                 >
                   Admin Matches
@@ -93,6 +128,8 @@ export default function Header() {
               <li>
                 <Link
                   href={ensureTrailingSlash('/admin/badges')}
+                  className={linkClassName('/admin/badges')}
+                  aria-current={linkAriaCurrent('/admin/badges')}
                   onClick={() => setOpen(false)}
                 >
                   Admin Badges
@@ -105,6 +142,8 @@ export default function Header() {
               <li>
                 <Link
                   href={ensureTrailingSlash('/profile')}
+                  className={linkClassName('/profile')}
+                  aria-current={linkAriaCurrent('/profile')}
                   onClick={() => setOpen(false)}
                 >
                   Profile
@@ -119,6 +158,8 @@ export default function Header() {
             <li>
               <Link
                 href={ensureTrailingSlash('/login')}
+                className={linkClassName('/login')}
+                aria-current={linkAriaCurrent('/login')}
                 onClick={() => setOpen(false)}
               >
                 Login


### PR DESCRIPTION
## Summary
- mark header navigation links as active based on the current pathname and expose aria-current for assistive tech
- style the navigation to surface the active state and add visible focus rings without suppressing outlines

## Testing
- npm run lint *(fails: existing lint errors in players/[id]/error.tsx and other files)*

------
https://chatgpt.com/codex/tasks/task_e_68d60a687fac83239f9bd47c6b2a3eaf