### PR TITLE
Handle match 404 with route not found page

### DIFF
--- a/apps/web/src/app/matches/[mid]/not-found.tsx
+++ b/apps/web/src/app/matches/[mid]/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+import { ensureTrailingSlash } from "../../../lib/routes";
+
+export default function MatchNotFound() {
+  return (
+    <main className="container">
+      <div className="text-sm">
+        <Link
+          href={ensureTrailingSlash("/matches")}
+          className="underline underline-offset-2"
+        >
+          ← Back to matches
+        </Link>
+      </div>
+      <h1 className="heading mt-6">Match not found</h1>
+      <p className="mt-2 text-slate-700 dark:text-slate-200">
+        We couldn&apos;t find the match you were looking for. It may have been moved
+        or no longer exists.
+      </p>
+      <Link
+        href={ensureTrailingSlash("/matches")}
+        className="button mt-4 inline-flex items-center"
+      >
+        Browse matches
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- call Next.js `notFound` when the match API returns a 404 so the framework can serve the segment-level 404 boundary
- add a route-specific not-found page with clear messaging and navigation back to the matches list
- extend the match detail tests to cover the 404 path while preserving the existing fallback for other failures

## Testing
- pnpm vitest run src/app/matches/[mid]/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d613c1d818832387d940330d093c06