### PR TITLE
Fix name collision for stage standings import

### DIFF
--- a/apps/web/src/app/tournaments/[id]/page.tsx
+++ b/apps/web/src/app/tournaments/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
   withAbsolutePhotoUrl,
   type ApiError,
   type StageScheduleMatch,
-  type StageStandings,
+  type StageStandings as StageStandingsResponse,
   type StageSummary,
   type TournamentSummary,
 } from "../../../lib/api";
@@ -88,7 +88,7 @@ export default async function TournamentDetailPage({
   const stageData = await Promise.all(
     stages.map(async (stage) => {
       let matches: StageScheduleMatch[] = [];
-      let standings: StageStandings | null = null;
+      let standings: StageStandingsResponse | null = null;
 
       try {
         matches = await listStageMatches(params.id, stage.id, {


### PR DESCRIPTION
## Summary
- alias the StageStandings type import to avoid colliding with the component name
- update the local variable to use the new alias so TypeScript can compile

## Testing
- `npm run build -- --no-lint`


------
https://chatgpt.com/codex/tasks/task_e_68d8aa7901a08323a17afb1286ce5664