### PR TITLE
Add localized username guidance to signup form

### DIFF
--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -124,4 +124,29 @@ describe('LoginPage signup feedback', () => {
     expect(mockedPersistSession).not.toHaveBeenCalled();
     expect(pushMock).not.toHaveBeenCalled();
   });
+
+  it('shows username format guidance when validation fails', async () => {
+    renderWithToast(<LoginPage />);
+
+    const [, signupUsername] = screen.getAllByLabelText('Username');
+    const signupPassword = screen.getAllByLabelText('Password')[1];
+    const confirmPassword = screen.getByLabelText('Confirm Password');
+
+    fireEvent.change(signupUsername, { target: { value: 'Invalid Name' } });
+    fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
+    fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(
+      within(alert).getByText(
+        /Usernames can include letters, numbers, underscores, hyphens, and periods\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(alert).getByText(/You can also use a valid email address\./i),
+    ).toBeInTheDocument();
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -9,6 +9,8 @@ import {
   persistSession,
 } from "../../lib/api";
 import { useToast } from "../../components/ToastProvider";
+import { useLocale } from "../../lib/LocaleContext";
+import { getAuthCopy } from "../../lib/authCopy";
 
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -214,6 +216,7 @@ async function extractSignupErrors(response: Response): Promise<string[]> {
 export default function LoginPage() {
   const router = useRouter();
   const { showToast } = useToast();
+  const locale = useLocale();
   const [user, setUser] = useState(currentUsername());
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -223,6 +226,14 @@ export default function LoginPage() {
   const [errors, setErrors] = useState<string[]>([]);
   const passwordStrengthLabelId = useId();
   const passwordStrengthHelperId = useId();
+  const { usernameCharacterRule, usernameEmailOption } = useMemo(
+    () => getAuthCopy(locale),
+    [locale]
+  );
+  const usernameGuidelines = useMemo(
+    () => [usernameCharacterRule, usernameEmailOption],
+    [usernameCharacterRule, usernameEmailOption]
+  );
   const passwordStrength = useMemo(
     () => getPasswordStrength(newPass),
     [newPass]
@@ -267,9 +278,7 @@ export default function LoginPage() {
       !EMAIL_REGEX.test(trimmedUser) &&
       !USERNAME_REGEX.test(trimmedUser)
     ) {
-      validationErrors.push(
-        "Username must be a valid email address or contain only letters, numbers, underscores, hyphens, and periods.",
-      );
+      validationErrors.push(usernameCharacterRule, usernameEmailOption);
     }
     if (newPass.length < 12 || !PASSWORD_REGEX.test(newPass)) {
       validationErrors.push(
@@ -382,6 +391,16 @@ export default function LoginPage() {
             autoComplete="username"
             required
           />
+          <ul className="password-guidelines">
+            {usernameGuidelines.map((guideline) => (
+              <li key={guideline} className="password-guidelines__item">
+                <span className="password-guidelines__status" aria-hidden="true">
+                  •
+                </span>
+                {guideline}
+              </li>
+            ))}
+          </ul>
         </div>
         <div className="form-field">
           <label htmlFor="signup-password" className="form-label">

--- a/apps/web/src/lib/authCopy.ts
+++ b/apps/web/src/lib/authCopy.ts
@@ -1,0 +1,44 @@
+export interface AuthCopy {
+  usernameCharacterRule: string;
+  usernameEmailOption: string;
+}
+
+const AUTH_COPY: Record<string, AuthCopy> = {
+  default: {
+    usernameCharacterRule:
+      "Usernames can include letters, numbers, underscores, hyphens, and periods.",
+    usernameEmailOption: "You can also use a valid email address.",
+  },
+  "en-au": {
+    usernameCharacterRule:
+      "Usernames can include letters, numbers, underscores, hyphens, and full stops.",
+    usernameEmailOption: "You can also use a valid email address.",
+  },
+};
+
+function getLocaleChain(locale: string): string[] {
+  const lower = (locale ?? "").toLowerCase();
+  const parts = lower.split("-").filter(Boolean);
+  const chain = ["default"];
+  if (parts[0]) {
+    chain.push(parts[0]);
+  }
+  if (parts.length > 1) {
+    chain.push(lower);
+  }
+  return chain;
+}
+
+export function getAuthCopy(locale: string): AuthCopy {
+  const chain = getLocaleChain(locale);
+  const result: AuthCopy = { ...AUTH_COPY.default };
+
+  for (const key of chain) {
+    const copy = AUTH_COPY[key];
+    if (copy) {
+      Object.assign(result, copy);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a locale-aware auth copy helper for username guidance
- surface localized username guidelines beside the signup field and in validation errors
- extend login page tests to cover the new validation behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d61e8032d48323b3038ca068f64bcb