### PR TITLE
Improve leaderboard accessibility semantics

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -265,4 +265,55 @@ describe("Leaderboard", () => {
     expect(url.searchParams.has("country")).toBe(false);
     expect(url.searchParams.has("clubId")).toBe(false);
   });
+
+  it("annotates the leaderboard table for accessibility", async () => {
+    const response = [
+      {
+        rank: 1,
+        playerId: "1",
+        playerName: "Player One",
+        rating: 1200,
+        setsWon: 5,
+        setsLost: 2,
+      },
+    ];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => response });
+    global.fetch = fetchMock as typeof fetch;
+    updateMockLocation("/leaderboard/padel");
+
+    render(<Leaderboard sport="padel" />);
+
+    const table = await screen.findByRole("table");
+    expect(table).toHaveAttribute("id", "leaderboard-results");
+
+    const headers = screen.getAllByRole("columnheader");
+    headers.forEach((header) => {
+      expect(header).toHaveAttribute("scope", "col");
+    });
+
+    expect(screen.getByRole("columnheader", { name: "#" })).toHaveAttribute(
+      "aria-sort",
+      "ascending",
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Leaderboard sports" }),
+    ).toHaveAttribute("aria-controls", "leaderboard-results");
+
+    expect(
+      screen.getByRole("form", { name: "Leaderboard filters" }),
+    ).toHaveAttribute("aria-controls", "leaderboard-results");
+
+    expect(screen.getByRole("button", { name: "Apply" })).toHaveAttribute(
+      "aria-controls",
+      "leaderboard-results",
+    );
+
+    expect(screen.getByRole("button", { name: "Clear" })).toHaveAttribute(
+      "aria-controls",
+      "leaderboard-results",
+    );
+  });
 });

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -59,6 +59,8 @@ const formatSportLabel = (sportId: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 
+const RESULTS_TABLE_ID = "leaderboard-results";
+
 const canonicalizePathname = (pathname: string) => {
   if (pathname === "/" || pathname === "") {
     return "/";
@@ -508,16 +510,51 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const TableHeader = () => (
     <thead>
       <tr>
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>#</th>
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Player</th>
+        <th
+          scope="col"
+          aria-sort="ascending"
+          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+        >
+          #
+        </th>
+        <th scope="col" style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>
+          Player
+        </th>
         {sport === ALL_SPORTS && (
-          <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Sport</th>
+          <th
+            scope="col"
+            style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+          >
+            Sport
+          </th>
         )}
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Rating</th>
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>W</th>
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>L</th>
-        <th style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>Matches</th>
-        <th style={{ textAlign: "left", padding: "4px 0" }}>Win%</th>
+        <th
+          scope="col"
+          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+        >
+          Rating
+        </th>
+        <th
+          scope="col"
+          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+        >
+          W
+        </th>
+        <th
+          scope="col"
+          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+        >
+          L
+        </th>
+        <th
+          scope="col"
+          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
+        >
+          Matches
+        </th>
+        <th scope="col" style={{ textAlign: "left", padding: "4px 0" }}>
+          Win%
+        </th>
       </tr>
     </thead>
   );
@@ -547,60 +584,68 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           </h1>
           <p style={{ fontSize: "0.85rem", color: "#555" }}>{regionDescription}</p>
         </div>
-        <nav
-          aria-label="Leaderboard sports"
+        <section
+          aria-label="Leaderboard controls"
           style={{ flex: "0 0 auto", fontSize: "0.9rem" }}
         >
-          <ul
-            role="tablist"
-            style={{
-              display: "flex",
-              gap: "0.5rem",
-              padding: 0,
-              margin: 0,
-              listStyle: "none",
-            }}
+          <nav
+            aria-label="Leaderboard sports"
+            aria-controls={RESULTS_TABLE_ID}
           >
-            {navItems.map((item) => {
-              const isActive = item.id === sport;
-              return (
-                <li key={item.id}>
-                  <Link
-                    href={
-                      item.id === ALL_SPORTS
-                        ? withRegion("/leaderboard?sport=all")
-                        : withRegion(`/leaderboard?sport=${item.id}`)
-                    }
-                    role="tab"
-                    aria-selected={isActive}
-                    aria-current={isActive ? "page" : undefined}
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      padding: "0.35rem 0.85rem",
-                      borderRadius: "999px",
-                      border: "1px solid",
-                      borderColor: isActive ? "#222" : "#ccc",
-                      background: isActive ? "#222" : "transparent",
-                      color: isActive ? "#fff" : "#222",
-                      fontWeight: isActive ? 600 : 500,
-                      textDecoration: "none",
-                      transition: "background 0.2s ease, color 0.2s ease",
-                    }}
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
+            <ul
+              role="tablist"
+              style={{
+                display: "flex",
+                gap: "0.5rem",
+                padding: 0,
+                margin: 0,
+                listStyle: "none",
+              }}
+            >
+              {navItems.map((item) => {
+                const isActive = item.id === sport;
+                return (
+                  <li key={item.id}>
+                    <Link
+                      href={
+                        item.id === ALL_SPORTS
+                          ? withRegion("/leaderboard?sport=all")
+                          : withRegion(`/leaderboard?sport=${item.id}`)
+                      }
+                      role="tab"
+                      aria-selected={isActive}
+                      aria-current={isActive ? "page" : undefined}
+                      aria-controls={RESULTS_TABLE_ID}
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        padding: "0.35rem 0.85rem",
+                        borderRadius: "999px",
+                        border: "1px solid",
+                        borderColor: isActive ? "#222" : "#ccc",
+                        background: isActive ? "#222" : "transparent",
+                        color: isActive ? "#fff" : "#222",
+                        fontWeight: isActive ? 600 : 500,
+                        textDecoration: "none",
+                        transition: "background 0.2s ease, color 0.2s ease",
+                      }}
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </section>
       </header>
 
       {supportsFilters ? (
         <form
           onSubmit={handleSubmit}
+          aria-label="Leaderboard filters"
+          aria-controls={RESULTS_TABLE_ID}
           style={{
             marginTop: "1rem",
             display: "flex",
@@ -637,6 +682,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           <div style={{ display: "flex", gap: "0.5rem" }}>
             <button
               type="submit"
+              aria-controls={RESULTS_TABLE_ID}
               style={{
                 padding: "0.4rem 0.9rem",
                 borderRadius: "4px",
@@ -653,6 +699,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             <button
               type="button"
               onClick={handleClear}
+              aria-controls={RESULTS_TABLE_ID}
               style={{
                 padding: "0.4rem 0.9rem",
                 borderRadius: "4px",
@@ -701,6 +748,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
 
       {loading ? (
         <table
+          id={RESULTS_TABLE_ID}
           style={{
             width: "100%",
             borderCollapse: "collapse",
@@ -762,6 +810,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         )
       ) : (
         <table
+          id={RESULTS_TABLE_ID}
           style={{
             width: "100%",
             borderCollapse: "collapse",


### PR DESCRIPTION
## Summary
- annotate the leaderboard table with column scopes, aria-sort, and a consistent id to communicate ordering
- tie the sport navigation and filter form to the results table via aria-controls and wrap them in a landmark section
- add a regression test that checks the new accessibility attributes on the leaderboard

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d62506d5ec83238b35fc662a2e4538