### PR TITLE
Normalize match participant separators and labels

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -195,9 +195,9 @@ describe("MatchDetailPage", () => {
 
     render(await MatchDetailPage({ params: { mid: "m2" } }));
 
-    expect(
-      screen.getByRole("heading", { level: 1, name: "Ann vs Ben vs Cam" })
-    ).toBeInTheDocument();
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Ann vs Ben vs Cam");
+    expect(heading).toHaveAccessibleName("Ann versus Ben versus Cam");
 
     const meta = screen.getByText(
       (text, element) =>
@@ -560,8 +560,8 @@ describe("MatchDetailPage", () => {
     expect(
       screen.getByText(/could not reach the player service/i)
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 1, name: /unknown vs unknown/i })
-    ).toBeInTheDocument();
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(/unknown vs unknown/i);
+    expect(heading).toHaveAccessibleName(/unknown versus unknown/i);
   });
 });

--- a/apps/web/src/components/MatchParticipants.test.tsx
+++ b/apps/web/src/components/MatchParticipants.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import MatchParticipants from "./MatchParticipants";
+
+describe("MatchParticipants", () => {
+  const sides = [
+    [
+      { id: "p1", name: "Ann" },
+      { id: "p2", name: "Bob" },
+    ],
+    [{ id: "p3", name: "Cam" }],
+  ];
+
+  it("normalizes whitespace for custom separators", () => {
+    render(
+      <MatchParticipants
+        as="h2"
+        sides={sides}
+        separatorSymbol="  &  "
+        separatorLabel="  crew  "
+        versusSymbol="  VS  "
+        versusLabel=" showdown "
+      />
+    );
+
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent("Ann & Bob VS Cam");
+    expect(heading).not.toHaveTextContent(/VS\s+VS/);
+    expect(heading).toHaveAccessibleName("Ann crew Bob showdown Cam");
+
+    const separator = screen.getByLabelText("crew");
+    expect(separator.textContent?.trim()).toBe("&");
+
+    const versus = screen.getByLabelText("showdown");
+    expect(versus.textContent?.trim()).toBe("VS");
+  });
+
+  it("falls back to defaults when symbols are blank", () => {
+    render(
+      <MatchParticipants as="h3" sides={sides} separatorSymbol="  " versusSymbol="  " />
+    );
+
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading.textContent?.replace(/\s+/g, " ")).toBe("Ann & Bob vs Cam");
+    expect(heading).toHaveAccessibleName("Ann and Bob versus Cam");
+
+    const separator = screen.getByLabelText("and");
+    expect(separator.textContent?.trim()).toBe("&");
+
+    const versus = screen.getByLabelText("versus");
+    expect(versus.textContent?.trim()).toBe("vs");
+  });
+});

--- a/apps/web/src/components/MatchParticipants.tsx
+++ b/apps/web/src/components/MatchParticipants.tsx
@@ -1,5 +1,6 @@
 import { ComponentPropsWithoutRef, ElementType } from 'react';
 import PlayerName, { PlayerInfo } from './PlayerName';
+import { resolveText } from '../lib/text';
 
 type BaseProps = {
   sides: PlayerInfo[][];
@@ -31,22 +32,10 @@ export default function MatchParticipants<
 }: MatchParticipantsProps<T>) {
   const Component = (as ?? DEFAULT_ELEMENT) as ElementType;
   const classes = ['match-participants', className].filter(Boolean).join(' ');
-  const fallbackSeparatorText =
-    typeof separatorSymbol === 'string' && separatorSymbol.trim().length > 0
-      ? separatorSymbol.trim()
-      : 'and';
-  const separatorScreenReaderText =
-    typeof separatorLabel === 'string' && separatorLabel.trim().length > 0
-      ? separatorLabel
-      : fallbackSeparatorText;
-  const fallbackVersusText =
-    typeof versusSymbol === 'string' && versusSymbol.trim().length > 0
-      ? versusSymbol.trim()
-      : 'versus';
-  const versusScreenReaderText =
-    typeof versusLabel === 'string' && versusLabel.trim().length > 0
-      ? versusLabel
-      : fallbackVersusText;
+  const visualSeparator = ` ${resolveText(separatorSymbol, '&')} `;
+  const visualVersus = ` ${resolveText(versusSymbol, 'vs')} `;
+  const separatorScreenReaderText = resolveText(separatorLabel, 'and');
+  const versusScreenReaderText = resolveText(versusLabel, 'versus');
 
   if (!sides.length) {
     return <Component className={classes} {...rest} />;
@@ -72,10 +61,12 @@ export default function MatchParticipants<
               key={`${player.id}-group-${playerIndex}`}
               className="match-participants__entry-group"
             >
-              <span className="match-participants__separator" aria-hidden="true">
-                {` ${separatorSymbol} `}
+              <span
+                className="match-participants__separator"
+                aria-label={separatorScreenReaderText}
+              >
+                {visualSeparator}
               </span>
-              <span className="sr-only">{separatorScreenReaderText}</span>
               <span className="match-participants__entry">
                 <PlayerName player={player} />
               </span>
@@ -87,10 +78,12 @@ export default function MatchParticipants<
           <span key={sideIndex} className="match-participants__side-wrapper">
             {sideIndex > 0 && (
               <>
-                <span className="match-participants__versus" aria-hidden="true">
-                  {` ${versusSymbol} `}
+                <span
+                  className="match-participants__versus"
+                  aria-label={versusScreenReaderText}
+                >
+                  {visualVersus}
                 </span>
-                <span className="sr-only">{versusScreenReaderText}</span>
               </>
             )}
             <span className="match-participants__side">{renderedSide}</span>

--- a/apps/web/src/lib/text.test.ts
+++ b/apps/web/src/lib/text.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { normalizeWhitespace, resolveText } from "./text";
+
+describe("text helpers", () => {
+  it("normalizes whitespace sequences", () => {
+    expect(normalizeWhitespace("  A   B\tC  ")).toBe("A B C");
+  });
+
+  it("falls back when value is not a usable string", () => {
+    expect(resolveText(undefined, "fallback")).toBe("fallback");
+    expect(resolveText("   ", "fallback")).toBe("fallback");
+  });
+
+  it("returns trimmed text when available", () => {
+    expect(resolveText("  Hello  ", "fallback")).toBe("Hello");
+  });
+});

--- a/apps/web/src/lib/text.ts
+++ b/apps/web/src/lib/text.ts
@@ -1,0 +1,11 @@
+export function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function resolveText(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const normalized = normalizeWhitespace(value);
+  return normalized.length > 0 ? normalized : fallback;
+}


### PR DESCRIPTION
## Summary
- add reusable text helpers to trim and normalize participant symbols and labels
- update MatchParticipants to use the helpers and improve aria labeling, with new component coverage
- adjust match detail expectations to assert the refined accessible strings

## Testing
- npm --prefix apps/web test MatchParticipants.test.tsx -- --run
- npm --prefix apps/web test src/app/matches/[mid]/page.test.tsx -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d675c6816883239abd370b03e949e8