### PR TITLE
Ensure login redirects honor trailing slash

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { apiFetch, isAdmin, withAbsolutePhotoUrl } from "../../../lib/api";
+import { ensureTrailingSlash } from "../../../lib/routes";
 import { PlayerInfo } from "../../../components/PlayerName";
 import MatchParticipants from "../../../components/MatchParticipants";
 import { useLocale } from "../../../lib/LocaleContext";
@@ -144,7 +145,7 @@ export default function AdminMatchesPage() {
 
   useEffect(() => {
     if (!isAdmin()) {
-      window.location.href = "/login";
+      window.location.href = ensureTrailingSlash("/login");
       return;
     }
     load();

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -25,6 +25,7 @@ import {
   ensureAbsoluteApiUrl,
   persistSession,
 } from "../../lib/api";
+import { ensureTrailingSlash } from "../../lib/routes";
 import type { PlayerLocationPayload } from "../../lib/api";
 import ClubSelect from "../../components/ClubSelect";
 import {
@@ -184,7 +185,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (!isLoggedIn()) {
-      router.push("/login");
+      router.push(ensureTrailingSlash("/login"));
       return;
     }
     let active = true;
@@ -207,7 +208,7 @@ export default function ProfilePage() {
           if (!active) return;
           const status = (playerErr as Error & { status?: number }).status;
           if (status === 401) {
-            router.push("/login");
+            router.push(ensureTrailingSlash("/login"));
             return;
           }
           if (status === 404) {
@@ -222,7 +223,7 @@ export default function ProfilePage() {
         }
       } catch {
         if (!active) return;
-        router.push("/login");
+        router.push(ensureTrailingSlash("/login"));
         return;
       } finally {
         if (active) {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import { ensureTrailingSlash } from "../../../lib/routes";
 import { useLocale } from "../../../lib/LocaleContext";
 import { getDatePlaceholder } from "../../../lib/i18n";
 import { buildPlayedAtISOString } from "../../../lib/datetime";
@@ -59,7 +60,7 @@ export default function RecordPadelPage() {
         setError("Failed to load players");
         const status = (err as { status?: number }).status;
         if (status === 401) {
-          router.push("/login");
+          router.push(ensureTrailingSlash("/login"));
         }
       }
     }


### PR DESCRIPTION
## Summary
- update profile, record padel, and admin matches pages to use ensureTrailingSlash for login redirects
- import the shared route helper in each page so redirects point to the canonical /login/ path

## Testing
- pnpm build
- pnpm start (manual verification of /profile/ redirect)


------
https://chatgpt.com/codex/tasks/task_e_68d61c53897883239a295e1a5832330a