### PR TITLE
Add padel Americano recording support

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -374,7 +374,7 @@ function validateBowlingFrameInput(
 export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   const router = useRouter();
   const sport = sportId;
-  const isPadel = sport === "padel";
+  const isPadel = sport === "padel" || sport === "padel_americano";
   const isPickleball = sport === "pickleball";
   const isBowling = sport === "bowling";
 

--- a/apps/web/src/app/record/[sport]/page.test.tsx
+++ b/apps/web/src/app/record/[sport]/page.test.tsx
@@ -56,6 +56,17 @@ describe("resolveRecordSportRoute", () => {
     });
   });
 
+  it("redirects padel Americano requests using underscores to the canonical slug", () => {
+    const result = resolveRecordSportRoute({
+      params: { sport: "padel_americano" },
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      destination: "/record/padel-americano/",
+    });
+  });
+
   it("returns not-found for an unknown sport", () => {
     const result = resolveRecordSportRoute({
       params: { sport: "archery" },
@@ -70,6 +81,14 @@ describe("resolveRecordSportRoute", () => {
     });
 
     expect(result).toEqual({ type: "render", sportId: "padel" });
+  });
+
+  it("renders the dynamic form for padel Americano", () => {
+    const result = resolveRecordSportRoute({
+      params: { sport: "padel-americano" },
+    });
+
+    expect(result).toEqual({ type: "render", sportId: "padel_americano" });
   });
 });
 

--- a/apps/web/src/lib/recording.ts
+++ b/apps/web/src/lib/recording.ts
@@ -27,6 +27,12 @@ const RECORD_SPORTS: Record<string, RecordSportMeta> = {
     form: "dynamic",
     implemented: true,
   },
+  padel_americano: {
+    id: "padel_americano",
+    slug: "padel-americano",
+    form: "dynamic",
+    implemented: true,
+  },
   pickleball: {
     id: "pickleball",
     slug: "pickleball",

--- a/apps/web/src/lib/sportCopy.ts
+++ b/apps/web/src/lib/sportCopy.ts
@@ -6,6 +6,23 @@ export interface SportCopy {
   confirmationMessage?: string;
 }
 
+const padelDefaultCopy: SportCopy = {
+  matchDetailsHint:
+    'Note the match date, time and venue so partners can find the fixture later.',
+  timeHint: 'Enter the local start time so partners can follow the fixture',
+  playersHint:
+    'Pick the players for sides A and B. Leave a spot blank if a walkover occurred.',
+  scoringHint:
+    'Use the final set tally for each team (for example 6-3, 4-6, 6-4 → enter 2 and 1).',
+  confirmationMessage: 'Save this padel match result?',
+};
+
+const padelEnAuCopy: SportCopy = {
+  matchDetailsHint:
+    'Log the match details so clubmates back in Australia know when you played.',
+  confirmationMessage: 'Lock in this padel result?',
+};
+
 const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
   bowling: {
     default: {
@@ -25,21 +42,12 @@ const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
     },
   },
   padel: {
-    default: {
-      matchDetailsHint:
-        'Note the match date, time and venue so partners can find the fixture later.',
-      timeHint: 'Enter the local start time so partners can follow the fixture',
-      playersHint:
-        'Pick the players for sides A and B. Leave a spot blank if a walkover occurred.',
-      scoringHint:
-        'Use the final set tally for each team (for example 6-3, 4-6, 6-4 → enter 2 and 1).',
-      confirmationMessage: 'Save this padel match result?',
-    },
-    'en-au': {
-      matchDetailsHint:
-        'Log the match details so clubmates back in Australia know when you played.',
-      confirmationMessage: 'Lock in this padel result?',
-    },
+    default: padelDefaultCopy,
+    'en-au': padelEnAuCopy,
+  },
+  padel_americano: {
+    default: padelDefaultCopy,
+    'en-au': padelEnAuCopy,
   },
   pickleball: {
     default: {


### PR DESCRIPTION
## Summary
- add padel Americano to the recording metadata so the dynamic form can load
- reuse the existing padel copy for the new sport and default its form to doubles
- cover the new slug handling with resolveRecordSportRoute tests

## Testing
- pnpm vitest run src/app/record/[sport]/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d932f83ef483238584d61ade411396