### PR TITLE
Hide player creation form for non-admin viewers

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -590,6 +590,17 @@ textarea {
   color: var(--color-accent-red);
 }
 
+.player-list__loading {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.player-list__loading-text {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
 .player-list__admin-note {
   margin-top: 1.5rem;
   font-size: 0.95rem;

--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import PlayersPage from "./page";
 import ToastProvider from "../../components/ToastProvider";
 
@@ -524,16 +525,12 @@ describe("PlayersPage", () => {
     });
 
     expect(
-      screen.getByText(/only administrators can add new players/i)
+      screen.getByText(/sign in as an admin to add players/i)
     ).toBeTruthy();
+    const loginCta = screen.getByRole("link", { name: /login/i });
+    expect(loginCta).toHaveAttribute("href", "/login");
     expect(screen.queryByRole("button", { name: /add/i })).toBeNull();
-    const controls = document.querySelector(
-      "[data-testid=\"player-create-controls\"]"
-    ) as HTMLElement | null;
-    expect(controls).toBeTruthy();
-    expect(controls?.hasAttribute("hidden")).toBe(true);
-    expect(controls?.getAttribute("aria-hidden")).toBe("true");
-    expect(controls?.hasAttribute("inert")).toBe(true);
+    expect(screen.queryByTestId("player-create-controls")).toBeNull();
   });
 
   it("hides per-player admin controls for non-admin users", async () => {
@@ -591,9 +588,6 @@ describe("PlayersPage", () => {
     });
 
     const controls = screen.getByTestId("player-create-controls");
-    expect(controls.hasAttribute("hidden")).toBe(false);
-    expect(controls.getAttribute("aria-hidden")).toBe("false");
-    expect(controls.hasAttribute("inert")).toBe(false);
     expect(screen.getByRole("button", { name: /add/i })).toBeTruthy();
     window.localStorage.removeItem("token");
   });


### PR DESCRIPTION
## Summary
- hide the player creation controls behind an admin check and show a login call-to-action for other viewers
- surface an explicit loading status message while the roster is being fetched
- adjust styling and tests to cover the new non-admin messaging

## Testing
- pnpm exec vitest run src/app/players/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d675a019688323a27322005bcef99f