### PR TITLE
Improve bowling roll input UX

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -968,6 +968,40 @@ textarea {
   text-align: center;
 }
 
+.bowling-roll-input {
+  width: 3.25rem;
+  text-align: center;
+}
+
+.bowling-roll-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.bowling-roll-action {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid rgba(10, 31, 68, 0.15);
+  background: rgba(10, 31, 68, 0.05);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.bowling-roll-action:hover:not(:disabled),
+.bowling-roll-action:focus-visible:not(:disabled) {
+  background: rgba(10, 31, 68, 0.12);
+  color: var(--color-primary);
+}
+
+.bowling-roll-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .bowling-frame-cell {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add roll enablement logic, keyboard navigation, and quick strike/spare/gutter actions to the bowling recorder
- show live frame totals with partial scoring feedback while preserving cumulative totals when available
- style the new shortcut controls for clarity

## Testing
- npm run lint *(fails: existing unused variable in src/app/players/page.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d68b7fef08832392bd8d530ecc5732