### PR TITLE
Prevent stale player search results

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "20.11.30",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.3",
@@ -1351,6 +1352,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {


### PR DESCRIPTION
## Summary
- track the latest player search request so older responses no longer overwrite current results
- ensure loading and error state updates only apply to the most recent fetch

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d61a5440d08323ad2fa25547dd41c3