### PR TITLE
Prioritize stored locale during client locale resolution

### DIFF
--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -68,7 +68,7 @@ describe('LocaleProvider', () => {
     expect(localeDisplay).toHaveTextContent('sv-SE');
   });
 
-  it('updates the stored locale when browser hints change', async () => {
+  it('retains the stored locale when browser hints differ', async () => {
     window.localStorage.setItem(LOCALE_STORAGE_KEY, 'sv-SE');
     vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(['en-AU', 'en-US']);
     vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('en-US');
@@ -80,11 +80,11 @@ describe('LocaleProvider', () => {
     );
 
     await waitFor(() => {
-      expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('en-GB');
+      expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('sv-SE');
     });
 
     const localeDisplay = await screen.findByTestId('locale-value');
-    expect(localeDisplay).toHaveTextContent('en-GB');
+    expect(localeDisplay).toHaveTextContent('sv-SE');
   });
 
   it('falls back to navigator.language when languages is empty', async () => {

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -32,15 +32,15 @@ function resolveLocaleCandidates(
     candidates.push(normalizedPreferred);
   }
 
+  if (normalizedStored && normalizedStored !== normalizedPreferred) {
+    candidates.push(normalizedStored);
+  }
+
   if (acceptLanguage) {
     const parsed = parseAcceptLanguage(acceptLanguage, normalizedFallback);
     if (parsed) {
       candidates.push(parsed);
     }
-  }
-
-  if (normalizedStored && normalizedStored !== normalizedPreferred) {
-    candidates.push(normalizedStored);
   }
 
   if (typeof navigator !== 'undefined') {


### PR DESCRIPTION
## Summary
- ensure resolveLocaleCandidates ranks stored locale preferences ahead of accept-language hints so SSR and hydration agree
- update locale provider test expectations to verify stored preferences persist when browser hints differ

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d625e010d08323944df6db598e3d55