### PR TITLE
Improve accessibility for navigation and forms

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -35,6 +35,15 @@ body {
   color: var(--color-text);
 }
 
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--color-accent-blue);
+  outline-offset: 2px;
+}
+
 a {
   color: var(--color-accent-blue);
 }
@@ -55,6 +64,26 @@ img {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.skip-to-content {
+  position: absolute;
+  top: 0;
+  left: -999px;
+  padding: 0.75rem 1rem;
+  background: var(--color-accent-blue);
+  color: #ffffff;
+  border-radius: 0 0 8px 0;
+  text-decoration: none;
+  box-shadow: none;
+  transition: transform 0.2s ease;
+  z-index: 1000;
+}
+
+.skip-to-content:focus-visible {
+  left: 0;
+  transform: translateY(0);
+  box-shadow: 0 4px 12px rgba(10, 31, 68, 0.25);
 }
 
 /* Reusable layout helpers */

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  useMemo,
-  useState,
-  type MouseEvent,
-  type ReactElement,
-} from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 import {
@@ -177,8 +172,7 @@ export default function HomePageClient({
     };
   };
 
-  const retrySports = async (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const retrySports = async () => {
     setSportsLoading(true);
     try {
       const r = await apiFetch('/v0/sports', { cache: 'no-store' });
@@ -195,8 +189,7 @@ export default function HomePageClient({
     }
   };
 
-  const retryMatches = async (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const retryMatches = async () => {
     setMatchesLoading(true);
     setPaginationError(false);
     try {
@@ -258,26 +251,34 @@ export default function HomePageClient({
       <section className="section">
         <h2 className="heading">Sports</h2>
         {sportsLoading && sports.length === 0 ? (
-          <ul className="sport-list">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li key={`sport-skeleton-${i}`} className="sport-item">
-                <div className="skeleton" style={{ width: '100%', height: '1em' }} />
-              </li>
-            ))}
-          </ul>
+          <div
+            className="sport-list__status"
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <p className="sr-only">Loading sports…</p>
+            <ul className="sport-list" aria-hidden="true">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li key={`sport-skeleton-${i}`} className="sport-item">
+                  <div className="skeleton" style={{ width: '100%', height: '1em' }} />
+                </li>
+              ))}
+            </ul>
+          </div>
         ) : sports.length === 0 ? (
           sportError ? (
-            <p>
+            <p role="alert">
               Unable to load sports. Check connection.{' '}
-              <a href="#" onClick={retrySports}>
+              <button type="button" className="link-button" onClick={retrySports}>
                 Retry
-              </a>
+              </button>
             </p>
           ) : (
             <p>No sports found.</p>
           )
         ) : (
-          <ul className="sport-list" role="list">
+          <ul className="sport-list" role="list" aria-busy={sportsLoading}>
             {sports.map((s) => {
               const icon = sportIcons[s.id];
               const href = recordPathForSport(s.id);
@@ -304,27 +305,38 @@ export default function HomePageClient({
       <section className="section">
         <h2 className="heading">Recent Matches</h2>
         {matchesLoading && matches.length === 0 ? (
-          <ul className="match-list">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li key={`match-skeleton-${i}`} className="card match-item">
-                <div className="skeleton" style={{ width: '60%', height: '1em', marginBottom: '4px' }} />
-                <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
-              </li>
-            ))}
-          </ul>
+          <div
+            className="match-list__status"
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <p className="sr-only">Loading matches…</p>
+            <ul className="match-list" aria-hidden="true">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li key={`match-skeleton-${i}`} className="card match-item">
+                  <div
+                    className="skeleton"
+                    style={{ width: '60%', height: '1em', marginBottom: '4px' }}
+                  />
+                  <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
+                </li>
+              ))}
+            </ul>
+          </div>
         ) : matches.length === 0 ? (
           matchError ? (
-            <p>
+            <p role="alert">
               Unable to load matches. Check connection.{' '}
-              <a href="#" onClick={retryMatches}>
+              <button type="button" className="link-button" onClick={retryMatches}>
                 Retry
-              </a>
+              </button>
             </p>
           ) : (
             <p>No matches recorded yet.</p>
           )
         ) : (
-          <ul className="match-list" role="list">
+          <ul className="match-list" role="list" aria-busy={matchesLoading}>
             {matches.map((m) => {
               const matchWithRuleset = m as MatchWithOptionalRuleset;
               const rulesetLabel = resolveRulesetLabel(matchWithRuleset);
@@ -369,6 +381,9 @@ export default function HomePageClient({
                 >
                   {loadingMore ? 'Loading…' : 'Load more matches'}
                 </button>
+                <span className="sr-only" role="status" aria-live="polite">
+                  {loadingMore ? 'Loading more matches' : ''}
+                </span>
                 {paginationError ? (
                   <p role="alert" className="error-text">
                     Unable to load more matches. Please try again.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -34,12 +34,17 @@ export default function RootLayout({
   return (
     <html lang={locale}>
       <body>
+        <a className="skip-to-content" href="#main-content">
+          Skip to main content
+        </a>
         <LocaleProvider locale={locale} acceptLanguage={acceptLanguage}>
           <ToastProvider>
             <ChunkErrorReload />
             <Header />
             <SessionBanner />
-            {children}
+            <div id="main-content" tabIndex={-1}>
+              {children}
+            </div>
           </ToastProvider>
         </LocaleProvider>
       </body>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -316,6 +316,8 @@ export default function LoginPage() {
   const errorSummaryTitleId = useId();
   const loginErrorTitleId = useId();
   const signupErrorTitleId = useId();
+  const loginInlineErrorId = useId();
+  const signupInlineErrorId = useId();
   const { usernameCharacterRule, usernameEmailOption } = useMemo(
     () => getAuthCopy(locale),
     [locale]
@@ -470,7 +472,12 @@ export default function LoginPage() {
       )}
       <form onSubmit={handleLogin} className="auth-form">
         {loginErrors.length > 0 && (
-          <div className="auth-form__error" aria-live="polite">
+          <div
+            id={loginInlineErrorId}
+            className="auth-form__error"
+            role="alert"
+            aria-live="assertive"
+          >
             {loginErrors[0]}
           </div>
         )}
@@ -485,6 +492,10 @@ export default function LoginPage() {
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="username"
             required
+            aria-invalid={loginErrors.length > 0}
+            aria-describedby={
+              loginErrors.length > 0 ? loginInlineErrorId : undefined
+            }
           />
         </div>
         <div className="form-field">
@@ -498,6 +509,10 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="current-password"
             required
+            aria-invalid={loginErrors.length > 0}
+            aria-describedby={
+              loginErrors.length > 0 ? loginInlineErrorId : undefined
+            }
           />
         </div>
         <button type="submit">Login</button>
@@ -516,6 +531,10 @@ export default function LoginPage() {
             onChange={(e) => setNewUser(e.target.value)}
             autoComplete="username"
             required
+            aria-invalid={signupErrors.length > 0}
+            aria-describedby={
+              signupErrors.length > 0 ? signupInlineErrorId : undefined
+            }
           />
           <ul className="password-guidelines">
             {usernameGuidelines.map((guideline) => (
@@ -539,6 +558,14 @@ export default function LoginPage() {
             onChange={(e) => setNewPass(e.target.value)}
             autoComplete="new-password"
             required
+            aria-invalid={signupErrors.length > 0}
+            aria-describedby={[
+              signupErrors.length > 0 ? signupInlineErrorId : null,
+              passwordStrengthLabelId,
+              passwordStrengthHelperId,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined}
           />
           <div className="password-strength" aria-live="polite">
             <div
@@ -598,10 +625,19 @@ export default function LoginPage() {
             onChange={(e) => setConfirmPass(e.target.value)}
             autoComplete="new-password"
             required
+            aria-invalid={signupErrors.length > 0}
+            aria-describedby={
+              signupErrors.length > 0 ? signupInlineErrorId : undefined
+            }
           />
         </div>
         {signupErrors.length > 0 && (
-          <div className="auth-form__error" aria-live="polite">
+          <div
+            id={signupInlineErrorId}
+            className="auth-form__error"
+            role="alert"
+            aria-live="assertive"
+          >
             Please review the issues listed above before continuing.
           </div>
         )}

--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -587,7 +587,7 @@ describe("PlayersPage", () => {
       renderWithProviders(<PlayersPage />);
     });
 
-    const controls = screen.getByTestId("player-create-controls");
+    screen.getByTestId("player-create-controls");
     expect(screen.getByRole("button", { name: /add/i })).toBeTruthy();
     window.localStorage.removeItem("token");
   });


### PR DESCRIPTION
## Summary
- add a skip link and global focus-visible styles to improve keyboard navigation
- announce home page loading states and convert retry controls into real buttons
- hook login and signup inputs to their error text with aria attributes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6945741fc8323b88e412e291398c5