### PR TITLE
Fix participant display helpers

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -7,6 +7,7 @@ import { ensureTrailingSlash } from "../../../lib/routes";
 import { PlayerInfo } from "../../../components/PlayerName";
 import MatchParticipants from "../../../components/MatchParticipants";
 import { useLocale } from "../../../lib/LocaleContext";
+import { resolveParticipantGroups } from "../../../lib/participants";
 
 type MatchRow = {
   id: string;
@@ -94,12 +95,13 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   }
 
   return details.map(({ row, detail }) => {
-    const participants = detail.participants
+    const sortedParticipants = detail.participants
       .slice()
-      .sort((a, b) => a.side.localeCompare(b.side))
-      .map((p) =>
-        p.playerIds.map((id) => idToPlayer.get(id) ?? { id, name: "Unknown" })
-      );
+      .sort((a, b) => a.side.localeCompare(b.side));
+    const participants = resolveParticipantGroups(
+      sortedParticipants,
+      (id) => idToPlayer.get(id)
+    );
     return { ...row, participants, summary: detail.summary };
   });
 }

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -82,8 +82,17 @@ export default function HomePageClient({
     hasMore: boolean;
     nextOffset: number | null;
   }> => {
-    const rows = (await response.json()) as MatchRow[];
-    const pagination = extractMatchPagination(response.headers, fallbackLimit);
+    const parsed = await response.json();
+    const rows = Array.isArray(parsed)
+      ? (parsed as MatchRow[])
+      : Array.isArray((parsed as { items?: unknown }).items)
+      ? ((parsed as { items: MatchRow[] }).items ?? [])
+      : [];
+    const headerBag =
+      response && "headers" in response && response.headers instanceof Headers
+        ? response.headers
+        : new Headers();
+    const pagination = extractMatchPagination(headerBag, fallbackLimit);
     const enriched = await enrichMatches(rows);
     return {
       enriched,

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -17,6 +17,7 @@ import {
   shouldRebuildRacketSummary,
   isRecord,
 } from "../../../lib/match-summary";
+import { resolveParticipantGroups } from "../../../lib/participants";
 
 export const dynamic = "force-dynamic";
 
@@ -394,13 +395,9 @@ export default async function MatchDetailPage({
   const idToPlayer = playerLookup.map;
   const playerLookupError = playerLookup.error;
 
-  const sidePlayers: Record<string, PlayerInfo[]> = {};
-  for (const p of parts) {
-    const players = (p.playerIds ?? []).map(
-      (id) => idToPlayer.get(id) ?? { id, name: "Unknown" }
-    );
-    sidePlayers[p.side] = players;
-  }
+  const participantGroups = resolveParticipantGroups(parts, (id) =>
+    idToPlayer.get(id)
+  );
 
   const notices: string[] = [];
   if (playerLookupError) {
@@ -508,10 +505,10 @@ export default async function MatchDetailPage({
 
       <header className="section">
         <h1 className="heading">
-          {Object.keys(sidePlayers).length ? (
+          {participantGroups.length ? (
             <MatchParticipants
               as="span"
-              sides={Object.values(sidePlayers)}
+              sides={participantGroups}
               separatorSymbol="/"
             />
           ) : (

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -6,6 +6,7 @@ import { PlayerInfo } from "../../components/PlayerName";
 import MatchParticipants from "../../components/MatchParticipants";
 import { formatDate, parseAcceptLanguage } from "../../lib/i18n";
 import { ensureTrailingSlash } from "../../lib/routes";
+import { resolveParticipantGroups } from "../../lib/participants";
 
 export const dynamic = "force-dynamic";
 
@@ -118,12 +119,13 @@ async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> {
   }
 
   return details.map(({ row, detail }) => {
-    const participants = detail.participants
+    const sortedParticipants = detail.participants
       .slice()
-      .sort((a, b) => a.side.localeCompare(b.side))
-      .map((p) =>
-        p.playerIds.map((id) => idToPlayer.get(id) ?? { id, name: "Unknown" })
-      );
+      .sort((a, b) => a.side.localeCompare(b.side));
+    const participants = resolveParticipantGroups(
+      sortedParticipants,
+      (id) => idToPlayer.get(id)
+    );
     return { ...row, participants, summary: detail.summary };
   });
 }

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   type NormalizedMatchSummary,
   type NormalizedVersusRecord,
 } from "../../../lib/player-stats";
+import { sanitizePlayersBySide } from "../../../lib/participants";
 
 export const dynamic = "force-dynamic";
 
@@ -231,6 +232,7 @@ async function getMatches(
         playerSide = p.side;
       }
     }
+    const sanitizedPlayers = sanitizePlayersBySide(players);
     let playerWon: boolean | undefined = undefined;
     const summary = detail.summary;
     if (playerSide && summary) {
@@ -243,7 +245,7 @@ async function getMatches(
     }
     return {
       ...row,
-      players,
+      players: sanitizedPlayers,
       participants: detail.participants ?? [],
       summary,
       playerSide,

--- a/apps/web/src/lib/matches.ts
+++ b/apps/web/src/lib/matches.ts
@@ -27,6 +27,7 @@ export type EnrichedMatch = MatchRow & {
 };
 
 import { apiFetch, withAbsolutePhotoUrl } from './api';
+import { sanitizePlayersBySide } from './participants';
 
 function parseNumber(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -112,6 +113,7 @@ export async function enrichMatches(rows: MatchRow[]): Promise<EnrichedMatch[]> 
         (id) => idToPlayer.get(id) ?? { id, name: 'Unknown' }
       );
     }
-    return { ...row, players };
+    const sanitizedPlayers = sanitizePlayersBySide(players);
+    return { ...row, players: sanitizedPlayers };
   });
 }

--- a/apps/web/src/lib/participants.test.ts
+++ b/apps/web/src/lib/participants.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { PlayerInfo } from "../components/PlayerName";
+import {
+  resolveParticipantGroups,
+  sanitizePlayerGroups,
+  sanitizePlayersBySide,
+} from "./participants";
+
+describe("participants helpers", () => {
+  it("removes empty player entries and sides", () => {
+    const groups: Array<Array<PlayerInfo | null>> = [
+      [
+        { id: "1", name: " Alice " },
+        { id: "2", name: "" },
+        { id: "3", name: "Bob" },
+      ],
+      [],
+      [
+        { id: "4", name: "   " },
+        { id: "5", name: "Carol" },
+      ],
+    ];
+
+    const sanitized = sanitizePlayerGroups(groups);
+    expect(sanitized).toEqual([
+      [
+        { id: "1", name: "Alice" },
+        { id: "3", name: "Bob" },
+      ],
+      [{ id: "5", name: "Carol" }],
+    ]);
+  });
+
+  it("drops empty sides in player maps", () => {
+    const playersBySide = {
+      A: [
+        { id: "1", name: "Alice" },
+        { id: "2", name: "" },
+      ],
+      B: [],
+      C: [
+        { id: "3", name: "   " },
+        { id: "4", name: "Dave" },
+      ],
+    } satisfies Record<string, Array<PlayerInfo | null>>;
+
+    const sanitized = sanitizePlayersBySide(playersBySide);
+    expect(sanitized).toEqual({
+      A: [{ id: "1", name: "Alice" }],
+      C: [{ id: "4", name: "Dave" }],
+    });
+  });
+
+  it("resolves participants and fills missing players", () => {
+    const participants = [
+      { playerIds: ["1", "missing", ""] },
+      { playerIds: [] },
+      { playerIds: ["3"] },
+    ];
+    const lookup = new Map<string, PlayerInfo>([
+      ["1", { id: "1", name: "Alice" }],
+      ["3", { id: "3", name: " Carol " }],
+    ]);
+
+    const groups = resolveParticipantGroups(participants, (id) =>
+      lookup.get(id),
+    );
+
+    expect(groups).toEqual([
+      [
+        { id: "1", name: "Alice" },
+        { id: "missing", name: "Unknown" },
+      ],
+      [{ id: "3", name: "Carol" }],
+    ]);
+  });
+});

--- a/apps/web/src/lib/participants.ts
+++ b/apps/web/src/lib/participants.ts
@@ -1,0 +1,94 @@
+import { PlayerInfo } from "../components/PlayerName";
+
+function sanitizePlayer(
+  player: PlayerInfo | null | undefined
+): PlayerInfo | null {
+  if (!player) {
+    return null;
+  }
+
+  const name = typeof player.name === "string" ? player.name.trim() : "";
+  if (!name) {
+    return null;
+  }
+
+  if (name === player.name) {
+    return player;
+  }
+
+  return { ...player, name };
+}
+
+function sanitizePlayerGroup(
+  group: Array<PlayerInfo | null | undefined> | null | undefined
+): PlayerInfo[] {
+  if (!group) {
+    return [];
+  }
+
+  const sanitized: PlayerInfo[] = [];
+  for (const entry of group) {
+    const player = sanitizePlayer(entry ?? null);
+    if (player) {
+      sanitized.push(player);
+    }
+  }
+  return sanitized;
+}
+
+export function sanitizePlayerGroups(
+  groups: Array<Array<PlayerInfo | null | undefined> | null | undefined>
+): PlayerInfo[][] {
+  const sanitized: PlayerInfo[][] = [];
+  for (const group of groups) {
+    const players = sanitizePlayerGroup(group);
+    if (players.length) {
+      sanitized.push(players);
+    }
+  }
+  return sanitized;
+}
+
+export function sanitizePlayersBySide(
+  playersBySide: Record<
+    string,
+    Array<PlayerInfo | null | undefined> | null | undefined
+  >
+): Record<string, PlayerInfo[]> {
+  const entries = Object.entries(playersBySide).flatMap(([side, players]) => {
+    const sanitized = sanitizePlayerGroup(players);
+    return sanitized.length ? ([[side, sanitized] as const]) : [];
+  });
+  return Object.fromEntries(entries);
+}
+
+type ParticipantLike = {
+  playerIds?: Array<string | null | undefined> | null;
+};
+
+export function resolveParticipantGroups(
+  participants: Array<ParticipantLike | null | undefined> | null | undefined,
+  resolvePlayer: (id: string) => PlayerInfo | undefined
+): PlayerInfo[][] {
+  if (!participants?.length) {
+    return [];
+  }
+
+  const groups = participants.map((participant) => {
+    if (!participant) {
+      return [];
+    }
+    const ids = participant.playerIds ?? [];
+    return ids.map((rawId) => {
+      if (!rawId) {
+        return null;
+      }
+      const id = String(rawId);
+      return resolvePlayer(id) ?? { id, name: "Unknown" };
+    });
+  });
+
+  return sanitizePlayerGroups(groups);
+}
+
+export { sanitizePlayerGroup as sanitizePlayerList };


### PR DESCRIPTION
## Summary
- add participant normalization utilities to filter empty players and reuse them wherever match sides are rendered
- update match list, detail, admin, and player views to show sanitized participant data
- make home page pagination parsing tolerant of wrapped API responses and add coverage for the new helpers

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d66bedf16c8323a2afc4df44db2066