### PR TITLE
Handle API error codes in web client

### DIFF
--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MatchesPage from '../matches/page';
+import { apiFetch, type ApiError } from '../../lib/api';
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>(
+    '../../lib/api'
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+vi.mock('next/headers', () => ({
+  headers: () => ({
+    get: () => 'en-US',
+  }),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+const makeApiError = (
+  code: string,
+  parsedMessage: string,
+  status?: number
+): ApiError => {
+  const err = new Error(parsedMessage) as ApiError;
+  err.code = code;
+  err.parsedMessage = parsedMessage;
+  if (status !== undefined) {
+    err.status = status;
+  }
+  return err;
+};
+
+describe('MatchesPage error handling', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it('shows a friendly message for forbidden errors', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    mockedApiFetch.mockRejectedValueOnce(
+      makeApiError('match_forbidden', 'forbidden', 403)
+    );
+
+    const ui = await MatchesPage({});
+    render(ui);
+
+    expect(
+      screen.getByText(/You do not have permission to view these matches\./i)
+    ).toBeInTheDocument();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Unhandled matches error code')
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlayersPage from '../players/page';
+import {
+  apiFetch,
+  isAdmin,
+  type ApiError,
+} from '../../lib/api';
+import ToastProvider from '../../components/ToastProvider';
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>(
+    '../../lib/api'
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+    isAdmin: vi.fn(),
+  };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedIsAdmin = vi.mocked(isAdmin);
+
+const makeApiError = (
+  code: string,
+  parsedMessage: string,
+  status?: number
+): ApiError => {
+  const err = new Error(parsedMessage) as ApiError;
+  err.code = code;
+  err.parsedMessage = parsedMessage;
+  if (status !== undefined) {
+    err.status = status;
+  }
+  return err;
+};
+
+describe('PlayersPage error handling', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedIsAdmin.mockReset();
+    mockedIsAdmin.mockReturnValue(false);
+  });
+
+  it('shows a friendly message when hidden players are forbidden', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    mockedApiFetch.mockRejectedValueOnce(
+      makeApiError('players_include_hidden_forbidden', 'forbidden', 403)
+    );
+
+    render(
+      <ToastProvider>
+        <PlayersPage />
+      </ToastProvider>
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(
+      /You do not have permission to view hidden players\./i
+    );
+
+    const toast = await screen.findByTestId('toast');
+    expect(toast).toHaveTextContent(
+      /You do not have permission to view hidden players\./i
+    );
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalled();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Unhandled players fetch error code')
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- capture API error codes and parsed messages in apiFetch errors
- surface friendly messaging for known login, player list, and matches error codes while logging unexpected responses
- add vitest coverage for the new error-handling branches

## Testing
- pnpm --dir apps/web exec -- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d628f6e8a08323964e57511430f4ca