### PR TITLE
Allow hard delete of soft-deleted players

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -855,7 +855,7 @@ async def delete_player(
     user: User = Depends(require_admin),
 ):
     p = await session.get(Player, player_id)
-    if not p or p.deleted_at is not None:
+    if not p or (not hard and p.deleted_at is not None):
         raise PlayerNotFound(player_id)
 
     if hard:


### PR DESCRIPTION
## Summary
- allow the admin delete handler to hard delete players even if they were already soft deleted
- add coverage ensuring a soft-deleted player can be hard deleted and removed from the database

## Testing
- pytest tests/test_players.py -k "delete" -q


------
https://chatgpt.com/codex/tasks/task_e_68d8de979b108323af6755140148e9c1