### PR TITLE
Improve login feedback and password strength meter

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@cst/web",
       "version": "0.1.0",
       "dependencies": {
+        "@zxcvbn-ts/core": "^3.0.4",
         "chart.js": "^4.5.0",
         "chartjs-chart-matrix": "^1.3.0",
         "next": "14.2.5",
@@ -2044,6 +2045,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@zxcvbn-ts/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@zxcvbn-ts/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "1.0.16"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -3802,6 +3812,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@zxcvbn-ts/core": "^3.0.4",
     "chart.js": "^4.5.0",
     "chartjs-chart-matrix": "^1.3.0",
     "next": "14.2.5",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -286,38 +286,37 @@ textarea {
   margin-top: 0.25rem;
 }
 
-.password-strength__track {
-  position: relative;
+.password-strength__meter {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+}
+
+.password-strength__segment {
   height: 8px;
-  background: rgba(10, 31, 68, 0.12);
   border-radius: 999px;
-  overflow: hidden;
+  background: rgba(10, 31, 68, 0.12);
+  transition: background-color 0.3s ease, opacity 0.3s ease;
+  opacity: 0.35;
 }
 
-.password-strength__bar {
-  height: 100%;
-  width: 0;
-  border-radius: inherit;
-  transition: width 0.3s ease, background-color 0.3s ease;
+.password-strength__segment--active {
+  opacity: 1;
 }
 
-.password-strength__bar--empty {
-  background: transparent;
-}
-
-.password-strength__bar--weak {
+.password-strength__segment--weak {
   background: var(--color-accent-red);
 }
 
-.password-strength__bar--fair {
+.password-strength__segment--fair {
   background: var(--color-warning);
 }
 
-.password-strength__bar--strong {
+.password-strength__segment--strong {
   background: var(--color-accent-blue);
 }
 
-.password-strength__bar--very-strong {
+.password-strength__segment--very-strong {
   background: var(--color-success);
 }
 
@@ -736,6 +735,42 @@ textarea {
   gap: 0.75rem;
   max-width: 420px;
   margin-bottom: 1.5rem;
+}
+
+.auth-error-summary {
+  border-left: 4px solid var(--color-accent-red);
+  background: rgba(255, 66, 82, 0.12);
+  padding: 1rem 1.25rem;
+  margin: 1rem 0 1.5rem;
+  border-radius: 6px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.auth-error-summary h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.auth-error-summary__group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.auth-error-summary__group h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.auth-error-summary__group ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-accent-red);
+}
+
+.auth-form__error {
+  color: var(--color-accent-red);
+  font-size: 0.9rem;
 }
 
 .connection-indicator {


### PR DESCRIPTION
## Summary
- add a zxcvbn-powered password strength meter with accessible segmented feedback
- surface login and signup validation issues through a shared error summary and inline hints
- style the new error messaging and password meter states for clearer visuals

## Testing
- npm run lint *(fails: ./src/app/players/page.test.tsx:590:11  Error: 'controls' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68d68ddf3aac8323a42950fd935d21c2