### PR TITLE
Add alert semantics to admin matches error message

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -164,7 +164,11 @@ export default function AdminMatchesPage() {
   return (
     <main className="container">
       <h1 className="heading">Admin Matches</h1>
-      {error && <p className="error">{error}</p>}
+      {error && (
+        <p className="error" role="alert" aria-live="assertive">
+          {error}
+        </p>
+      )}
       <ul className="match-list">
         {matches.map((m) => (
           <li key={m.id} className="card match-item">


### PR DESCRIPTION
## Summary
- ensure the admin matches error message announces itself by rendering it inside a `role="alert"` container with assertive live region semantics

## Testing
- npm install
- npm run dev (manual verification with API offline to trigger the error state)
- npx playwright@1.45.1 install chromium *(fails: network socket closed while downloading browser)*

------
https://chatgpt.com/codex/tasks/task_e_68d89710f4a88323bd0b98a307a1308a