### PR TITLE
Handle player detail errors with status-aware UI

### DIFF
--- a/apps/web/src/app/players/[id]/PlayerDetailErrorBoundary.tsx
+++ b/apps/web/src/app/players/[id]/PlayerDetailErrorBoundary.tsx
@@ -1,76 +1,182 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   Component,
   type ErrorInfo,
+  type JSX,
   type ReactNode,
-} from 'react';
+  useCallback,
+  useState,
+} from "react";
 
-interface Props {
+export type PlayerDetailError = {
+  status?: number;
+  message?: string;
+};
+
+interface BoundaryProps {
   playerId: string;
-  children: ReactNode;
+  initialError?: PlayerDetailError | null;
+  children?: ReactNode;
+}
+
+interface InnerProps extends BoundaryProps {
+  onRetry: () => void;
 }
 
 interface State {
   hasError: boolean;
+  error: PlayerDetailError | null;
 }
 
-export default class PlayerDetailErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false };
+function normaliseError(error: unknown, fallback?: string): PlayerDetailError {
+  if (error && typeof error === "object") {
+    const maybeStatus = (error as { status?: unknown }).status;
+    const status = typeof maybeStatus === "number" ? maybeStatus : undefined;
+    const message = (error as { message?: unknown }).message;
+    return {
+      status,
+      message: typeof message === "string" && message.length > 0 ? message : fallback,
+    };
+  }
+  return { message: fallback };
+}
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+function getErrorCopy(error: PlayerDetailError | null) {
+  const status = error?.status;
+  if (status === 404) {
+    return {
+      title: "This player could not be found.",
+      description:
+        "The player might have been removed or the link you followed could be out of date.",
+      statusNote: "Error code: 404",
+    };
+  }
+  if (typeof status === "number" && status >= 500) {
+    return {
+      title: "We ran into a temporary problem fetching this player.",
+      description: "Please try again in a moment.",
+      statusNote: `Error code: ${status}`,
+    };
+  }
+  if (typeof status === "number" && status >= 400) {
+    return {
+      title: "We can't display this player right now.",
+      description:
+        "The request was rejected. You can try again or return to the players list.",
+      statusNote: `Error code: ${status}`,
+    };
+  }
+  return {
+    title: "Unable to display this player right now.",
+    description: "Something went wrong while loading the player details.",
+    statusNote: undefined,
+  };
+}
+
+class PlayerDetailErrorBoundaryInner extends Component<InnerProps, State> {
+  constructor(props: InnerProps) {
+    super(props);
+    this.state = {
+      hasError: Boolean(props.initialError),
+      error: props.initialError ?? null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      hasError: true,
+      error: normaliseError(error, error.message),
+    };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Player detail rendering failed', {
+    console.error("Player detail rendering failed", {
       error,
       errorInfo,
       playerId: this.props.playerId,
     });
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.playerId !== this.props.playerId && this.state.hasError) {
-      this.setState({ hasError: false });
+  componentDidUpdate(prevProps: InnerProps) {
+    if (prevProps.playerId !== this.props.playerId) {
+      this.setState({
+        hasError: Boolean(this.props.initialError),
+        error: this.props.initialError ?? null,
+      });
+      return;
+    }
+    if (prevProps.initialError !== this.props.initialError) {
+      this.setState({
+        hasError: Boolean(this.props.initialError),
+        error: this.props.initialError ?? null,
+      });
     }
   }
 
   private handleRetry = () => {
-    this.setState({ hasError: false });
+    this.props.onRetry();
   };
 
   render(): ReactNode {
     if (this.state.hasError) {
+      const copy = getErrorCopy(this.state.error);
+      const message = this.state.error?.message;
       return (
-        <div
-          role="alert"
-          className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700"
-        >
-          <p className="font-semibold">Unable to display this player right now.</p>
-          <p className="mt-2">
-            Something went wrong while loading the player details. Please refresh
-            the page or try again later.
-          </p>
-          <p className="mt-2">
-            If the problem continues,{' '}
-            <Link href="/players" className="underline">
-              return to the players list
-            </Link>
-            .
-          </p>
-          <button
-            type="button"
-            onClick={this.handleRetry}
-            className="mt-3 inline-flex items-center text-sm font-medium underline"
+        <div className="container">
+          <div
+            role="alert"
+            className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700"
           >
-            Try again
-          </button>
+            <p className="font-semibold">{copy.title}</p>
+            <p className="mt-2">{copy.description}</p>
+            {copy.statusNote ? (
+              <p className="mt-2 font-medium">{copy.statusNote}</p>
+            ) : null}
+            {message && message !== copy.title ? (
+              <p className="mt-2 break-words text-xs text-red-600">{message}</p>
+            ) : null}
+            <p className="mt-2">
+              If the problem continues, {" "}
+              <Link href="/players" className="underline">
+                return to the players list
+              </Link>
+              .
+            </p>
+            <button
+              type="button"
+              onClick={this.handleRetry}
+              className="mt-3 inline-flex items-center text-sm font-medium underline"
+            >
+              Try again
+            </button>
+          </div>
         </div>
       );
     }
 
-    return this.props.children;
+    return this.props.children ?? null;
   }
+}
+
+export default function PlayerDetailErrorBoundary(
+  props: BoundaryProps
+): JSX.Element {
+  const router = useRouter();
+  const [resetKey, setResetKey] = useState(0);
+
+  const handleRetry = useCallback(() => {
+    setResetKey((key) => key + 1);
+    router.refresh();
+  }, [router]);
+
+  return (
+    <PlayerDetailErrorBoundaryInner
+      key={`${props.playerId}-${resetKey}`}
+      {...props}
+      onRetry={handleRetry}
+    />
+  );
 }

--- a/apps/web/src/app/players/__tests__/player.page.test.tsx
+++ b/apps/web/src/app/players/__tests__/player.page.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<typeof import('next/navigation')>(
+    'next/navigation'
+  );
+  return {
+    ...actual,
+    useRouter: () => ({
+      refresh: refreshMock,
+    }),
+  };
+});
+
+vi.mock('next/headers', () => ({
+  headers: () => ({
+    get: (key: string) => (key.toLowerCase() === 'accept-language' ? 'en-US' : null),
+  }),
+}));
+
+vi.mock('../[id]/PlayerCharts', () => ({
+  default: () => <div data-testid="player-charts" />,
+}));
+
+vi.mock('../[id]/comments-client', () => ({
+  default: () => <div data-testid="player-comments" />,
+}));
+
+vi.mock('../[id]/PhotoUpload', () => ({
+  default: () => <div data-testid="photo-upload" />,
+}));
+
+vi.mock('../../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/api')>(
+    '../../../lib/api'
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+    fetchClubs: vi.fn(),
+  };
+});
+
+import PlayerPage from '../[id]/page';
+import { apiFetch, fetchClubs } from '../../../lib/api';
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedFetchClubs = vi.mocked(fetchClubs);
+
+const makeResponse = <T,>(
+  data: T,
+  init: { status?: number } = {}
+): Response => {
+  const status = init.status ?? 200;
+  const ok = status >= 200 && status < 300;
+  return {
+    ok,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+    clone() {
+      return makeResponse(data, init);
+    },
+  } as unknown as Response;
+};
+
+const makeError = (status: number, message: string): Error & { status: number } => {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  refreshMock.mockReset();
+});
+
+describe('PlayerPage server component', () => {
+  it('renders player details when the API succeeds', async () => {
+    mockedFetchClubs.mockResolvedValue([
+      { id: 'club-1', name: 'Ace Club' },
+    ]);
+
+    mockedApiFetch.mockImplementation(async (path) => {
+      if (path === '/v0/players/player-1') {
+        return makeResponse({
+          id: 'player-1',
+          name: 'Pat Jones',
+          club_id: 'club-1',
+          badges: [],
+          social_links: [],
+        });
+      }
+      if (path.startsWith('/v0/matches?playerId=player-1&upcoming=true')) {
+        return makeResponse([]);
+      }
+      if (path.startsWith('/v0/matches?playerId=player-1')) {
+        return makeResponse([
+          {
+            id: 'match-1',
+            sport: 'tennis',
+            bestOf: 3,
+            playedAt: '2024-01-02T00:00:00Z',
+            location: 'Court A',
+          },
+        ]);
+      }
+      if (path === '/v0/matches/match-1') {
+        return makeResponse({
+          participants: [
+            { side: 'A', playerIds: ['player-1'] },
+            { side: 'B', playerIds: ['opponent-1'] },
+          ],
+          summary: { sets: { A: 2, B: 1 } },
+        });
+      }
+      if (path.startsWith('/v0/players/by-ids')) {
+        return makeResponse([
+          { id: 'player-1', name: 'Pat Jones' },
+          { id: 'opponent-1', name: 'Taylor Opponent' },
+        ]);
+      }
+      if (path === '/v0/players/player-1/stats') {
+        return makeResponse(null, { status: 204 });
+      }
+      throw new Error(`Unexpected apiFetch call: ${path}`);
+    });
+
+    const view = await PlayerPage({
+      params: { id: 'player-1' },
+      searchParams: {},
+    });
+
+    render(view);
+
+    expect(
+      screen.getByRole('heading', { name: /pat jones/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Back to players/i)).toBeInTheDocument();
+    expect(mockedApiFetch).toHaveBeenCalled();
+  });
+
+  it('renders a not found view when the player is missing', async () => {
+    mockedApiFetch.mockImplementation(async (path) => {
+      if (path === '/v0/players/missing') {
+        throw makeError(404, 'HTTP 404: Player not found');
+      }
+      throw new Error(`Unexpected apiFetch call: ${path}`);
+    });
+
+    const view = await PlayerPage({
+      params: { id: 'missing' },
+      searchParams: {},
+    });
+
+    render(view);
+
+    expect(
+      screen.getByRole('heading', { name: /player not found/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Back to players/i)).toBeInTheDocument();
+  });
+
+  it('surfaces server errors with retry affordance', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    mockedApiFetch.mockRejectedValue(makeError(503, 'HTTP 503: Service Unavailable'));
+
+    const view = await PlayerPage({
+      params: { id: 'player-2' },
+      searchParams: {},
+    });
+
+    render(view);
+
+    expect(
+      screen.getByText(/temporary problem fetching this player/i)
+    ).toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: /try again/i });
+    await userEvent.click(button);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- distinguish 404s on the player details route and surface other failures through PlayerDetailErrorBoundary
- update the boundary to carry status-aware messaging, propagate initial errors, and trigger a real router refresh on retry
- add Vitest coverage for player page success and error flows plus a FastAPI regression test for the versioned player endpoint

## Testing
- npm test -- --run
- pytest backend/tests/test_players.py::test_versioned_missing_player_returns_problem_detail -q

------
https://chatgpt.com/codex/tasks/task_e_68d612c0433883238eed77bf32e0ea69