### PR TITLE
Align leaderboard sports with recordable options

### DIFF
--- a/apps/web/src/app/leaderboard/constants.ts
+++ b/apps/web/src/app/leaderboard/constants.ts
@@ -1,9 +1,10 @@
 export const ALL_SPORTS = "all" as const;
 export const MASTER_SPORT = "master" as const;
 export const SPORTS = [
+  "bowling",
   "padel",
   "padel_americano",
-  "badminton",
+  "pickleball",
   "table-tennis",
   "disc_golf",
 ] as const;

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -56,7 +56,7 @@ describe("Leaderboard", () => {
     ).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Disc Golf" })).toBeInTheDocument();
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain(apiUrl("/v0/leaderboards?sport=disc_golf"));
   });
@@ -72,7 +72,8 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
-      apiUrl("/v0/leaderboards?sport=padel&country=SE")
+      apiUrl("/v0/leaderboards?sport=padel&country=SE"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 
@@ -87,7 +88,8 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
-      apiUrl("/v0/leaderboards?sport=padel&clubId=club-a")
+      apiUrl("/v0/leaderboards?sport=padel&clubId=club-a"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 
@@ -100,7 +102,7 @@ describe("Leaderboard", () => {
 
     render(<Leaderboard sport="all" country="SE" clubId="club-a" />);
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
     const urls = fetchMock.mock.calls.map((c) => c[0]);
     expect(urls).toContain(
       apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")
@@ -133,18 +135,18 @@ describe("Leaderboard", () => {
       .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
 
-    render(<Leaderboard sport="badminton" country="SE" />);
+    render(<Leaderboard sport="bowling" country="SE" />);
 
     await screen.findByRole("heading", {
       level: 2,
-      name: "No Badminton matches in this region yet.",
+      name: "No Bowling matches in this region yet.",
     });
     expect(
       screen.getByText("Try adjusting the filters or record a new match."),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Record a Badminton match" }),
-    ).toHaveAttribute("href", expect.stringContaining("/record/badminton"));
+      screen.getByRole("link", { name: "Record a Bowling match" }),
+    ).toHaveAttribute("href", expect.stringContaining("/record/bowling"));
   });
 
   it("shows an error message when fetching fails", async () => {

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -72,9 +72,10 @@ const canonicalizePathname = (pathname: string) => {
 const SPORT_ICONS: Record<LeaderboardSport, string> = {
   [ALL_SPORTS]: "🏅",
   [MASTER_SPORT]: "🌍",
+  bowling: "🎳",
   padel: "🎾",
   padel_americano: "🎾",
-  badminton: "🏸",
+  pickleball: "🥒",
   "table-tennis": "🏓",
   disc_golf: "🥏",
 };


### PR DESCRIPTION
## Summary
- update the leaderboard sport list to match the sports that can be recorded
- add icons for the new leaderboard sports and adjust empty states accordingly
- refresh leaderboard tests to cover the new sports and updated fetch behaviour

## Testing
- pnpm test --run src/app/leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d93c3498c8832382c0e3bd5b8f78ae