### PR TITLE
Improve loading status announcement for admin badges

### DIFF
--- a/apps/web/src/app/admin/badges/page.tsx
+++ b/apps/web/src/app/admin/badges/page.tsx
@@ -176,7 +176,11 @@ export default function AdminBadgesPage() {
           {success}
         </p>
       )}
-      {loading && <p>Loading badges...</p>}
+      {loading && (
+        <p role="status" aria-live="polite">
+          Loading badges...
+        </p>
+      )}
 
       <section className="card" style={{ marginBottom: 24 }}>
         <h2>Create new badge</h2>


### PR DESCRIPTION
## Summary
- add accessibility roles to the admin badge loading message to ensure it is announced by assistive tech

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8971055708323b3caa1603959d8f5