### PR TITLE
Improve loading resilience and skeletons

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -517,6 +517,18 @@ textarea {
   color: rgba(10, 31, 68, 0.7);
 }
 
+.player-list__stats-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.player-list__stats-skeleton {
+  display: inline-block;
+  width: 80px;
+  height: 0.75rem;
+}
+
 .player-list__admin {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -494,11 +494,7 @@ export default function ProfilePage() {
   const preferencesInputsDisabled = !preferencesLoaded || preferencesSaving;
 
   if (loading) {
-    return (
-      <main className="container">
-        <p>Loading...</p>
-      </main>
-    );
+    return <ProfileSkeleton />;
   }
 
   return (
@@ -1104,6 +1100,54 @@ export default function ProfilePage() {
             </button>
           </div>
         )}
+      </section>
+    </main>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <main className="container" aria-busy="true">
+      <h1 className="heading">Profile</h1>
+      <div className="auth-form" aria-hidden>
+        <span
+          className="skeleton"
+          style={{
+            width: 120,
+            height: 120,
+            borderRadius: "50%",
+          }}
+        />
+        <span className="skeleton" style={{ width: "60%", height: "1rem" }} />
+        <span className="skeleton" style={{ width: "40%", height: "1rem" }} />
+        <span className="skeleton" style={{ width: "100%", height: 40 }} />
+        <span className="skeleton" style={{ width: "100%", height: 40 }} />
+      </div>
+      <section className="form-fieldset" aria-hidden>
+        <div className="form-grid">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`profile-skeleton-field-${index}`} className="form-field">
+              <span
+                className="skeleton"
+                style={{ width: "30%", maxWidth: 140, height: "0.85rem" }}
+              />
+              <span className="skeleton" style={{ width: "100%", height: 40 }} />
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="form-fieldset" aria-hidden>
+        <div className="form-grid">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={`profile-skeleton-pref-${index}`} className="form-field">
+              <span
+                className="skeleton"
+                style={{ width: "45%", maxWidth: 200, height: "0.85rem" }}
+              />
+              <span className="skeleton" style={{ width: "100%", height: 36 }} />
+            </div>
+          ))}
+        </div>
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- add an abortable timeout and skeleton placeholders to the players list along with a stats loading shimmer
- introduce a structured skeleton layout for the profile page while loading account data
- guard leaderboard requests with abort controllers and clearer timeout messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6731b8b408323be8e62cafcff812d