### PR TITLE
Add Americano leaderboard segregation

### DIFF
--- a/apps/web/src/app/leaderboard/constants.ts
+++ b/apps/web/src/app/leaderboard/constants.ts
@@ -1,6 +1,12 @@
 export const ALL_SPORTS = "all" as const;
 export const MASTER_SPORT = "master" as const;
-export const SPORTS = ["padel", "badminton", "table-tennis", "disc_golf"] as const;
+export const SPORTS = [
+  "padel",
+  "padel_americano",
+  "badminton",
+  "table-tennis",
+  "disc_golf",
+] as const;
 
 export const SPORT_OPTIONS = [ALL_SPORTS, MASTER_SPORT, ...SPORTS] as const;
 

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -56,7 +56,7 @@ describe("Leaderboard", () => {
     ).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Disc Golf" })).toBeInTheDocument();
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain(apiUrl("/v0/leaderboards?sport=disc_golf"));
   });
@@ -100,7 +100,7 @@ describe("Leaderboard", () => {
 
     render(<Leaderboard sport="all" country="SE" clubId="club-a" />);
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain(
       apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -73,6 +73,7 @@ const SPORT_ICONS: Record<LeaderboardSport, string> = {
   [ALL_SPORTS]: "🏅",
   [MASTER_SPORT]: "🌍",
   padel: "🎾",
+  padel_americano: "🎾",
   badminton: "🏸",
   "table-tennis": "🏓",
   disc_golf: "🥏",

--- a/backend/alembic/versions/0026_padel_americano_leaderboard.py
+++ b/backend/alembic/versions/0026_padel_americano_leaderboard.py
@@ -1,0 +1,36 @@
+"""Add padel_americano sport entry"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import table, column, String, select
+
+
+revision = "0026_padel_americano_leaderboard"
+down_revision = "0025_tournament_created_by_user_id"
+branch_labels = None
+depends_on = None
+
+
+sport_table = table(
+    "sport",
+    column("id", String),
+    column("name", String),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    existing = conn.execute(
+        select(sport_table.c.id).where(sport_table.c.id == "padel_americano")
+    ).scalar_one_or_none()
+    if existing is None:
+        conn.execute(
+            sport_table.insert().values(id="padel_americano", name="Padel Americano")
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sport_table.delete().where(sport_table.c.id == "padel_americano")
+    )

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -20,6 +20,7 @@ async def main():
         have = {x.id for x in existing}
         for sid, name in [
             ("padel", "Padel"),
+            ("padel_americano", "Padel Americano"),
             ("bowling", "Bowling"),
             ("tennis", "Tennis"),
             ("pickleball", "Pickleball"),

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -23,6 +23,7 @@ from app.models import (
     MatchParticipant,
     ScoreEvent,
     MasterRating,
+    Stage,
 )  # noqa: E402
 from app.routers import leaderboards  # noqa: E402
 
@@ -48,6 +49,7 @@ def setup_db():
                     Club.__table__,
                     Player.__table__,
                     Rating.__table__,
+                    Stage.__table__,
                     Match.__table__,
                     ScoreEvent.__table__,
                     MasterRating.__table__,

--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -10,6 +10,8 @@ from sqlalchemy import select, text
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from app.models import Stage
+
 
 @pytest.fixture
 def anyio_backend():
@@ -145,7 +147,12 @@ async def test_create_match_rejects_duplicate_players(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
         db.Base.metadata.create_all,
-        tables=[Sport.__table__, Match.__table__, MatchParticipant.__table__],
+        tables=[
+            Sport.__table__,
+            Stage.__table__,
+            Match.__table__,
+            MatchParticipant.__table__,
+        ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -179,6 +186,7 @@ async def test_create_match_friendly_skips_stat_updates(tmp_path, monkeypatch):
       tables=[
         Sport.__table__,
         Player.__table__,
+        Stage.__table__,
         Match.__table__,
         MatchParticipant.__table__,
         ScoreEvent.__table__,
@@ -245,7 +253,13 @@ async def test_create_match_by_name_is_case_insensitive(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
       db.Base.metadata.create_all,
-      tables=[Player.__table__, Sport.__table__, Match.__table__, MatchParticipant.__table__],
+      tables=[
+        Player.__table__,
+        Sport.__table__,
+        Stage.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+      ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -282,7 +296,12 @@ async def test_create_match_with_sets(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
       db.Base.metadata.create_all,
-      tables=[Sport.__table__, Match.__table__, MatchParticipant.__table__],
+      tables=[
+        Sport.__table__,
+        Stage.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+      ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -316,7 +335,12 @@ async def test_create_match_with_details(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
       db.Base.metadata.create_all,
-      tables=[Sport.__table__, Match.__table__, MatchParticipant.__table__],
+      tables=[
+        Sport.__table__,
+        Stage.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+      ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -348,7 +372,13 @@ async def test_create_match_by_name_with_sets(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
       db.Base.metadata.create_all,
-      tables=[Player.__table__, Sport.__table__, Match.__table__, MatchParticipant.__table__],
+      tables=[
+        Player.__table__,
+        Sport.__table__,
+        Stage.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+      ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -390,7 +420,12 @@ async def test_create_match_normalizes_timezone(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
       db.Base.metadata.create_all,
-      tables=[Sport.__table__, Match.__table__, MatchParticipant.__table__],
+      tables=[
+        Sport.__table__,
+        Stage.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+      ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -439,7 +474,11 @@ async def test_list_matches_returns_most_recent_first(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
         db.Base.metadata.create_all,
-        tables=[Sport.__table__, Match.__table__],
+        tables=[
+            Sport.__table__,
+            Stage.__table__,
+            Match.__table__,
+        ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -504,7 +543,11 @@ async def test_list_matches_upcoming_filter(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
         db.Base.metadata.create_all,
-        tables=[Sport.__table__, Match.__table__],
+        tables=[
+            Sport.__table__,
+            Stage.__table__,
+            Match.__table__,
+        ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -552,6 +595,7 @@ def test_list_matches_filters_by_player(tmp_path):
           tables=[
               Sport.__table__,
               Player.__table__,
+              Stage.__table__,
               Match.__table__,
               MatchParticipant.__table__,
           ],
@@ -756,6 +800,7 @@ async def test_delete_match_updates_ratings_and_leaderboard(tmp_path):
             Player.__table__,
             Rating.__table__,
             GlickoRating.__table__,
+            Stage.__table__,
             Match.__table__,
             ScoreEvent.__table__,
         ],
@@ -844,7 +889,12 @@ async def test_create_match_rejects_naive_date(tmp_path):
   engine = db.get_engine()
   async with engine.begin() as conn:
     await conn.run_sync(
-        db.Base.metadata.create_all, tables=[Sport.__table__, Match.__table__]
+        db.Base.metadata.create_all,
+        tables=[
+            Sport.__table__,
+            Stage.__table__,
+            Match.__table__,
+        ],
     )
 
   async with db.AsyncSessionLocal() as session:
@@ -884,7 +934,13 @@ async def test_user_with_multiple_player_records_can_modify_match(tmp_path):
   async with engine.begin() as conn:
     await conn.run_sync(
         db.Base.metadata.create_all,
-        tables=[Match.__table__, MatchParticipant.__table__, ScoreEvent.__table__, Player.__table__],
+        tables=[
+            Stage.__table__,
+            Match.__table__,
+            MatchParticipant.__table__,
+            ScoreEvent.__table__,
+            Player.__table__,
+        ],
     )
 
   async def dummy_broadcast(mid: str, message: dict) -> None:

--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -634,6 +634,7 @@ async def test_owner_can_schedule_their_americano_stage(monkeypatch):
         session.add(
             RuleSet(id="padel-default", sport_id="padel", name="Padel", config={})
         )
+        session.add(Sport(id="padel_americano", name="Padel Americano"))
         for idx in range(4):
             session.add(Player(id=f"p{idx+1}", name=f"Player {idx+1}"))
         session.add(
@@ -1043,16 +1044,23 @@ async def test_americano_match_events_trigger_rating(monkeypatch):
         assert stats["p4"]["losses"] == 1
         assert stats["p1"]["matchesPlayed"] == 1
 
-        leaderboard = client.get(
+        padel_board = client.get(
             "/leaderboards", params={"sport": "padel"}
         ).json()
-        assert {entry["playerId"] for entry in leaderboard["leaders"]} >= {
+        assert padel_board["leaders"] == []
+
+        americano_board = client.get(
+            "/leaderboards", params={"sport": "padel_americano"}
+        ).json()
+        assert {entry["playerId"] for entry in americano_board["leaders"]} >= {
             "p1",
             "p2",
             "p3",
             "p4",
         }
-        ratings = {entry["playerId"]: entry["rating"] for entry in leaderboard["leaders"]}
+        ratings = {
+            entry["playerId"]: entry["rating"] for entry in americano_board["leaders"]
+        }
         assert ratings["p1"] > ratings["p3"]
 
     async with db.AsyncSessionLocal() as session:


### PR DESCRIPTION
## Summary
- route Americano stage results to a dedicated rating bucket so padel ratings stay unaffected
- surface the new Americano leaderboard in the API, seeds, migration, and web UI options
- adjust tests to cover the Americano leaderboard expectations and add a migration for the new sport id

## Testing
- pytest tests/test_tournaments.py::test_americano_match_events_trigger_rating -q
- pnpm exec vitest run src/app/leaderboard/leaderboard.test.tsx *(fails: suite expects additional mocked elements outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68d8db2382ec83239214c8396be7b20d