### PR TITLE
Add preferred locale setting and improve date/time localization

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,9 +4,13 @@ import Header from './header';
 import ChunkErrorReload from '../components/ChunkErrorReload';
 import ToastProvider from '../components/ToastProvider';
 import SessionBanner from '../components/SessionBanner';
-import { headers } from 'next/headers';
+import { headers, cookies } from 'next/headers';
 import { LocaleProvider } from '../lib/LocaleContext';
-import { parseAcceptLanguage } from '../lib/i18n';
+import {
+  parseAcceptLanguage,
+  normalizeLocale,
+  LOCALE_COOKIE_KEY,
+} from '../lib/i18n';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -20,7 +24,12 @@ export default function RootLayout({
 }) {
   const headerList = headers();
   const acceptLanguage = headerList.get('accept-language');
-  const locale = parseAcceptLanguage(acceptLanguage);
+  const cookieStore = cookies();
+  const cookieLocale = cookieStore.get(LOCALE_COOKIE_KEY)?.value ?? null;
+  const locale = normalizeLocale(
+    cookieLocale,
+    parseAcceptLanguage(acceptLanguage),
+  );
 
   return (
     <html lang={locale}>

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -365,6 +365,7 @@ describe("ProfilePage", () => {
         defaultLeaderboardSport: "padel",
         defaultLeaderboardCountry: "SE",
         weeklySummaryEmails: false,
+        preferredLocale: "sv-SE",
       }),
     );
 
@@ -387,9 +388,15 @@ describe("ProfilePage", () => {
     )) as HTMLInputElement;
     expect(weeklyToggle.checked).toBe(false);
 
+    const localeInput = (await screen.findByLabelText(
+      "Preferred locale",
+    )) as HTMLInputElement;
+    expect(localeInput.value).toBe("sv-SE");
+
     fireEvent.change(sportSelect, { target: { value: "disc_golf" } });
     fireEvent.change(countrySelect, { target: { value: "" } });
     fireEvent.click(weeklyToggle);
+    fireEvent.change(localeInput, { target: { value: "fr-FR" } });
 
     const savePreferencesButton = await screen.findByRole("button", {
       name: /save preferences/i,
@@ -406,10 +413,12 @@ describe("ProfilePage", () => {
       defaultLeaderboardSport: string;
       defaultLeaderboardCountry: string;
       weeklySummaryEmails: boolean;
+      preferredLocale: string;
     };
     expect(parsed.defaultLeaderboardSport).toBe("disc_golf");
     expect(parsed.defaultLeaderboardCountry).toBe("");
     expect(parsed.weeklySummaryEmails).toBe(true);
+    expect(parsed.preferredLocale).toBe("fr-FR");
 
     await screen.findByText("Preferences updated.");
   });

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -54,6 +54,16 @@ const SOCIAL_LINK_LABEL_REQUIRED_MESSAGE = "Link label is required";
 type SaveFeedback = { type: "success" | "error"; message: string } | null;
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+const PREFERENCES_LOCALE_HINT_ID = "preferences-locale-hint";
+const LOCALE_SUGGESTIONS = [
+  { value: "en-GB", label: "English (United Kingdom)" },
+  { value: "en-US", label: "English (United States)" },
+  { value: "en-AU", label: "English (Australia)" },
+  { value: "fr-FR", label: "French (France)" },
+  { value: "de-DE", label: "German (Germany)" },
+  { value: "es-ES", label: "Spanish (Spain)" },
+  { value: "sv-SE", label: "Swedish (Sweden)" },
+];
 
 function isValidHttpUrl(value: string): boolean {
   if (!value) {
@@ -769,6 +779,39 @@ export default function ProfilePage() {
             ))}
           </select>
         </label>
+        <label className="form-field" htmlFor="preferences-locale">
+          <span className="form-label">Preferred locale</span>
+          <input
+            id="preferences-locale"
+            type="text"
+            value={preferences.preferredLocale}
+            onChange={(event) => {
+              setPreferencesFeedback(null);
+              setMessage(null);
+              setError(null);
+              setPreferences((prev) => ({
+                ...prev,
+                preferredLocale: event.target.value,
+              }));
+            }}
+            list="preferences-locale-options"
+            placeholder="e.g., en-GB"
+            autoComplete="language"
+            spellCheck={false}
+            disabled={preferencesInputsDisabled}
+            aria-describedby={PREFERENCES_LOCALE_HINT_ID}
+          />
+        </label>
+        <span id={PREFERENCES_LOCALE_HINT_ID} className="form-hint">
+          Used to format dates, times, and placeholder values across the app.
+        </span>
+        <datalist id="preferences-locale-options">
+          {LOCALE_SUGGESTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </datalist>
         <label
           className="form-field"
           htmlFor="preferences-weekly-summary"

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -5,7 +5,10 @@ import { flushSync } from "react-dom";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { useLocale } from "../../../lib/LocaleContext";
-import { getDatePlaceholder } from "../../../lib/i18n";
+import {
+  getDatePlaceholder,
+  usesTwentyFourHourClock,
+} from "../../../lib/i18n";
 import { buildPlayedAtISOString } from "../../../lib/datetime";
 import {
   summarizeBowlingInput,
@@ -207,10 +210,12 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   const [doubles, setDoubles] = useState(isPadel);
   const [submitting, setSubmitting] = useState(false);
   const locale = useLocale();
-  const datePlaceholder = useMemo(
-    () => getDatePlaceholder(locale),
+  const datePlaceholder = useMemo(() => getDatePlaceholder(locale), [locale]);
+  const uses24HourTime = useMemo(
+    () => usesTwentyFourHourClock(locale),
     [locale],
   );
+  const timePlaceholder = uses24HourTime ? "HH:MM" : undefined;
   const sportCopy = useMemo(
     () => getSportCopy(sport, locale),
     [locale, sport],
@@ -612,6 +617,12 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
                 onChange={(e) => setTime(e.target.value)}
                 lang={locale}
                 aria-describedby={sportCopy.timeHint ? timeHintId : undefined}
+                step={60}
+                inputMode={uses24HourTime ? "numeric" : undefined}
+                pattern={
+                  uses24HourTime ? "([01][0-9]|2[0-3]):[0-5][0-9]" : undefined
+                }
+                placeholder={timePlaceholder}
               />
               {sportCopy.timeHint && (
                 <span id={timeHintId} className="form-hint">

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -134,8 +134,38 @@ describe("RecordSportForm", () => {
       render(<RecordSportForm sportId="bowling" />);
 
       const dateInput = await screen.findByLabelText(/date/i);
-      expect(dateInput).toHaveAttribute("placeholder", "dd/mm/yyyy");
-      expect(screen.getByText("Format: dd/mm/yyyy")).toBeInTheDocument();
+      expect(dateInput).toHaveAttribute("placeholder", "DD/MM/YYYY");
+      expect(screen.getByText("Format: DD/MM/YYYY")).toBeInTheDocument();
+    } finally {
+      localeSpy.mockRestore();
+    }
+  });
+
+  it("uses European date placeholders and 24-hour time when locale is de-DE", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ players: [] }) });
+    global.fetch = fetchMock as typeof fetch;
+
+    const localeSpy = vi
+      .spyOn(LocaleContext, "useLocale")
+      .mockReturnValue("de-DE");
+
+    try {
+      render(<RecordSportForm sportId="padel" />);
+
+      const dateInput = await screen.findByLabelText(/date/i);
+      expect(dateInput).toHaveAttribute("placeholder", "DD/MM/YYYY");
+      expect(screen.getByText("Format: DD/MM/YYYY")).toBeInTheDocument();
+
+      const timeInput = await screen.findByLabelText(/start time/i);
+      expect(timeInput).toHaveAttribute("placeholder", "HH:MM");
+      expect(timeInput).toHaveAttribute("inputmode", "numeric");
+      expect(timeInput).toHaveAttribute(
+        "pattern",
+        "([01][0-9]|2[0-3]):[0-5][0-9]",
+      );
+      expect(timeInput).toHaveAttribute("step", "60");
     } finally {
       localeSpy.mockRestore();
     }

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -119,8 +119,38 @@ describe("RecordPadelPage", () => {
       render(<RecordPadelPage />);
 
       const dateInput = await screen.findByLabelText(/date/i);
-      expect(dateInput).toHaveAttribute("placeholder", "dd/mm/yyyy");
-      expect(screen.getByText("Format: dd/mm/yyyy")).toBeInTheDocument();
+      expect(dateInput).toHaveAttribute("placeholder", "DD/MM/YYYY");
+      expect(screen.getByText("Format: DD/MM/YYYY")).toBeInTheDocument();
+    } finally {
+      localeSpy.mockRestore();
+    }
+  });
+
+  it("uses European date placeholders and 24-hour time when locale is fr-FR", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ players: [] }) });
+    global.fetch = fetchMock as typeof fetch;
+
+    const localeSpy = vi
+      .spyOn(LocaleContext, "useLocale")
+      .mockReturnValue("fr-FR");
+
+    try {
+      render(<RecordPadelPage />);
+
+      const dateInput = await screen.findByLabelText(/date/i);
+      expect(dateInput).toHaveAttribute("placeholder", "DD/MM/YYYY");
+      expect(screen.getByText("Format: DD/MM/YYYY")).toBeInTheDocument();
+
+      const timeInput = await screen.findByLabelText(/start time/i);
+      expect(timeInput).toHaveAttribute("placeholder", "HH:MM");
+      expect(timeInput).toHaveAttribute("inputmode", "numeric");
+      expect(timeInput).toHaveAttribute(
+        "pattern",
+        "([01][0-9]|2[0-3]):[0-5][0-9]",
+      );
+      expect(timeInput).toHaveAttribute("step", "60");
     } finally {
       localeSpy.mockRestore();
     }

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -5,7 +5,10 @@ import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import { ensureTrailingSlash } from "../../../lib/routes";
 import { useLocale } from "../../../lib/LocaleContext";
-import { getDatePlaceholder } from "../../../lib/i18n";
+import {
+  getDatePlaceholder,
+  usesTwentyFourHourClock,
+} from "../../../lib/i18n";
 import { buildPlayedAtISOString } from "../../../lib/datetime";
 
 interface Player {
@@ -90,10 +93,12 @@ export default function RecordPadelPage() {
     setSetErrors((prev) => [...prev, ""]);
   };
 
-  const datePlaceholder = useMemo(
-    () => getDatePlaceholder(locale),
+  const datePlaceholder = useMemo(() => getDatePlaceholder(locale), [locale]);
+  const uses24HourTime = useMemo(
+    () => usesTwentyFourHourClock(locale),
     [locale],
   );
+  const timePlaceholder = uses24HourTime ? "HH:MM" : undefined;
 
   const validateSets = () => {
     const errors = sets.map(() => "");
@@ -235,6 +240,12 @@ export default function RecordPadelPage() {
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
                 lang={locale}
+                step={60}
+                inputMode={uses24HourTime ? "numeric" : undefined}
+                pattern={
+                  uses24HourTime ? "([01][0-9]|2[0-3]):[0-5][0-9]" : undefined
+                }
+                placeholder={timePlaceholder}
               />
             </label>
           </div>

--- a/apps/web/src/app/user-settings.ts
+++ b/apps/web/src/app/user-settings.ts
@@ -1,7 +1,9 @@
 import { ALL_SPORTS, SPORT_OPTIONS } from "./leaderboard/constants";
 import { COUNTRY_OPTIONS } from "../lib/countries";
+import { normalizeLocale, storeLocalePreference } from "../lib/i18n";
 
 export const USER_SETTINGS_STORAGE_KEY = "cst:user-settings";
+export const USER_SETTINGS_CHANGED_EVENT = "cst:user-settings-change";
 
 const SPORT_OPTION_SET = new Set<string>(SPORT_OPTIONS);
 const COUNTRY_CODE_SET = new Set<string>(COUNTRY_OPTIONS.map((option) => option.code));
@@ -10,12 +12,14 @@ export interface UserSettings {
   defaultLeaderboardSport: string;
   defaultLeaderboardCountry: string;
   weeklySummaryEmails: boolean;
+  preferredLocale: string;
 }
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   defaultLeaderboardSport: ALL_SPORTS,
   defaultLeaderboardCountry: "",
   weeklySummaryEmails: true,
+  preferredLocale: "",
 };
 
 export function getDefaultUserSettings(): UserSettings {
@@ -64,6 +68,14 @@ function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
+function sanitizePreferredLocale(value: unknown): string {
+  if (typeof value !== "string") {
+    return DEFAULT_USER_SETTINGS.preferredLocale;
+  }
+  const normalized = normalizeLocale(value, "");
+  return normalized;
+}
+
 export type PartialUserSettings = Partial<UserSettings> | null | undefined;
 
 export function normalizeUserSettings(value: PartialUserSettings): UserSettings {
@@ -78,6 +90,7 @@ export function normalizeUserSettings(value: PartialUserSettings): UserSettings 
       record.weeklySummaryEmails,
       DEFAULT_USER_SETTINGS.weeklySummaryEmails,
     ),
+    preferredLocale: sanitizePreferredLocale(record.preferredLocale),
   };
 }
 
@@ -108,7 +121,9 @@ export function saveUserSettings(settings: PartialUserSettings): UserSettings {
     } catch {
       // Ignore storage quota errors or unavailable localStorage.
     }
+    window.dispatchEvent(new Event(USER_SETTINGS_CHANGED_EVENT));
   }
+  storeLocalePreference(normalized.preferredLocale);
   return normalized;
 }
 
@@ -119,7 +134,8 @@ export function areUserSettingsEqual(
   return (
     a.defaultLeaderboardSport === b.defaultLeaderboardSport &&
     a.defaultLeaderboardCountry === b.defaultLeaderboardCountry &&
-    a.weeklySummaryEmails === b.weeklySummaryEmails
+    a.weeklySummaryEmails === b.weeklySummaryEmails &&
+    a.preferredLocale === b.preferredLocale
   );
 }
 
@@ -129,5 +145,9 @@ export function clearUserSettings(): void {
     window.localStorage?.removeItem(USER_SETTINGS_STORAGE_KEY);
   } catch {
     // Ignore storage errors.
+  }
+  storeLocalePreference("");
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(USER_SETTINGS_CHANGED_EVENT));
   }
 }


### PR DESCRIPTION
## Summary
- add a preferred locale field to persisted user settings and surface it in the profile preferences UI
- persist locale preferences to cookies/local storage, update LocaleProvider/root layout to honor them, and keep `<html lang>` in sync
- adjust record forms to show DD/MM/YYYY placeholders and 24-hour time inputs for day-first locales with new Vitest coverage

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d620d103908323bb0eaf59f8abfcc9