### PR TITLE
Improve accessibility navigation and feedback

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -39,6 +39,32 @@ a {
   color: var(--color-accent-blue);
 }
 
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--color-accent-red);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-120%);
+  background: var(--color-nav-bg);
+  color: var(--color-nav-text);
+  padding: 0.75rem 1rem;
+  z-index: 999;
+  border-radius: 0 0 8px 0;
+  text-decoration: none;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
 img {
   max-width: 100%;
   height: auto;

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  useMemo,
-  useState,
-  type MouseEvent,
-  type ReactElement,
-} from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 import {
@@ -177,8 +172,7 @@ export default function HomePageClient({
     };
   };
 
-  const retrySports = async (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const retrySports = async () => {
     setSportsLoading(true);
     try {
       const r = await apiFetch('/v0/sports', { cache: 'no-store' });
@@ -195,8 +189,7 @@ export default function HomePageClient({
     }
   };
 
-  const retryMatches = async (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
+  const retryMatches = async () => {
     setMatchesLoading(true);
     setPaginationError(false);
     try {
@@ -257,21 +250,33 @@ export default function HomePageClient({
 
       <section className="section">
         <h2 className="heading">Sports</h2>
+        {sportsLoading ? (
+          <p className="sr-only" role="status" aria-live="polite">
+            Updating sports…
+          </p>
+        ) : null}
         {sportsLoading && sports.length === 0 ? (
-          <ul className="sport-list">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li key={`sport-skeleton-${i}`} className="sport-item">
-                <div className="skeleton" style={{ width: '100%', height: '1em' }} />
-              </li>
-            ))}
-          </ul>
+          <div role="status" aria-live="polite">
+            <p className="sr-only">Loading sports…</p>
+            <ul className="sport-list">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li key={`sport-skeleton-${i}`} className="sport-item">
+                  <div className="skeleton" style={{ width: '100%', height: '1em' }} />
+                </li>
+              ))}
+            </ul>
+          </div>
         ) : sports.length === 0 ? (
           sportError ? (
-            <p>
+            <p role="alert">
               Unable to load sports. Check connection.{' '}
-              <a href="#" onClick={retrySports}>
+              <button
+                type="button"
+                onClick={retrySports}
+                className="link-button"
+              >
                 Retry
-              </a>
+              </button>
             </p>
           ) : (
             <p>No sports found.</p>
@@ -303,22 +308,37 @@ export default function HomePageClient({
 
       <section className="section">
         <h2 className="heading">Recent Matches</h2>
+        {matchesLoading ? (
+          <p className="sr-only" role="status" aria-live="polite">
+            Updating matches…
+          </p>
+        ) : null}
         {matchesLoading && matches.length === 0 ? (
-          <ul className="match-list">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <li key={`match-skeleton-${i}`} className="card match-item">
-                <div className="skeleton" style={{ width: '60%', height: '1em', marginBottom: '4px' }} />
-                <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
-              </li>
-            ))}
-          </ul>
+          <div role="status" aria-live="polite">
+            <p className="sr-only">Loading recent matches…</p>
+            <ul className="match-list">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <li key={`match-skeleton-${i}`} className="card match-item">
+                  <div
+                    className="skeleton"
+                    style={{ width: '60%', height: '1em', marginBottom: '4px' }}
+                  />
+                  <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
+                </li>
+              ))}
+            </ul>
+          </div>
         ) : matches.length === 0 ? (
           matchError ? (
-            <p>
+            <p role="alert">
               Unable to load matches. Check connection.{' '}
-              <a href="#" onClick={retryMatches}>
+              <button
+                type="button"
+                onClick={retryMatches}
+                className="link-button"
+              >
                 Retry
-              </a>
+              </button>
             </p>
           ) : (
             <p>No matches recorded yet.</p>
@@ -369,6 +389,11 @@ export default function HomePageClient({
                 >
                   {loadingMore ? 'Loading…' : 'Load more matches'}
                 </button>
+                {loadingMore ? (
+                  <p className="sr-only" aria-live="polite">
+                    Loading more matches…
+                  </p>
+                ) : null}
                 {paginationError ? (
                   <p role="alert" className="error-text">
                     Unable to load more matches. Please try again.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -34,12 +34,17 @@ export default function RootLayout({
   return (
     <html lang={locale}>
       <body>
+        <a className="skip-link" href="#main-content">
+          Skip to main content
+        </a>
         <LocaleProvider locale={locale} acceptLanguage={acceptLanguage}>
           <ToastProvider>
             <ChunkErrorReload />
             <Header />
             <SessionBanner />
-            {children}
+            <div id="main-content" tabIndex={-1} className="skip-target">
+              {children}
+            </div>
           </ToastProvider>
         </LocaleProvider>
       </body>

--- a/apps/web/src/app/players/page.test.tsx
+++ b/apps/web/src/app/players/page.test.tsx
@@ -587,7 +587,7 @@ describe("PlayersPage", () => {
       renderWithProviders(<PlayersPage />);
     });
 
-    const controls = screen.getByTestId("player-create-controls");
+    expect(screen.getByTestId("player-create-controls")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add/i })).toBeTruthy();
     window.localStorage.removeItem("token");
   });

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -89,6 +89,8 @@ export default function PlayersPage() {
 
   const trimmedName = name.trim();
   const nameIsValid = NAME_REGEX.test(trimmedName);
+  const showNameError = !nameIsValid && trimmedName !== "";
+  const nameInputErrorId = "player-name-error";
 
   const load = useCallback(async (query: string = debouncedSearch) => {
     const requestId = loadRequestId.current + 1;
@@ -455,6 +457,7 @@ export default function PlayersPage() {
             className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center"
           >
             <button
+              type="button"
               className="underline"
               onClick={() => {
                 void load();
@@ -560,6 +563,7 @@ export default function PlayersPage() {
                           ))}
                         </select>
                         <button
+                          type="button"
                           className="player-list__action player-list__toggle"
                           onClick={() => handleToggleVisibility(p)}
                           disabled={updatingVisibility === p.id}
@@ -567,6 +571,7 @@ export default function PlayersPage() {
                           {p.hidden ? "Unhide" : "Hide"}
                         </button>
                         <button
+                          type="button"
                           className="player-list__action player-list__delete"
                           onClick={() => handleDelete(p.id)}
                         >
@@ -594,10 +599,12 @@ export default function PlayersPage() {
               onChange={(e) => setName(e.target.value)}
               placeholder="Enter player name"
               autoComplete="name"
+              aria-invalid={showNameError}
+              aria-describedby={showNameError ? nameInputErrorId : undefined}
             />
           </div>
-          {!nameIsValid && trimmedName !== "" && (
-            <div className="text-red-500 mt-2">
+          {showNameError && (
+            <div id={nameInputErrorId} className="text-red-500 mt-2" role="alert">
               Name must be 1-50 characters and contain only letters,
               numbers, spaces, hyphens, or apostrophes.
             </div>
@@ -615,13 +622,18 @@ export default function PlayersPage() {
             />
           </div>
           <button
+            type="button"
             className="button"
             onClick={create}
             disabled={creating || name.trim() === ""}
           >
             {creating ? "Saving…" : "Add"}
           </button>
-          {success && <div className="text-green-600 mt-2">{success}</div>}
+          {success && (
+            <div className="text-green-600 mt-2" role="status" aria-live="polite">
+              {success}
+            </div>
+          )}
         </div>
       ) : (
         <div className="player-list__admin-note">


### PR DESCRIPTION
## Summary
- add a skip-to-content link and visible focus outlines across the app
- announce async loading/error states and use button semantics on the home dashboard
- tighten player form accessibility with associated error messaging and update related test coverage

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d693f6c6e48323a9b51e05e2c3e14b