### PR TITLE
Handle undefined chart area when rendering player heatmap

### DIFF
--- a/apps/web/src/components/charts/MatchHeatmap.tsx
+++ b/apps/web/src/components/charts/MatchHeatmap.tsx
@@ -42,10 +42,18 @@ export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
           const alpha = maxV ? value / maxV : 0;
           return `rgba(26, 115, 232, ${alpha})`;
         },
-        width: (ctx: ScriptableContext<'matrix'>) =>
-          ctx.chart.chartArea.width / xLabels.length - 2,
-        height: (ctx: ScriptableContext<'matrix'>) =>
-          ctx.chart.chartArea.height / yLabels.length - 2,
+        width: (ctx: ScriptableContext<'matrix'>) => {
+          const { chartArea } = ctx.chart;
+          if (!chartArea) return 0;
+          const columns = Math.max(xLabels.length, 1);
+          return Math.max(chartArea.width / columns - 2, 0);
+        },
+        height: (ctx: ScriptableContext<'matrix'>) => {
+          const { chartArea } = ctx.chart;
+          if (!chartArea) return 0;
+          const rows = Math.max(yLabels.length, 1);
+          return Math.max(chartArea.height / rows - 2, 0);
+        },
       },
     ],
   };


### PR DESCRIPTION
## Summary
- guard the heatmap cell size calculations against a missing chart area
- ensure column and row counts never cause division by zero when rendering player stats

## Testing
- npm test -- --run PlayerCharts

------
https://chatgpt.com/codex/tasks/task_e_68d62ffb4b0c832394423ddd5b1678dd