### PR TITLE
Improve badges loading announcement

### DIFF
--- a/apps/web/src/app/admin/badges/page.tsx
+++ b/apps/web/src/app/admin/badges/page.tsx
@@ -177,9 +177,9 @@ export default function AdminBadgesPage() {
         </p>
       )}
       {loading && (
-        <p role="status" aria-live="polite">
-          Loading badges...
-        </p>
+        <div role="status" aria-live="polite" aria-atomic="true">
+          <p>Loading badges...</p>
+        </div>
       )}
 
       <section className="card" style={{ marginBottom: 24 }}>


### PR DESCRIPTION
## Summary
- wrap the admin badges loading message in a polite live region
- ensure the message only renders while data is loading to avoid distraction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a1e810ac8323a00410bdce5980b1