### PR TITLE
Prioritize stored locale when resolving user language

### DIFF
--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -58,6 +58,21 @@ describe('LocaleProvider', () => {
     expect(localeDisplay).toHaveTextContent('sv-SE');
   });
 
+  it('prefers a stored locale ahead of browser hints', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'sv-SE');
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-AU', 'en-US']);
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
+
+    render(
+      <LocaleProvider locale="en-US" acceptLanguage="en-GB,en;q=0.9">
+        <LocaleConsumer />
+      </LocaleProvider>,
+    );
+
+    const localeDisplay = await screen.findByTestId('locale-value');
+    expect(localeDisplay).toHaveTextContent('sv-SE');
+  });
+
   it('falls back to navigator.language when languages is empty', async () => {
     vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue([]);
     vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-GB');

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -18,6 +18,11 @@ function resolveLocaleCandidates(
 ): string[] {
   const normalizedFallback = normalizeLocale(fallback);
   const candidates: string[] = [];
+  const normalizedStored = normalizeLocale(storedLocale, '');
+
+  if (normalizedStored) {
+    candidates.push(normalizedStored);
+  }
 
   if (acceptLanguage) {
     const parsed = parseAcceptLanguage(acceptLanguage, normalizedFallback);
@@ -39,11 +44,6 @@ function resolveLocaleCandidates(
     }
   }
 
-  const normalizedStored = normalizeLocale(storedLocale, '');
-  if (normalizedStored) {
-    candidates.push(normalizedStored);
-  }
-
   candidates.push(normalizedFallback);
 
   return Array.from(new Set(candidates));
@@ -60,10 +60,6 @@ function pickLocaleCandidate(
   for (const candidate of candidates) {
     const normalized = normalizeLocale(candidate, '');
     if (!normalized) {
-      continue;
-    }
-
-    if (normalizedStored && normalized === normalizedStored) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- prefer the persisted locale when building the resolution candidate list
- allow stored locales to be selected ahead of browser hints
- add a regression test to ensure the stored preference wins over navigator values

## Testing
- pnpm vitest run src/lib/LocaleContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d60ba6995c83238bcf3067d73aa99f