### PR TITLE
Add disc golf match creation and selection flows to record form

### DIFF
--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -1,18 +1,119 @@
 "use client";
 
-import { Suspense, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
+type MatchSummary = {
+  id: string;
+  sport: string;
+  location?: string | null;
+  playedAt?: string | null;
+};
+
+const MATCH_FETCH_LIMIT = 50;
+
 function DiscGolfForm() {
   const params = useSearchParams();
+  const router = useRouter();
   const mid = params.get("mid") || "";
-  const hasMatchId = Boolean(mid);
+  const [currentMatchId, setCurrentMatchId] = useState(mid);
+  const hasMatchId = Boolean(currentMatchId);
   const [hole, setHole] = useState(1);
   const [a, setA] = useState("");
   const [b, setB] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [matchPickerError, setMatchPickerError] = useState<string | null>(null);
+  const [creatingMatch, setCreatingMatch] = useState(false);
+  const [availableMatches, setAvailableMatches] = useState<MatchSummary[]>([]);
+  const [isLoadingMatches, setIsLoadingMatches] = useState(false);
+  const matchOptions = useMemo(
+    () => availableMatches.filter((m) => m.sport === "disc_golf"),
+    [availableMatches],
+  );
+
+  useEffect(() => {
+    setCurrentMatchId((prev) => {
+      if (prev === mid) {
+        return prev;
+      }
+      return mid;
+    });
+  }, [mid]);
+
+  useEffect(() => {
+    if (mid) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setIsLoadingMatches(true);
+    setMatchPickerError(null);
+    (async () => {
+      try {
+        const res = await fetch(
+          `${base}/v0/matches?limit=${MATCH_FETCH_LIMIT}&offset=0`,
+          {
+            method: "GET",
+            signal: controller.signal,
+          },
+        );
+        if (!res.ok) {
+          throw new Error("Failed to load matches");
+        }
+        const data = (await res.json()) as MatchSummary[];
+        if (!cancelled) {
+          setAvailableMatches(data);
+        }
+      } catch (err) {
+        if (!cancelled && !(err instanceof DOMException && err.name === "AbortError")) {
+          setMatchPickerError("Failed to load existing disc golf matches.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingMatches(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [mid]);
+
+  const navigateToMatch = (matchId: string) => {
+    setCurrentMatchId(matchId);
+    setHole(1);
+    setA("");
+    setB("");
+    setError(null);
+    setMatchPickerError(null);
+    router.push(`/record/disc-golf/?mid=${encodeURIComponent(matchId)}`);
+  };
+
+  const startMatch = async () => {
+    setCreatingMatch(true);
+    setMatchPickerError(null);
+    try {
+      const res = await fetch(`${base}/v0/matches`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sport: "disc_golf",
+          participants: [],
+          details: { sport: "disc_golf" },
+        }),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to create match");
+      }
+      const data = (await res.json()) as { id: string };
+      navigateToMatch(data.id);
+    } catch {
+      setMatchPickerError("Failed to start a new match.");
+    } finally {
+      setCreatingMatch(false);
+    }
+  };
 
   const submit = async () => {
     if (!hasMatchId) return;
@@ -23,7 +124,7 @@ function DiscGolfForm() {
     ];
     try {
       for (const ev of events) {
-        const res = await fetch(`${base}/v0/matches/${mid}/events`, {
+        const res = await fetch(`${base}/v0/matches/${currentMatchId}/events`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(ev),
@@ -44,10 +145,43 @@ function DiscGolfForm() {
     <main className="container">
       <h1 className="heading">Record Disc Golf</h1>
       {!hasMatchId && (
-        <p>
-          Select a match before recording scores. Open this page from a match
-          scoreboard or include a match id in the link.
-        </p>
+        <div className="form-stack">
+          <p>
+            Start a new match or choose an existing disc golf match before
+            recording hole scores.
+          </p>
+          <div className="form-grid form-grid--two">
+            <button type="button" onClick={startMatch} disabled={creatingMatch}>
+              {creatingMatch ? "Starting…" : "Start new match"}
+            </button>
+            <label className="form-field" htmlFor="disc-golf-existing-match">
+              <span className="form-label">Existing match</span>
+              <select
+                id="disc-golf-existing-match"
+                onChange={(event) => {
+                  const matchId = event.target.value;
+                  if (matchId) {
+                    navigateToMatch(matchId);
+                  }
+                }}
+                disabled={isLoadingMatches || matchOptions.length === 0}
+                defaultValue=""
+              >
+                <option value="" disabled>
+                  {isLoadingMatches
+                    ? "Loading matches…"
+                    : "Select a disc golf match"}
+                </option>
+                {matchOptions.map((match) => (
+                  <option key={match.id} value={match.id}>
+                    {match.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {matchPickerError && <p>{matchPickerError}</p>}
+        </div>
       )}
       <p>Hole {hole}</p>
       <div className="scores form-grid form-grid--two">


### PR DESCRIPTION
## Summary
- add a start-new-match action to the disc golf recorder that creates a match via the API and routes to the new match id
- surface an existing-match selector by fetching disc golf matches so recording can resume without reloading
- extend the disc golf recorder tests to cover the new creation and selection flows as well as the pre-hydrated match case

## Testing
- pnpm vitest run src/app/record/disc-golf/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6251a1bf48323a205b67a0c053daf