### PR TITLE
Fix lint warnings in profile and toast components

### DIFF
--- a/apps/web/src/app/players/[id]/error.tsx
+++ b/apps/web/src/app/players/[id]/error.tsx
@@ -18,8 +18,8 @@ export default function PlayerError({
     <main className="container">
       <h1 className="heading">Player unavailable</h1>
       <p className="mt-2 text-red-600" role="alert">
-        We couldn't load this player's details right now. Please refresh the
-        page or try again later. If the problem continues, return to the
+        We couldn&apos;t load this player&apos;s details right now. Please refresh
+        the page or try again later. If the problem continues, return to the
         players list.
       </p>
       <div className="mt-4 flex flex-col items-start gap-3 md:flex-row md:items-center">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useState, type FormEvent, type ChangeEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ChangeEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import {
   fetchMe,
@@ -153,16 +159,16 @@ export default function ProfilePage() {
     setPreferencesFeedback(null);
   };
 
-  const resetSocialLinkState = (links: PlayerSocialLink[]) => {
+  const resetSocialLinkState = useCallback((links: PlayerSocialLink[]) => {
     setSocialLinks(links);
     setLinkDrafts(
       Object.fromEntries(
         links.map((link) => [link.id, { label: link.label, url: link.url }])
       ) as Record<string, { label: string; url: string }>
     );
-  };
+  }, []);
 
-  const applyPlayerDetails = (player: PlayerMe | null) => {
+  const applyPlayerDetails = useCallback((player: PlayerMe | null) => {
     const nextCountry = player?.country_code ?? "";
     const nextClub = player?.club_id ?? "";
     const nextBio = player?.bio ?? "";
@@ -174,7 +180,7 @@ export default function ProfilePage() {
     setInitialClubId(nextClub);
     setInitialBio(nextBio);
     resetSocialLinkState(nextLinks);
-  };
+  }, [resetSocialLinkState]);
 
   useEffect(() => {
     if (!isLoggedIn()) {
@@ -227,7 +233,7 @@ export default function ProfilePage() {
     return () => {
       active = false;
     };
-  }, [router]);
+  }, [applyPlayerDetails, router]);
 
   useEffect(() => {
     const stored = loadUserSettings();

--- a/apps/web/src/components/ToastProvider.tsx
+++ b/apps/web/src/components/ToastProvider.tsx
@@ -68,9 +68,10 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   );
 
   useEffect(() => {
+    const timersMap = timers.current;
     return () => {
-      timers.current.forEach((timeout) => clearTimeout(timeout));
-      timers.current.clear();
+      timersMap.forEach((timeout) => clearTimeout(timeout));
+      timersMap.clear();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- escape apostrophes in the player error boundary to satisfy React linting
- memoize profile helper callbacks so they can be safely used in effects
- clean up toast timers using a stable reference during unmount

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d60ee464d483238719fde1da6c99dc