### PR TITLE
Improve admin match error alert accessibility

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -165,7 +165,12 @@ export default function AdminMatchesPage() {
     <main className="container">
       <h1 className="heading">Admin Matches</h1>
       {error && (
-        <p className="error" role="alert" aria-live="assertive">
+        <p
+          className="error"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
           {error}
         </p>
       )}


### PR DESCRIPTION
## Summary
- ensure the admin matches error message uses an assertive alert region so failures are announced by assistive tech

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d8a1e80d2c832389c153ad7f45765f