### PR TITLE
Add tournament management UI and API helpers

### DIFF
--- a/apps/web/src/app/__tests__/tournaments.page.test.tsx
+++ b/apps/web/src/app/__tests__/tournaments.page.test.tsx
@@ -1,0 +1,228 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TournamentsClient from '../tournaments/tournaments-client';
+import TournamentDetailPage from '../tournaments/[id]/page';
+import {
+  apiFetch,
+  createStage,
+  createTournament,
+  scheduleAmericanoStage,
+  fetchStageStandings,
+  listStageMatches,
+  isAdmin,
+  type StageScheduleMatch,
+  type StageStandings,
+} from '../../lib/api';
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>(
+    '../../lib/api'
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+    createStage: vi.fn(),
+    createTournament: vi.fn(),
+    scheduleAmericanoStage: vi.fn(),
+    fetchStageStandings: vi.fn(),
+    listStageMatches: vi.fn(),
+    isAdmin: vi.fn(),
+  };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedCreateTournament = vi.mocked(createTournament);
+const mockedCreateStage = vi.mocked(createStage);
+const mockedScheduleAmericanoStage = vi.mocked(scheduleAmericanoStage);
+const mockedFetchStageStandings = vi.mocked(fetchStageStandings);
+const mockedListStageMatches = vi.mocked(listStageMatches);
+const mockedIsAdmin = vi.mocked(isAdmin);
+
+const jsonResponse = (data: unknown): Response =>
+  ({
+    ok: true,
+    json: async () => data,
+  } as Response);
+
+describe('Tournaments client view', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedCreateTournament.mockReset();
+    mockedCreateStage.mockReset();
+    mockedScheduleAmericanoStage.mockReset();
+    mockedIsAdmin.mockReset();
+    mockedIsAdmin.mockReturnValue(true);
+  });
+
+  it('renders tournaments and appends newly created entries', async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { id: 'padel', name: 'Padel' },
+        ])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          players: [
+            { id: 'p1', name: 'Alex' },
+            { id: 'p2', name: 'Billie' },
+            { id: 'p3', name: 'Casey' },
+            { id: 'p4', name: 'Devon' },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { id: 'padel-default', name: 'Padel Default' },
+        ])
+      );
+
+    const initial = [
+      { id: 't-existing', sport: 'padel', name: 'Existing Cup' },
+    ];
+
+    mockedCreateTournament.mockResolvedValue({
+      id: 't-new',
+      sport: 'padel',
+      name: 'Winter Americano',
+    });
+    mockedCreateStage.mockResolvedValue({
+      id: 's1',
+      tournamentId: 't-new',
+      type: 'americano',
+      config: { format: 'americano' },
+    });
+    const scheduledMatches: StageScheduleMatch[] = [
+      {
+        id: 'm1',
+        sport: 'padel',
+        stageId: 's1',
+        rulesetId: 'padel-default',
+        participants: [
+          { id: 'pa', side: 'A', playerIds: ['p1', 'p2'] },
+          { id: 'pb', side: 'B', playerIds: ['p3', 'p4'] },
+        ],
+      },
+    ];
+    mockedScheduleAmericanoStage.mockResolvedValue({
+      stageId: 's1',
+      matches: scheduledMatches,
+    });
+
+    render(<TournamentsClient initialTournaments={initial} loadError={false} />);
+
+    const nameInput = await screen.findByLabelText('Tournament name');
+    fireEvent.change(nameInput, { target: { value: 'Winter Americano' } });
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    });
+
+    const playerCheckboxes = screen.getAllByRole('checkbox');
+    playerCheckboxes.slice(0, 4).forEach((box) => fireEvent.click(box));
+
+    const submitButton = screen.getByRole('button', { name: /create and schedule/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockedCreateTournament).toHaveBeenCalledWith({
+        sport: 'padel',
+        name: 'Winter Americano',
+      });
+    });
+    expect(mockedCreateStage).toHaveBeenCalledWith('t-new', {
+      type: 'americano',
+      config: { format: 'americano' },
+    });
+    expect(mockedScheduleAmericanoStage).toHaveBeenCalledWith('t-new', 's1', {
+      playerIds: ['p1', 'p2', 'p3', 'p4'],
+      rulesetId: 'padel-default',
+    });
+
+    expect(
+      await screen.findByText(/Created Winter Americano with 1 scheduled match./i)
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Existing Cup')).toBeInTheDocument();
+    expect(screen.getByText('Winter Americano')).toBeInTheDocument();
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+    expect(screen.getByText('Billie')).toBeInTheDocument();
+  });
+});
+
+describe('Tournament detail page', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedFetchStageStandings.mockReset();
+    mockedListStageMatches.mockReset();
+    mockedIsAdmin.mockReset();
+  });
+
+  it('renders schedule and standings from API helpers', async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ id: 't1', sport: 'padel', name: 'Championship' })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'stage-1', tournamentId: 't1', type: 'americano', config: null }])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { id: 'p1', name: 'Player One' },
+          { id: 'p2', name: 'Player Two' },
+          { id: 'p3', name: 'Player Three' },
+          { id: 'p4', name: 'Player Four' },
+        ])
+      );
+
+    const matches: StageScheduleMatch[] = [
+      {
+        id: 'm1',
+        sport: 'padel',
+        stageId: 'stage-1',
+        rulesetId: 'padel-default',
+        participants: [
+          { id: 'pa', side: 'A', playerIds: ['p1', 'p2'] },
+          { id: 'pb', side: 'B', playerIds: ['p3', 'p4'] },
+        ],
+      },
+    ];
+    const standings: StageStandings = {
+      stageId: 'stage-1',
+      standings: [
+        {
+          playerId: 'p1',
+          matchesPlayed: 1,
+          wins: 1,
+          losses: 0,
+          draws: 0,
+          pointsScored: 12,
+          pointsAllowed: 7,
+          pointsDiff: 5,
+          setsWon: 2,
+          setsLost: 0,
+          points: 3,
+        },
+      ],
+    };
+    mockedListStageMatches.mockResolvedValue(matches);
+    mockedFetchStageStandings.mockResolvedValue(standings);
+
+    const element = await TournamentDetailPage({ params: { id: 't1' } });
+    render(element);
+
+    expect(await screen.findByText('Championship')).toBeInTheDocument();
+    expect(screen.getByText('Stage: Americano')).toBeInTheDocument();
+    expect(screen.getByText('Player One')).toBeInTheDocument();
+    expect(screen.getByText('Player Four')).toBeInTheDocument();
+    expect(screen.getByText('Points')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /record a match/i })).toBeInTheDocument();
+
+    expect(mockedListStageMatches).toHaveBeenCalledWith('t1', 'stage-1', {
+      cache: 'no-store',
+    });
+    expect(mockedFetchStageStandings).toHaveBeenCalledWith('t1', 'stage-1', {
+      cache: 'no-store',
+    });
+  });
+});

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -117,6 +117,16 @@ export default function Header() {
             <>
               <li>
                 <Link
+                  href={ensureTrailingSlash('/tournaments')}
+                  className={linkClassName('/tournaments')}
+                  aria-current={linkAriaCurrent('/tournaments')}
+                  onClick={() => setOpen(false)}
+                >
+                  Tournaments
+                </Link>
+              </li>
+              <li>
+                <Link
                   href={ensureTrailingSlash('/admin/matches')}
                   className={linkClassName('/admin/matches')}
                   aria-current={linkAriaCurrent('/admin/matches')}

--- a/apps/web/src/app/tournaments/[id]/page.tsx
+++ b/apps/web/src/app/tournaments/[id]/page.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  apiFetch,
+  fetchStageStandings,
+  listStageMatches,
+  withAbsolutePhotoUrl,
+  type ApiError,
+  type StageScheduleMatch,
+  type StageStandings,
+  type StageSummary,
+  type TournamentSummary,
+} from "../../../lib/api";
+import type { PlayerInfo } from "../../../components/PlayerName";
+import StageScheduleTable from "../stage-schedule";
+import StageStandings from "../stage-standings";
+import { ensureTrailingSlash } from "../../../lib/routes";
+
+async function fetchTournament(id: string): Promise<TournamentSummary> {
+  try {
+    const res = await apiFetch(`/v0/tournaments/${id}`, { cache: "no-store" });
+    return (await res.json()) as TournamentSummary;
+  } catch (error) {
+    const apiError = error as ApiError | undefined;
+    if (apiError?.status === 404) {
+      notFound();
+    }
+    throw error;
+  }
+}
+
+async function fetchStages(tournamentId: string): Promise<StageSummary[]> {
+  try {
+    const res = await apiFetch(`/v0/tournaments/${tournamentId}/stages`, {
+      cache: "no-store",
+    });
+    return (await res.json()) as StageSummary[];
+  } catch (error) {
+    console.error("Failed to load tournament stages", error);
+    return [];
+  }
+}
+
+async function fetchPlayersByIds(ids: string[]): Promise<Map<string, PlayerInfo>> {
+  const uniqueIds = Array.from(new Set(ids)).filter(Boolean);
+  const map = new Map<string, PlayerInfo>();
+  if (uniqueIds.length === 0) {
+    return map;
+  }
+
+  try {
+    const res = await apiFetch(
+      `/v0/players/by-ids?ids=${uniqueIds.map(encodeURIComponent).join(",")}`,
+      { cache: "no-store" }
+    );
+    const players = (await res.json()) as PlayerInfo[];
+    players.forEach((player) => {
+      if (player.id) {
+        map.set(player.id, withAbsolutePhotoUrl(player));
+      }
+    });
+  } catch (error) {
+    console.error("Failed to load player names for stage", error);
+  }
+
+  uniqueIds.forEach((id) => {
+    if (!map.has(id)) {
+      map.set(id, { id, name: "Unknown player" });
+    }
+  });
+
+  return map;
+}
+
+function describeStageType(stage: StageSummary): string {
+  const label = stage.type.replace(/_/g, " ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+export default async function TournamentDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const tournament = await fetchTournament(params.id);
+  const stages = await fetchStages(params.id);
+
+  const stageData = await Promise.all(
+    stages.map(async (stage) => {
+      let matches: StageScheduleMatch[] = [];
+      let standings: StageStandings | null = null;
+
+      try {
+        matches = await listStageMatches(params.id, stage.id, {
+          cache: "no-store",
+        });
+      } catch (error) {
+        console.error("Failed to load matches for stage", error);
+      }
+
+      try {
+        standings = await fetchStageStandings(params.id, stage.id, {
+          cache: "no-store",
+        });
+      } catch (error) {
+        console.error("Failed to load standings for stage", error);
+      }
+
+      const playerIds = new Set<string>();
+      matches.forEach((match) => {
+        match.participants.forEach((participant) => {
+          participant.playerIds.forEach((id) => playerIds.add(id));
+        });
+      });
+      standings?.standings.forEach((row) => playerIds.add(row.playerId));
+
+      const players = await fetchPlayersByIds(Array.from(playerIds));
+
+      return {
+        stage,
+        matches,
+        standings: standings?.standings ?? [],
+        players,
+      };
+    })
+  );
+
+  return (
+    <main className="container">
+      <nav aria-label="Breadcrumb" style={{ marginBottom: 12 }}>
+        <Link href={ensureTrailingSlash("/tournaments")} className="link-button">
+          ← Back to tournaments
+        </Link>
+      </nav>
+      <h1 className="heading">{tournament.name}</h1>
+      <p className="form-hint">Sport: {tournament.sport}</p>
+      <div style={{ margin: "12px 0" }}>
+        <Link
+          href={ensureTrailingSlash(`/record/${tournament.sport}`)}
+          className="link-button"
+        >
+          Record a match for this sport
+        </Link>
+      </div>
+      {stageData.length === 0 ? (
+        <p className="form-hint">No stages have been configured yet.</p>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          {stageData.map(({ stage, matches, standings, players }) => (
+            <section key={stage.id} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              <h2 style={{ fontSize: 20, fontWeight: 700 }}>
+                Stage: {describeStageType(stage)}
+              </h2>
+              <StageScheduleTable
+                matches={matches}
+                playerLookup={players}
+                title="Scheduled matches"
+                emptyLabel="Matches will appear once the stage has been scheduled."
+              />
+              <StageStandings
+                standings={standings}
+                playerLookup={players}
+                title="Leaderboard"
+              />
+            </section>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/tournaments/create-tournament-form.tsx
+++ b/apps/web/src/app/tournaments/create-tournament-form.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+} from "react";
+import {
+  apiFetch,
+  createStage,
+  createTournament,
+  scheduleAmericanoStage,
+  isAdmin,
+  type StageScheduleMatch,
+  type TournamentSummary,
+} from "../../lib/api";
+import type { PlayerInfo } from "../../components/PlayerName";
+import StageScheduleTable from "./stage-schedule";
+
+interface SportOption {
+  id: string;
+  name: string;
+}
+
+interface PlayerOption {
+  id: string;
+  name: string;
+}
+
+interface RulesetOption {
+  id: string;
+  name: string;
+}
+
+interface CreateTournamentFormProps {
+  onCreated?: (tournament: TournamentSummary) => void;
+}
+
+const MIN_AMERICANO_PLAYERS = 4;
+
+export default function CreateTournamentForm({
+  onCreated,
+}: CreateTournamentFormProps) {
+  const [admin, setAdmin] = useState(() => isAdmin());
+  const [sports, setSports] = useState<SportOption[]>([]);
+  const [players, setPlayers] = useState<PlayerOption[]>([]);
+  const [rulesets, setRulesets] = useState<RulesetOption[]>([]);
+  const [sportId, setSportId] = useState("");
+  const [rulesetId, setRulesetId] = useState("");
+  const [name, setName] = useState("");
+  const [selectedPlayers, setSelectedPlayers] = useState<string[]>([]);
+  const [loadingSports, setLoadingSports] = useState(false);
+  const [loadingPlayers, setLoadingPlayers] = useState(false);
+  const [loadingRulesets, setLoadingRulesets] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [scheduledMatches, setScheduledMatches] = useState<StageScheduleMatch[]>([]);
+
+  useEffect(() => {
+    const update = () => setAdmin(isAdmin());
+    window.addEventListener("storage", update);
+    return () => window.removeEventListener("storage", update);
+  }, []);
+
+  const loadSports = useCallback(async () => {
+    setLoadingSports(true);
+    try {
+      const res = await apiFetch("/v0/sports", { cache: "no-store" });
+      const data = (await res.json()) as SportOption[];
+      setSports(data);
+      if (!sportId && data.length) {
+        setSportId(data[0].id);
+      }
+    } catch (err) {
+      console.error("Failed to load sports", err);
+      setSports([]);
+    } finally {
+      setLoadingSports(false);
+    }
+  }, [sportId]);
+
+  const loadPlayers = useCallback(async () => {
+    setLoadingPlayers(true);
+    try {
+      const res = await apiFetch("/v0/players", { cache: "no-store" });
+      const data = (await res.json()) as { players: PlayerOption[] };
+      setPlayers(data.players || []);
+    } catch (err) {
+      console.error("Failed to load players", err);
+      setPlayers([]);
+    } finally {
+      setLoadingPlayers(false);
+    }
+  }, []);
+
+  const loadRulesets = useCallback(async (sport: string) => {
+    if (!sport) {
+      setRulesets([]);
+      setRulesetId("");
+      return;
+    }
+    setLoadingRulesets(true);
+    try {
+      const res = await apiFetch(
+        `/v0/rulesets?sport=${encodeURIComponent(sport)}`,
+        { cache: "no-store" }
+      );
+      const data = (await res.json()) as RulesetOption[];
+      setRulesets(data);
+      if (data.length) {
+        setRulesetId(data[0].id);
+      } else {
+        setRulesetId("");
+      }
+    } catch (err) {
+      console.error("Failed to load rulesets", err);
+      setRulesets([]);
+      setRulesetId("");
+    } finally {
+      setLoadingRulesets(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!admin) return;
+    loadSports();
+    loadPlayers();
+  }, [admin, loadSports, loadPlayers]);
+
+  useEffect(() => {
+    if (!admin) return;
+    loadRulesets(sportId);
+  }, [admin, sportId, loadRulesets]);
+
+  const playerLookup = useMemo(() => {
+    const map = new Map<string, PlayerInfo>();
+    players.forEach((player) => {
+      map.set(player.id, { id: player.id, name: player.name });
+    });
+    return map;
+  }, [players]);
+
+  const handlePlayerToggle = (playerId: string) => {
+    setError(null);
+    setSuccess(null);
+    setScheduledMatches([]);
+    setSelectedPlayers((prev) => {
+      if (prev.includes(playerId)) {
+        return prev.filter((id) => id !== playerId);
+      }
+      return [...prev, playerId];
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (creating) return;
+
+    const trimmedName = name.trim();
+    if (!trimmedName || !sportId) {
+      setError("Enter a name and select a sport.");
+      return;
+    }
+
+    if (
+      selectedPlayers.length < MIN_AMERICANO_PLAYERS ||
+      selectedPlayers.length % 2 !== 0
+    ) {
+      setError("Americano tournaments require an even number of at least four players.");
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    setSuccess(null);
+    setScheduledMatches([]);
+
+    try {
+      const tournament = await createTournament({ sport: sportId, name: trimmedName });
+      const stage = await createStage(tournament.id, {
+        type: "americano",
+        config: { format: "americano" },
+      });
+      const schedule = await scheduleAmericanoStage(tournament.id, stage.id, {
+        playerIds: selectedPlayers,
+        rulesetId: rulesetId || undefined,
+      });
+      setScheduledMatches(schedule.matches);
+      setSuccess(
+        `Created ${tournament.name} with ${schedule.matches.length} scheduled match${
+          schedule.matches.length === 1 ? "" : "es"
+        }.`
+      );
+      onCreated?.(tournament);
+      setName("");
+      setSelectedPlayers([]);
+    } catch (err) {
+      console.error("Failed to create tournament", err);
+      setError("Unable to create tournament. Please try again.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (!admin) {
+    return null;
+  }
+
+  const selectedCount = selectedPlayers.length;
+  const playerValidationMessage = selectedCount
+    ? `${selectedCount} player${selectedCount === 1 ? "" : "s"} selected`
+    : "Select players to include in the Americano schedule.";
+
+  return (
+    <section className="card" style={{ padding: 16 }}>
+      <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 12 }}>
+        Admin: Create Americano tournament
+      </h2>
+      <form onSubmit={handleSubmit} aria-label="Create tournament">
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div className="form-field">
+            <label className="form-label" htmlFor="tournament-name">
+              Tournament name
+            </label>
+            <input
+              id="tournament-name"
+              type="text"
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                setError(null);
+                setSuccess(null);
+                setScheduledMatches([]);
+              }}
+              placeholder="Autumn Americano"
+            />
+          </div>
+          <div className="form-field">
+            <label className="form-label" htmlFor="tournament-sport">
+              Sport
+            </label>
+            <select
+              id="tournament-sport"
+              value={sportId}
+              onChange={(event) => {
+                setSportId(event.target.value);
+                setError(null);
+                setSuccess(null);
+                setScheduledMatches([]);
+              }}
+              disabled={loadingSports}
+            >
+              {sports.map((sport) => (
+                <option key={sport.id} value={sport.id}>
+                  {sport.name}
+                </option>
+              ))}
+            </select>
+            {loadingSports && <p className="form-hint">Loading sports…</p>}
+          </div>
+          <div className="form-field">
+            <label className="form-label" htmlFor="tournament-ruleset">
+              Preferred ruleset (optional)
+            </label>
+            <select
+              id="tournament-ruleset"
+              value={rulesetId}
+              onChange={(event) => setRulesetId(event.target.value)}
+              disabled={loadingRulesets || rulesets.length === 0}
+            >
+              <option value="">Use sport default</option>
+              {rulesets.map((ruleset) => (
+                <option key={ruleset.id} value={ruleset.id}>
+                  {ruleset.name}
+                </option>
+              ))}
+            </select>
+            {loadingRulesets && <p className="form-hint">Loading rulesets…</p>}
+          </div>
+          <fieldset className="form-fieldset">
+            <legend className="form-legend">Players</legend>
+            {loadingPlayers ? (
+              <p className="form-hint">Loading players…</p>
+            ) : (
+              <div
+                style={{
+                  display: "grid",
+                  gap: 8,
+                  gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                }}
+              >
+                {players.map((player) => {
+                  const checkboxId = `player-${player.id}`;
+                  const checked = selectedPlayers.includes(player.id);
+                  return (
+                    <label
+                      key={player.id}
+                      className="form-field"
+                      htmlFor={checkboxId}
+                      style={{ flexDirection: "row", alignItems: "center", gap: 8 }}
+                    >
+                      <input
+                        id={checkboxId}
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => handlePlayerToggle(player.id)}
+                      />
+                      <span className="form-label" style={{ margin: 0 }}>
+                        {player.name}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            <p className="form-hint" style={{ marginTop: 8 }}>
+              {playerValidationMessage}
+            </p>
+          </fieldset>
+          {error && (
+            <p className="error" role="alert">
+              {error}
+            </p>
+          )}
+      {success && (
+        <p className="form-hint" role="status">
+          {success}
+        </p>
+      )}
+          <button type="submit" disabled={creating}>
+            {creating ? "Creating tournament…" : "Create and schedule"}
+          </button>
+        </div>
+      </form>
+      {scheduledMatches.length > 0 && (
+        <div style={{ marginTop: 16 }}>
+          <StageScheduleTable
+            matches={scheduledMatches}
+            playerLookup={playerLookup}
+            title="Generated schedule"
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/tournaments/page.tsx
+++ b/apps/web/src/app/tournaments/page.tsx
@@ -1,0 +1,27 @@
+import TournamentsClient from "./tournaments-client";
+import { listTournaments, type TournamentSummary } from "../../lib/api";
+
+export default async function TournamentsPage() {
+  let tournaments: TournamentSummary[] = [];
+  let loadError = false;
+
+  try {
+    tournaments = await listTournaments({ cache: "no-store" });
+  } catch (err) {
+    console.error("Failed to load tournaments", err);
+    loadError = true;
+  }
+
+  return (
+    <main className="container">
+      <h1 className="heading">Tournaments</h1>
+      <p className="form-hint">
+        Create Americano tournaments, generate schedules, and review standings.
+      </p>
+      <TournamentsClient
+        initialTournaments={tournaments}
+        loadError={loadError}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/app/tournaments/stage-schedule.tsx
+++ b/apps/web/src/app/tournaments/stage-schedule.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { StageScheduleMatch } from "../../lib/api";
+import type { PlayerInfo } from "../../components/PlayerName";
+
+export type PlayerLookup =
+  | Map<string, PlayerInfo>
+  | Record<string, PlayerInfo | undefined>;
+
+function getPlayerName(lookup: PlayerLookup, id: string): string {
+  if (lookup instanceof Map) {
+    const entry = lookup.get(id);
+    if (entry) return entry.name;
+  } else if (Object.prototype.hasOwnProperty.call(lookup, id)) {
+    const entry = lookup[id];
+    if (entry) return entry.name;
+  }
+  return "Unknown player";
+}
+
+interface StageScheduleTableProps {
+  matches: StageScheduleMatch[];
+  playerLookup: PlayerLookup;
+  title?: string;
+  emptyLabel?: string;
+}
+
+export default function StageScheduleTable({
+  matches,
+  playerLookup,
+  title = "Stage schedule",
+  emptyLabel = "No matches have been scheduled yet.",
+}: StageScheduleTableProps) {
+  if (!matches.length) {
+    return <p className="form-hint">{emptyLabel}</p>;
+  }
+
+  return (
+    <section className="card" style={{ padding: 16 }}>
+      <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>{title}</h3>
+      <div style={{ overflowX: "auto" }}>
+        <table className="scoreboard-table" aria-label={title}>
+          <thead>
+            <tr>
+              <th scope="col">Match</th>
+              <th scope="col">Side A</th>
+              <th scope="col">Side B</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matches.map((match, index) => {
+              const participants = match.participants
+                .slice()
+                .sort((a, b) => a.side.localeCompare(b.side));
+              const sideA = participants.find((p) => p.side === "A");
+              const sideB = participants.find((p) => p.side === "B");
+              const sideAPlayers = sideA
+                ? sideA.playerIds.map((id) => getPlayerName(playerLookup, id)).join(", ")
+                : "TBD";
+              const sideBPlayers = sideB
+                ? sideB.playerIds.map((id) => getPlayerName(playerLookup, id)).join(", ")
+                : "TBD";
+              return (
+                <tr key={match.id}>
+                  <th scope="row">
+                    Match {index + 1}
+                    {match.rulesetId && (
+                      <div className="form-hint">Ruleset: {match.rulesetId}</div>
+                    )}
+                  </th>
+                  <td>{sideAPlayers}</td>
+                  <td>{sideBPlayers}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/tournaments/stage-standings.tsx
+++ b/apps/web/src/app/tournaments/stage-standings.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { StageStanding } from "../../lib/api";
+import type { PlayerLookup } from "./stage-schedule";
+
+function resolvePlayerName(lookup: PlayerLookup, id: string): string {
+  if (lookup instanceof Map) {
+    const entry = lookup.get(id);
+    if (entry) return entry.name;
+  } else if (Object.prototype.hasOwnProperty.call(lookup, id)) {
+    const entry = lookup[id];
+    if (entry) return entry?.name ?? "Unknown player";
+  }
+  return "Unknown player";
+}
+
+interface StageStandingsProps {
+  standings: StageStanding[];
+  playerLookup: PlayerLookup;
+  title?: string;
+}
+
+export default function StageStandings({
+  standings,
+  playerLookup,
+  title = "Stage standings",
+}: StageStandingsProps) {
+  if (!standings.length) {
+    return (
+      <p className="form-hint">
+        Standings will appear after matches have been recorded.
+      </p>
+    );
+  }
+
+  return (
+    <section className="card" style={{ padding: 16 }}>
+      <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>{title}</h3>
+      <div style={{ overflowX: "auto" }}>
+        <table className="scoreboard-table" aria-label={title}>
+          <thead>
+            <tr>
+              <th scope="col">Player</th>
+              <th scope="col">Matches</th>
+              <th scope="col">Wins</th>
+              <th scope="col">Losses</th>
+              <th scope="col">Draws</th>
+              <th scope="col">Points</th>
+              <th scope="col">Points diff</th>
+            </tr>
+          </thead>
+          <tbody>
+            {standings.map((row) => (
+              <tr key={row.playerId}>
+                <th scope="row">{resolvePlayerName(playerLookup, row.playerId)}</th>
+                <td>{row.matchesPlayed}</td>
+                <td>{row.wins}</td>
+                <td>{row.losses}</td>
+                <td>{row.draws}</td>
+                <td>{row.points}</td>
+                <td>{row.pointsDiff}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/tournaments/tournaments-client.tsx
+++ b/apps/web/src/app/tournaments/tournaments-client.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ensureTrailingSlash } from "../../lib/routes";
+import type { TournamentSummary } from "../../lib/api";
+import CreateTournamentForm from "./create-tournament-form";
+
+interface TournamentsClientProps {
+  initialTournaments: TournamentSummary[];
+  loadError?: boolean;
+}
+
+export default function TournamentsClient({
+  initialTournaments,
+  loadError = false,
+}: TournamentsClientProps) {
+  const [tournaments, setTournaments] = useState(initialTournaments);
+
+  const emptyMessage = useMemo(() => {
+    if (loadError) {
+      return "Unable to load tournaments.";
+    }
+    if (tournaments.length === 0) {
+      return "No tournaments have been created yet.";
+    }
+    return null;
+  }, [loadError, tournaments.length]);
+
+  const handleTournamentCreated = (created: TournamentSummary) => {
+    setTournaments((prev) => {
+      const next = [created, ...prev];
+      next.sort((a, b) => a.name.localeCompare(b.name));
+      return next;
+    });
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <CreateTournamentForm onCreated={handleTournamentCreated} />
+      <section
+        aria-labelledby="tournament-list-heading"
+        style={{ display: "flex", flexDirection: "column", gap: 16 }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <h2 id="tournament-list-heading" className="subheading">
+            Existing tournaments
+          </h2>
+          <p className="form-hint">
+            Browse previously created tournaments and manage their stages.
+          </p>
+        </div>
+        {emptyMessage ? (
+          <p className={loadError ? "error" : "form-hint"}>{emptyMessage}</p>
+        ) : (
+          <ul style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {tournaments.map((tournament) => (
+              <li key={tournament.id} className="card" style={{ padding: 16 }}>
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 8 }}
+                >
+                  <div>
+                    <h3 style={{ fontSize: 18, fontWeight: 600 }}>
+                      {tournament.name}
+                    </h3>
+                    <p className="form-hint">Sport: {tournament.sport}</p>
+                    {tournament.clubId && (
+                      <p className="form-hint">Club: {tournament.clubId}</p>
+                    )}
+                  </div>
+                  <div>
+                    <Link
+                      href={ensureTrailingSlash(`/tournaments/${tournament.id}`)}
+                      className="link-button"
+                    >
+                      View tournament
+                    </Link>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add typed tournament and stage helper functions to the shared API client
- build tournaments index and detail experiences with admin scheduling and standings views
- introduce supporting client components and Vitest coverage for creation and detail flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ae215b848323aae79e3a80bac671