### PR TITLE
Debounce player search requests on players page

### DIFF
--- a/apps/web/src/lib/useDebounce.ts
+++ b/apps/web/src/lib/useDebounce.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      setDebouncedValue(value);
+      return;
+    }
+
+    const handle = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- add a reusable useDebounce hook for client components
- debounce the players search query before calling the API and include the q param
- extend the players page tests to cover incremental typing and input control

## Testing
- pnpm test --run src/app/players/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d616c2d0f883239022221c4e865db4