### PR TITLE
Adjust bowling time hint copy

### DIFF
--- a/apps/web/src/lib/sportCopy.ts
+++ b/apps/web/src/lib/sportCopy.ts
@@ -11,7 +11,8 @@ const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
     default: {
       matchDetailsHint:
         'Record when and where the game took place so everyone can follow the series.',
-      timeHint: 'Record the local start time so the series timeline stays accurate',
+      timeHint:
+        'Follow the local format shown in the example so the series timeline stays accurate',
       playersHint: 'Assign each scorecard to the correct bowler before entering their frames.',
       scoringHint:
         'Enter each roll per frame. Leave roll 2 empty after a strike and only fill roll 3 in the final frame when it is earned. Running totals update as you go.',


### PR DESCRIPTION
## Summary
- update the bowling time hint to reference the locale-specific example instead of prescribing a specific time format

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d68b6e72d48323a0df6151d98c98d7