### PR TITLE
Restore locale updates when browser hints change

### DIFF
--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -58,7 +58,7 @@ describe('LocaleProvider', () => {
     expect(localeDisplay).toHaveTextContent('sv-SE');
   });
 
-  it('prefers a stored locale ahead of browser hints', async () => {
+  it('updates the stored locale when browser hints change', async () => {
     window.localStorage.setItem(LOCALE_STORAGE_KEY, 'sv-SE');
     vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-AU', 'en-US']);
     vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
@@ -69,8 +69,12 @@ describe('LocaleProvider', () => {
       </LocaleProvider>,
     );
 
+    await waitFor(() => {
+      expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('en-GB');
+    });
+
     const localeDisplay = await screen.findByTestId('locale-value');
-    expect(localeDisplay).toHaveTextContent('sv-SE');
+    expect(localeDisplay).toHaveTextContent('en-GB');
   });
 
   it('falls back to navigator.language when languages is empty', async () => {

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -18,12 +18,6 @@ function resolveLocaleCandidates(
 ): string[] {
   const normalizedFallback = normalizeLocale(fallback);
   const candidates: string[] = [];
-  const normalizedStored = normalizeLocale(storedLocale, '');
-
-  if (normalizedStored) {
-    candidates.push(normalizedStored);
-  }
-
   if (acceptLanguage) {
     const parsed = parseAcceptLanguage(acceptLanguage, normalizedFallback);
     if (parsed) {
@@ -45,6 +39,12 @@ function resolveLocaleCandidates(
   }
 
   candidates.push(normalizedFallback);
+
+  const normalizedStored = normalizeLocale(storedLocale, '');
+
+  if (normalizedStored) {
+    candidates.push(normalizedStored);
+  }
 
   return Array.from(new Set(candidates));
 }


### PR DESCRIPTION
## Summary
- adjust locale candidate resolution so browser hints can override a previously stored preference
- update the locale provider test to confirm the stored value refreshes when hints change

## Testing
- npm test -- --run *(fails: repository is missing @testing-library/user-event, which is required by an existing test)*
- npx vitest run src/lib/LocaleContext.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d60f23aaa08323b02c59833a0bf2af