### PR TITLE
Use Next.js notFound for missing player details

### DIFF
--- a/apps/web/src/app/players/[id]/not-found.tsx
+++ b/apps/web/src/app/players/[id]/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function PlayerNotFound(): JSX.Element {
+  return (
+    <main className="container">
+      <h1 className="heading">Player not found</h1>
+      <p className="mt-2 text-gray-700">
+        We couldn&apos;t find the player you were looking for. They might have been
+        removed or never existed.
+      </p>
+      <Link href="/players" className="mt-4 inline-block">
+        Back to players
+      </Link>
+    </main>
+  );
+}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
 import { headers } from "next/headers";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 import { apiFetch, fetchClubs, withAbsolutePhotoUrl } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
 import PlayerComments from "./comments-client";
@@ -112,21 +113,6 @@ function toPlayerDetailError(
       ? err
       : fallbackMessage;
   return { status, message };
-}
-
-function renderPlayerNotFound(): JSX.Element {
-  return (
-    <main className="container">
-      <h1 className="heading">Player not found</h1>
-      <p className="mt-2 text-gray-700">
-        We couldn&apos;t find the player you were looking for. They might have been
-        removed or never existed.
-      </p>
-      <Link href="/players" className="mt-4 inline-block">
-        Back to players
-      </Link>
-    </main>
-  );
 }
 
 function renderPlayerError(
@@ -454,7 +440,7 @@ export default async function PlayerPage({
   } catch (err) {
     const status = getErrorStatus(err);
     if (status === 404) {
-      return renderPlayerNotFound();
+      notFound();
     }
     console.error(`Failed to load player ${params.id}`, err);
     return renderPlayerError(params.id, err);


### PR DESCRIPTION
## Summary
- call Next.js `notFound` from the player detail page when the API returns a 404
- move the "player not found" UI into a dedicated `not-found.tsx` route file
- update the player page tests to assert the Next.js helper is invoked for missing players

## Testing
- pnpm --filter web test -- --runTestsByPath apps/web/src/app/players/__tests__/player.page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d62282fe7483238996a483dc6b7d3c