### PR TITLE
Improve matches pagination clarity

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -189,6 +189,26 @@ textarea {
   cursor: not-allowed;
 }
 
+.pager {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 16px;
+}
+
+.pager__status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
+.pager__controls {
+  display: flex;
+  gap: 8px;
+}
+
 .section {
   margin-bottom: 16px;
 }

--- a/apps/web/src/app/matches/pager.tsx
+++ b/apps/web/src/app/matches/pager.tsx
@@ -5,14 +5,20 @@ import { ensureTrailingSlash } from "../../lib/routes";
 
 interface PagerProps {
   limit: number;
+  offset: number;
+  itemCount: number;
+  totalCount: number | null;
   prevOffset: number;
-  nextOffset: number;
+  nextOffset: number | null;
   disablePrev: boolean;
   disableNext: boolean;
 }
 
 export default function Pager({
   limit,
+  offset,
+  itemCount,
+  totalCount,
   prevOffset,
   nextOffset,
   disablePrev,
@@ -21,28 +27,55 @@ export default function Pager({
   const router = useRouter();
   const basePath = ensureTrailingSlash('/matches');
 
+  const pageNumber = Math.floor(offset / limit) + 1;
+  const totalKnown =
+    typeof totalCount === 'number' && Number.isFinite(totalCount);
+
+  let statusText: string;
+  if (itemCount <= 0) {
+    statusText = `Page ${pageNumber} · No matches on this page`;
+  } else {
+    const start = offset + 1;
+    const end = offset + itemCount;
+    statusText = `Page ${pageNumber} · Showing matches ${start}-${end}`;
+    if (totalKnown) {
+      statusText += ` of ${totalCount}`;
+    }
+  }
+
+  const handlePrev = () => {
+    if (disablePrev) return;
+    router.push(`${basePath}?limit=${limit}&offset=${prevOffset}`);
+  };
+
+  const handleNext = () => {
+    if (disableNext || nextOffset == null) return;
+    router.push(`${basePath}?limit=${limit}&offset=${nextOffset}`);
+  };
+
   return (
-    <div className="pager">
-      <button
-        type="button"
-        className="button"
-        disabled={disablePrev}
-        onClick={() =>
-          router.push(`${basePath}?limit=${limit}&offset=${prevOffset}`)
-        }
-      >
-        Previous
-      </button>
-      <button
-        type="button"
-        className="button"
-        disabled={disableNext}
-        onClick={() =>
-          router.push(`${basePath}?limit=${limit}&offset=${nextOffset}`)
-        }
-      >
-        Next
-      </button>
+    <div className="pager" role="navigation" aria-label="Matches pagination">
+      <p className="pager__status" aria-live="polite">
+        {statusText}
+      </p>
+      <div className="pager__controls">
+        <button
+          type="button"
+          className="button"
+          disabled={disablePrev}
+          onClick={handlePrev}
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          className="button"
+          disabled={disableNext}
+          onClick={handleNext}
+        >
+          Next
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- parse API pagination headers to disable the Next button when no more matches are available
- surface pagination context with range details in the matches pager and style the controls for clarity
- update matches page tests for pagination metadata handling

## Testing
- `pnpm vitest run src/app/matches/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d6818e9c68832382debf2f1f825e0b