### PR TITLE
Implement stage scheduling and standings recalculation

### DIFF
--- a/backend/alembic/versions/0024_stage_config_and_standings.py
+++ b/backend/alembic/versions/0024_stage_config_and_standings.py
@@ -1,0 +1,44 @@
+"""Add stage config column and stage standings table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0024_stage_config_and_standings"
+down_revision = "0023_match_friendly_flag"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("stage", sa.Column("config", sa.JSON(), nullable=True))
+
+    op.create_table(
+        "stage_standing",
+        sa.Column("stage_id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.String(), nullable=False),
+        sa.Column(
+            "matches_played", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("wins", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("losses", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("draws", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "points_scored", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "points_allowed", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("points_diff", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("sets_won", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("sets_lost", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("points", sa.Integer(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["player_id"], ["player.id"], name="fk_stage_player"),
+        sa.ForeignKeyConstraint(["stage_id"], ["stage.id"], name="fk_stage"),
+        sa.PrimaryKeyConstraint("stage_id", "player_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("stage_standing")
+    op.drop_column("stage", "config")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -100,6 +100,26 @@ class Stage(Base):
     id = Column(String, primary_key=True)
     tournament_id = Column(String, ForeignKey("tournament.id"), nullable=False)
     type = Column(String, nullable=False)  # "round_robin" | "single_elim"
+    config = Column(
+        JSON().with_variant(JSONB, "postgresql"), nullable=True
+    )
+
+
+class StageStanding(Base):
+    __tablename__ = "stage_standing"
+
+    stage_id = Column(String, ForeignKey("stage.id"), primary_key=True)
+    player_id = Column(String, ForeignKey("player.id"), primary_key=True)
+    matches_played = Column(Integer, nullable=False, default=0)
+    wins = Column(Integer, nullable=False, default=0)
+    losses = Column(Integer, nullable=False, default=0)
+    draws = Column(Integer, nullable=False, default=0)
+    points_scored = Column(Integer, nullable=False, default=0)
+    points_allowed = Column(Integer, nullable=False, default=0)
+    points_diff = Column(Integer, nullable=False, default=0)
+    sets_won = Column(Integer, nullable=False, default=0)
+    sets_lost = Column(Integer, nullable=False, default=0)
+    points = Column(Integer, nullable=False, default=0)
 
 class Match(Base):
     __tablename__ = "match"

--- a/backend/app/routers/tournaments.py
+++ b/backend/app/routers/tournaments.py
@@ -4,9 +4,22 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
-from ..models import Tournament, Stage
-from ..schemas import TournamentCreate, TournamentOut, StageCreate, StageOut
+from ..models import Tournament, Stage, StageStanding
+from ..schemas import (
+    TournamentCreate,
+    TournamentOut,
+    StageCreate,
+    StageOut,
+    StageScheduleRequest,
+    StageScheduleResponse,
+    StageScheduleMatchOut,
+    StageStandingsOut,
+    StageStandingOut,
+    ParticipantOut,
+)
 from ..exceptions import http_problem
+from ..services.tournaments import normalize_stage_type, schedule_americano
+from .admin import require_admin
 
 router = APIRouter()
 
@@ -49,11 +62,38 @@ async def get_tournament(
 async def create_stage(
     tournament_id: str, body: StageCreate, session: AsyncSession = Depends(get_session)
 ):
+    t = await session.get(Tournament, tournament_id)
+    if not t:
+        raise http_problem(
+            status_code=404,
+            detail="tournament not found",
+            code="tournament_not_found",
+        )
+
+    try:
+        stage_type = normalize_stage_type(body.type)
+    except ValueError as exc:
+        raise http_problem(
+            status_code=400,
+            detail=str(exc),
+            code="stage_type_unsupported",
+        )
+
     sid = uuid.uuid4().hex
-    s = Stage(id=sid, tournament_id=tournament_id, type=body.type)
+    s = Stage(
+        id=sid,
+        tournament_id=tournament_id,
+        type=stage_type,
+        config=body.config,
+    )
     session.add(s)
     await session.commit()
-    return StageOut(id=sid, tournamentId=tournament_id, type=body.type)
+    return StageOut(
+        id=sid,
+        tournamentId=tournament_id,
+        type=stage_type,
+        config=body.config,
+    )
 
 
 @router.get("/tournaments/{tournament_id}/stages", response_model=list[StageOut])
@@ -61,7 +101,15 @@ async def list_stages(tournament_id: str, session: AsyncSession = Depends(get_se
     rows = (
         await session.execute(select(Stage).where(Stage.tournament_id == tournament_id))
     ).scalars().all()
-    return [StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type) for s in rows]
+    return [
+        StageOut(
+            id=s.id,
+            tournamentId=s.tournament_id,
+            type=s.type,
+            config=s.config,
+        )
+        for s in rows
+    ]
 
 
 @router.get(
@@ -77,5 +125,132 @@ async def get_stage(
             detail="stage not found",
             code="stage_not_found",
         )
-    return StageOut(id=s.id, tournamentId=s.tournament_id, type=s.type)
+    return StageOut(
+        id=s.id,
+        tournamentId=s.tournament_id,
+        type=s.type,
+        config=s.config,
+    )
+
+
+@router.post(
+    "/tournaments/{tournament_id}/stages/{stage_id}/schedule",
+    response_model=StageScheduleResponse,
+)
+async def schedule_stage(
+    tournament_id: str,
+    stage_id: str,
+    body: StageScheduleRequest,
+    session: AsyncSession = Depends(get_session),
+    _admin=Depends(require_admin),
+):
+    stage = await session.get(Stage, stage_id)
+    if not stage or stage.tournament_id != tournament_id:
+        raise http_problem(
+            status_code=404,
+            detail="stage not found",
+            code="stage_not_found",
+        )
+
+    tournament = await session.get(Tournament, tournament_id)
+    if not tournament:
+        raise http_problem(
+            status_code=404,
+            detail="tournament not found",
+            code="tournament_not_found",
+        )
+
+    try:
+        stage_type = normalize_stage_type(stage.type)
+    except ValueError:
+        stage_type = stage.type
+
+    if stage_type != "americano":
+        raise http_problem(
+            status_code=400,
+            detail="stage type does not support automatic scheduling",
+            code="stage_schedule_unsupported",
+        )
+
+    try:
+        created = await schedule_americano(
+            stage.id,
+            tournament.sport_id,
+            body.playerIds,
+            session,
+            ruleset_id=body.rulesetId,
+        )
+    except ValueError as exc:
+        raise http_problem(
+            status_code=400,
+            detail=str(exc),
+            code="stage_schedule_invalid",
+        )
+
+    await session.commit()
+
+    matches = [
+        StageScheduleMatchOut(
+            id=match.id,
+            sport=match.sport_id,
+            stageId=match.stage_id,
+            rulesetId=match.ruleset_id,
+            participants=[
+                ParticipantOut(id=part.id, side=part.side, playerIds=part.player_ids)
+                for part in participants
+            ],
+        )
+        for match, participants in created
+    ]
+
+    return StageScheduleResponse(stageId=stage.id, matches=matches)
+
+
+@router.get(
+    "/tournaments/{tournament_id}/stages/{stage_id}/standings",
+    response_model=StageStandingsOut,
+)
+async def get_stage_standings(
+    tournament_id: str, stage_id: str, session: AsyncSession = Depends(get_session)
+):
+    stage = await session.get(Stage, stage_id)
+    if not stage or stage.tournament_id != tournament_id:
+        raise http_problem(
+            status_code=404,
+            detail="stage not found",
+            code="stage_not_found",
+        )
+
+    standings = (
+        await session.execute(
+            select(StageStanding)
+            .where(StageStanding.stage_id == stage_id)
+            .order_by(
+                StageStanding.points.desc(),
+                StageStanding.points_diff.desc(),
+                StageStanding.wins.desc(),
+                StageStanding.player_id,
+            )
+        )
+    ).scalars().all()
+
+    return StageStandingsOut(
+        stageId=stage.id,
+        standings=[
+            StageStandingOut(
+                playerId=row.player_id,
+                matchesPlayed=row.matches_played,
+                wins=row.wins,
+                losses=row.losses,
+                draws=row.draws,
+                pointsScored=row.points_scored,
+                pointsAllowed=row.points_allowed,
+                pointsDiff=row.points_diff,
+                setsWon=row.sets_won,
+                setsLost=row.sets_lost,
+                points=row.points,
+            )
+            for row in standings
+        ],
+    )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -664,6 +664,7 @@ class StageCreate(BaseModel):
     """Schema for creating a tournament stage."""
 
     type: str
+    config: Optional[Dict[str, Any]] = None
 
 
 class StageOut(BaseModel):
@@ -672,3 +673,51 @@ class StageOut(BaseModel):
     id: str
     tournamentId: str
     type: str
+    config: Optional[Dict[str, Any]] = None
+
+
+class StageScheduleRequest(BaseModel):
+    """Payload used to generate a schedule for a stage."""
+
+    playerIds: List[str]
+    rulesetId: Optional[str] = None
+
+
+class StageScheduleMatchOut(BaseModel):
+    """Representation of a match created during scheduling."""
+
+    id: str
+    sport: str
+    stageId: str
+    rulesetId: Optional[str] = None
+    participants: List[ParticipantOut] = Field(default_factory=list)
+
+
+class StageScheduleResponse(BaseModel):
+    """Response returned when a schedule is created."""
+
+    stageId: str
+    matches: List[StageScheduleMatchOut] = Field(default_factory=list)
+
+
+class StageStandingOut(BaseModel):
+    """Aggregate statistics for a player within a stage."""
+
+    playerId: str
+    matchesPlayed: int
+    wins: int
+    losses: int
+    draws: int
+    pointsScored: int
+    pointsAllowed: int
+    pointsDiff: int
+    setsWon: int
+    setsLost: int
+    points: int
+
+
+class StageStandingsOut(BaseModel):
+    """Collection of stage standings."""
+
+    stageId: str
+    standings: List[StageStandingOut] = Field(default_factory=list)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -9,6 +9,12 @@ from .stats import (
     compute_streaks,
     compute_sport_format_stats,
 )
+from .tournaments import (
+    SUPPORTED_STAGE_TYPES,
+    normalize_stage_type,
+    schedule_americano,
+    recompute_stage_standings,
+)
 from .master_rating import update_master_ratings
 
 __all__ = [
@@ -21,4 +27,8 @@ __all__ = [
     "compute_streaks",
     "compute_sport_format_stats",
     "update_master_ratings",
+    "SUPPORTED_STAGE_TYPES",
+    "normalize_stage_type",
+    "schedule_americano",
+    "recompute_stage_standings",
 ]

--- a/backend/app/services/tournaments.py
+++ b/backend/app/services/tournaments.py
@@ -1,0 +1,306 @@
+"""Helpers for tournament and stage orchestration."""
+
+from __future__ import annotations
+
+import uuid
+from itertools import combinations
+from typing import Iterable, Sequence
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import (
+    Match,
+    MatchParticipant,
+    Player,
+    RuleSet,
+    StageStanding,
+)
+
+
+SUPPORTED_STAGE_TYPES = {"round_robin", "single_elim", "americano"}
+
+
+def normalize_stage_type(stage_type: str) -> str:
+    """Normalize and validate a stage type identifier."""
+
+    value = (stage_type or "").strip().lower()
+    if value not in SUPPORTED_STAGE_TYPES:
+        raise ValueError(f"unsupported stage type: {stage_type!r}")
+    return value
+
+
+async def _resolve_ruleset(
+    session: AsyncSession, sport_id: str, preferred_ruleset: str | None
+) -> str:
+    if preferred_ruleset:
+        ruleset = await session.get(RuleSet, preferred_ruleset)
+        if not ruleset or ruleset.sport_id != sport_id:
+            raise ValueError("ruleset does not match sport")
+        return ruleset.id
+
+    result = await session.execute(
+        select(RuleSet.id).where(RuleSet.sport_id == sport_id).order_by(RuleSet.id)
+    )
+    ruleset_id = result.scalars().first()
+    if not ruleset_id:
+        raise ValueError(f"no ruleset configured for sport {sport_id!r}")
+    return ruleset_id
+
+
+def _unique_player_ids(player_ids: Iterable[str]) -> list[str]:
+    seen: dict[str, None] = {}
+    for pid in player_ids:
+        if not pid:
+            continue
+        if pid in seen:
+            raise ValueError("duplicate player ids provided")
+        seen[pid] = None
+    return list(seen.keys())
+
+
+async def schedule_americano(
+    stage_id: str,
+    sport_id: str,
+    player_ids: Sequence[str],
+    session: AsyncSession,
+    *,
+    ruleset_id: str | None = None,
+) -> list[tuple[Match, list[MatchParticipant]]]:
+    """Create Americano pairings for a stage.
+
+    Players are grouped into sets of four and scheduled so the first two face
+    the second two. The function raises ``ValueError`` if the stage already has
+    matches, if any player ids are unknown, or if the player list is not an
+    even number of at least four competitors.
+    """
+
+    unique_players = _unique_player_ids(player_ids)
+    if len(unique_players) < 4 or len(unique_players) % 2 != 0:
+        raise ValueError("Americano scheduling requires an even number of >=4 players")
+
+    existing_match = (
+        await session.execute(
+            select(Match.id).where(
+                Match.stage_id == stage_id,
+                Match.deleted_at.is_(None),
+            )
+        )
+    ).scalars().first()
+    if existing_match:
+        raise ValueError("stage already has scheduled matches")
+
+    registered = (
+        await session.execute(
+            select(Player.id).where(Player.id.in_(unique_players))
+        )
+    ).scalars().all()
+    missing = sorted(set(unique_players) - set(registered))
+    if missing:
+        raise ValueError(f"unknown players: {', '.join(missing)}")
+
+    resolved_ruleset = await _resolve_ruleset(session, sport_id, ruleset_id)
+
+    created: list[tuple[Match, list[MatchParticipant]]] = []
+    for group in combinations(unique_players, 4):
+        match_id = uuid.uuid4().hex
+        match = Match(
+            id=match_id,
+            sport_id=sport_id,
+            stage_id=stage_id,
+            ruleset_id=resolved_ruleset,
+            best_of=None,
+            played_at=None,
+            location=None,
+            details=None,
+            is_friendly=False,
+        )
+        session.add(match)
+
+        participants: list[MatchParticipant] = []
+        for side, players in zip(("A", "B"), (group[:2], group[2:])):
+            participant = MatchParticipant(
+                id=uuid.uuid4().hex,
+                match_id=match_id,
+                side=side,
+                player_ids=list(players),
+            )
+            session.add(participant)
+            participants.append(participant)
+
+        created.append((match, participants))
+
+    await session.flush()
+    await recompute_stage_standings(stage_id, session)
+    return created
+
+
+def _default_stats() -> dict[str, int]:
+    return {
+        "matches_played": 0,
+        "wins": 0,
+        "losses": 0,
+        "draws": 0,
+        "points_scored": 0,
+        "points_allowed": 0,
+        "sets_won": 0,
+        "sets_lost": 0,
+    }
+
+
+async def recompute_stage_standings(
+    stage_id: str, session: AsyncSession
+) -> list[StageStanding]:
+    """Rebuild the ``StageStanding`` rows for a stage."""
+
+    matches = (
+        await session.execute(
+            select(Match).where(
+                Match.stage_id == stage_id,
+                Match.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+
+    await session.execute(
+        delete(StageStanding).where(StageStanding.stage_id == stage_id)
+    )
+
+    if not matches:
+        return []
+
+    match_ids = [m.id for m in matches]
+    participants = (
+        await session.execute(
+            select(MatchParticipant).where(MatchParticipant.match_id.in_(match_ids))
+        )
+    ).scalars().all()
+
+    participants_by_match: dict[str, list[MatchParticipant]] = {}
+    for participant in participants:
+        participants_by_match.setdefault(participant.match_id, []).append(participant)
+
+    stats: dict[str, dict[str, int]] = {}
+    players_in_stage: set[str] = set()
+
+    def _to_int(value: object) -> int:
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0
+
+    for match in matches:
+        parts = participants_by_match.get(match.id, [])
+        players_a = [
+            pid
+            for part in parts
+            if part.side == "A"
+            for pid in (part.player_ids or [])
+        ]
+        players_b = [
+            pid
+            for part in parts
+            if part.side == "B"
+            for pid in (part.player_ids or [])
+        ]
+        players_in_stage.update(players_a)
+        players_in_stage.update(players_b)
+
+        if not players_a or not players_b:
+            continue
+
+        summary = match.details if isinstance(match.details, dict) else None
+        if not summary:
+            continue
+
+        score = summary.get("score") if isinstance(summary, dict) else None
+        a_score = b_score = 0
+        if isinstance(score, dict):
+            a_score = _to_int(score.get("A"))
+            b_score = _to_int(score.get("B"))
+
+        if a_score == 0 and b_score == 0:
+            set_scores = summary.get("set_scores") if isinstance(summary, dict) else None
+            if isinstance(set_scores, list):
+                a_score = sum(_to_int((entry or {}).get("A")) for entry in set_scores)
+                b_score = sum(_to_int((entry or {}).get("B")) for entry in set_scores)
+
+        sets = summary.get("sets") if isinstance(summary, dict) else None
+        if isinstance(sets, dict):
+            a_sets = _to_int(sets.get("A"))
+            b_sets = _to_int(sets.get("B"))
+        else:
+            a_sets = b_sets = 0
+
+        result: str | None
+        if a_sets or b_sets:
+            if a_sets > b_sets:
+                result = "A"
+            elif b_sets > a_sets:
+                result = "B"
+            else:
+                result = "draw"
+        elif a_score or b_score:
+            if a_score > b_score:
+                result = "A"
+            elif b_score > a_score:
+                result = "B"
+            else:
+                result = "draw"
+        else:
+            result = None
+
+        for pid in players_a:
+            player_stats = stats.setdefault(pid, _default_stats())
+            player_stats["matches_played"] += 1
+            player_stats["points_scored"] += a_score
+            player_stats["points_allowed"] += b_score
+            player_stats["sets_won"] += a_sets
+            player_stats["sets_lost"] += b_sets
+            if result == "A":
+                player_stats["wins"] += 1
+            elif result == "B":
+                player_stats["losses"] += 1
+            elif result == "draw":
+                player_stats["draws"] += 1
+
+        for pid in players_b:
+            player_stats = stats.setdefault(pid, _default_stats())
+            player_stats["matches_played"] += 1
+            player_stats["points_scored"] += b_score
+            player_stats["points_allowed"] += a_score
+            player_stats["sets_won"] += b_sets
+            player_stats["sets_lost"] += a_sets
+            if result == "B":
+                player_stats["wins"] += 1
+            elif result == "A":
+                player_stats["losses"] += 1
+            elif result == "draw":
+                player_stats["draws"] += 1
+
+    for pid in players_in_stage:
+        stats.setdefault(pid, _default_stats())
+
+    standings: list[StageStanding] = []
+    for pid in sorted(stats):
+        values = stats[pid]
+        points_diff = values["points_scored"] - values["points_allowed"]
+        points = values["wins"] * 3 + values["draws"]
+        standing = StageStanding(
+            stage_id=stage_id,
+            player_id=pid,
+            matches_played=values["matches_played"],
+            wins=values["wins"],
+            losses=values["losses"],
+            draws=values["draws"],
+            points_scored=values["points_scored"],
+            points_allowed=values["points_allowed"],
+            points_diff=points_diff,
+            sets_won=values["sets_won"],
+            sets_lost=values["sets_lost"],
+            points=points,
+        )
+        session.add(standing)
+        standings.append(standing)
+
+    return standings

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -84,3 +85,223 @@ async def test_stage_crud(tmp_path):
         resp = client.get(f"/tournaments/{tid}/stages/{sid}")
         assert resp.status_code == 200
         assert resp.json()["type"] == "round_robin"
+
+
+@pytest.mark.anyio
+async def test_stage_schedule_rejects_invalid_type(monkeypatch):
+    from app import db
+    from app.models import (
+        Sport,
+        Tournament,
+        Stage,
+        Player,
+        RuleSet,
+        Match,
+        MatchParticipant,
+        StageStanding,
+        ScoreEvent,
+    )
+    from app.routers import tournaments, matches
+    from app.routers.admin import require_admin
+    from app.routers.auth import get_current_user
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            db.Base.metadata.create_all,
+            tables=[
+                Sport.__table__,
+                Tournament.__table__,
+                Stage.__table__,
+                Player.__table__,
+                RuleSet.__table__,
+                Match.__table__,
+                MatchParticipant.__table__,
+                StageStanding.__table__,
+                ScoreEvent.__table__,
+            ],
+        )
+
+    async with db.AsyncSessionLocal() as session:
+        session.add(Sport(id="padel", name="Padel"))
+        session.add(RuleSet(id="padel-default", sport_id="padel", name="Padel", config={}))
+        for idx in range(4):
+            session.add(Player(id=f"p{idx+1}", name=f"Player {idx+1}"))
+        await session.commit()
+
+    app = FastAPI()
+    app.include_router(tournaments.router)
+    app.include_router(matches.router)
+
+    admin_user = SimpleNamespace(id="admin", is_admin=True)
+
+    async def _admin_dep():
+        return admin_user
+
+    app.dependency_overrides[require_admin] = _admin_dep
+    app.dependency_overrides[get_current_user] = _admin_dep
+
+    async def _noop_update_ratings(*args, **kwargs):
+        return None
+
+    async def _noop_update_metrics(*args, **kwargs):
+        return None
+
+    async def _noop_broadcast(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.routers.matches.update_ratings", _noop_update_ratings)
+    monkeypatch.setattr(
+        "app.routers.matches.update_player_metrics", _noop_update_metrics
+    )
+    monkeypatch.setattr("app.routers.matches.broadcast", _noop_broadcast)
+
+    with TestClient(app) as client:
+        tid = client.post(
+            "/tournaments", json={"sport": "padel", "name": "Winter Cup"}
+        ).json()["id"]
+
+        stage_resp = client.post(
+            f"/tournaments/{tid}/stages", json={"type": "round_robin"}
+        )
+        assert stage_resp.status_code == 200
+        sid = stage_resp.json()["id"]
+
+        resp = client.post(
+            f"/tournaments/{tid}/stages/{sid}/schedule",
+            json={"playerIds": ["p1", "p2", "p3", "p4"], "rulesetId": "padel-default"},
+        )
+        assert resp.status_code == 400
+        payload = resp.json()
+        assert payload["detail"] == "stage type does not support automatic scheduling"
+
+
+@pytest.mark.anyio
+async def test_stage_schedule_and_standings_flow(monkeypatch):
+    from app import db
+    from app.models import (
+        Sport,
+        Tournament,
+        Stage,
+        Player,
+        RuleSet,
+        Match,
+        MatchParticipant,
+        StageStanding,
+        ScoreEvent,
+    )
+    from app.routers import tournaments, matches
+    from app.routers.admin import require_admin
+    from app.routers.auth import get_current_user
+
+    db.engine = None
+    db.AsyncSessionLocal = None
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            db.Base.metadata.create_all,
+            tables=[
+                Sport.__table__,
+                Tournament.__table__,
+                Stage.__table__,
+                Player.__table__,
+                RuleSet.__table__,
+                Match.__table__,
+                MatchParticipant.__table__,
+                StageStanding.__table__,
+                ScoreEvent.__table__,
+            ],
+        )
+
+    async with db.AsyncSessionLocal() as session:
+        session.add(Sport(id="padel", name="Padel"))
+        session.add(
+            RuleSet(id="padel-default", sport_id="padel", name="Padel", config={})
+        )
+        for idx in range(4):
+            session.add(Player(id=f"p{idx+1}", name=f"Player {idx+1}"))
+        await session.commit()
+
+    app = FastAPI()
+    app.include_router(tournaments.router)
+    app.include_router(matches.router)
+
+    admin_user = SimpleNamespace(id="admin", is_admin=True)
+
+    async def _admin_dep():
+        return admin_user
+
+    app.dependency_overrides[require_admin] = _admin_dep
+    app.dependency_overrides[get_current_user] = _admin_dep
+
+    async def _noop_update_ratings(*args, **kwargs):
+        return None
+
+    async def _noop_update_metrics(*args, **kwargs):
+        return None
+
+    async def _noop_broadcast(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.routers.matches.update_ratings", _noop_update_ratings)
+    monkeypatch.setattr(
+        "app.routers.matches.update_player_metrics", _noop_update_metrics
+    )
+    monkeypatch.setattr("app.routers.matches.broadcast", _noop_broadcast)
+
+    with TestClient(app) as client:
+        tid = client.post(
+            "/tournaments", json={"sport": "padel", "name": "Americano"}
+        ).json()["id"]
+        sid = client.post(
+            f"/tournaments/{tid}/stages",
+            json={"type": "americano", "config": {"format": "americano"}},
+        ).json()["id"]
+
+        schedule_resp = client.post(
+            f"/tournaments/{tid}/stages/{sid}/schedule",
+            json={"playerIds": ["p1", "p2", "p3", "p4"], "rulesetId": "padel-default"},
+        )
+        assert schedule_resp.status_code == 200
+        schedule_payload = schedule_resp.json()
+        assert schedule_payload["stageId"] == sid
+        assert len(schedule_payload["matches"]) == 1
+
+        match_info = schedule_payload["matches"][0]
+        assert match_info["stageId"] == sid
+        assert match_info["rulesetId"] == "padel-default"
+        participants = {p["side"]: p["playerIds"] for p in match_info["participants"]}
+        assert participants["A"] == ["p1", "p2"]
+        assert participants["B"] == ["p3", "p4"]
+
+        standings_resp = client.get(
+            f"/tournaments/{tid}/stages/{sid}/standings"
+        )
+        assert standings_resp.status_code == 200
+        standings_payload = standings_resp.json()
+        assert standings_payload["stageId"] == sid
+        assert len(standings_payload["standings"]) == 4
+        assert all(entry["matchesPlayed"] == 0 for entry in standings_payload["standings"])
+
+        match_id = match_info["id"]
+        result_resp = client.post(
+            f"/matches/{match_id}/sets",
+            json={"sets": [{"A": 6, "B": 4}, {"A": 6, "B": 3}]},
+        )
+        assert result_resp.status_code == 200
+
+        updated = client.get(f"/tournaments/{tid}/stages/{sid}/standings").json()
+        stats = {row["playerId"]: row for row in updated["standings"]}
+        assert stats["p1"]["wins"] == 1
+        assert stats["p2"]["wins"] == 1
+        assert stats["p3"]["losses"] == 1
+        assert stats["p4"]["losses"] == 1
+        assert stats["p1"]["matchesPlayed"] == 1
+        assert stats["p3"]["pointsScored"] == 7
+        assert stats["p1"]["pointsScored"] == 12
+        assert stats["p1"]["pointsDiff"] == 5
+        assert stats["p3"]["pointsDiff"] == -5
+        assert stats["p1"]["points"] == 3
+        assert stats["p3"]["points"] == 0


### PR DESCRIPTION
## Summary
- add a JSON config column to stages and create the stage_standing table with an Alembic migration
- provide tournament services to validate stage types, schedule Americano matches, and rebuild standings
- extend schemas and routers with scheduling and standings endpoints and ensure match updates recalc standings
- add tests covering scheduling validation and standings updates

## Testing
- pytest backend/tests/test_tournaments.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a7cd0a08832393f3028d0ab4054f