### PR TITLE
Improve padel Americano recording guidance

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -375,6 +375,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   const router = useRouter();
   const sport = sportId;
   const isPadel = sport === "padel" || sport === "padel_americano";
+  const isPadelAmericano = sport === "padel_americano";
   const isPickleball = sport === "pickleball";
   const isBowling = sport === "bowling";
 
@@ -868,6 +869,33 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
 
   return (
     <main className="container">
+      {isPadelAmericano && (
+        <section className="card" aria-labelledby="padel-americano-tips-heading">
+          <h2 id="padel-americano-tips-heading" className="heading" style={{ marginBottom: "0.75rem" }}>
+            Recording a padel Americano tie
+          </h2>
+          <p style={{ marginTop: 0 }}>
+            Review the Americano rotation before saving each tie so every player pairing is captured accurately.
+          </p>
+          <ul>
+            <li>
+              <strong>Sign in first:</strong> logging in keeps all of your Americano ties together and lets you resume an unfinished session.
+            </li>
+            <li>
+              <strong>Set the pairings:</strong> Americanos are always doubles, so pick the two players on each side exactly as shown on your rotation sheet.
+            </li>
+            <li>
+              <strong>Capture the score:</strong> enter the total points earned by each pair (for example Team A 24 – Team B 20 in a race to 32). Use the target your club prefers if it differs from 32.
+            </li>
+            <li>
+              <strong>Note session details:</strong> record the date, start time and venue so everyone can find the tie later. Mark it as friendly for social hits.
+            </li>
+            <li>
+              <strong>Need fixtures?</strong> Generate a full Americano schedule from the <a href="/tournaments/">tournaments page</a> before logging results here.
+            </li>
+          </ul>
+        </section>
+      )}
       <form onSubmit={handleSubmit} className="form-stack">
         {isPickleball && (
           <label

--- a/apps/web/src/lib/sportCopy.ts
+++ b/apps/web/src/lib/sportCopy.ts
@@ -23,6 +23,24 @@ const padelEnAuCopy: SportCopy = {
   confirmationMessage: 'Lock in this padel result?',
 };
 
+const padelAmericanoDefaultCopy: SportCopy = {
+  matchDetailsHint:
+    'Capture the Americano rotation so everyone can follow when each tie was played.',
+  timeHint:
+    'Enter the start time for this tie so the Americano session timeline stays accurate',
+  playersHint:
+    'Padel Americanos are doubles—select the two players on each side according to your rotation sheet.',
+  scoringHint:
+    'Enter the total points each pair collected (for example 24-20 in a race to 32).',
+  confirmationMessage: 'Save this padel Americano tie?',
+};
+
+const padelAmericanoEnAuCopy: SportCopy = {
+  matchDetailsHint:
+    'Log the Americano details so your Aussie crew knows when the session ran.',
+  confirmationMessage: 'Lock in this padel Americano tie?',
+};
+
 const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
   bowling: {
     default: {
@@ -46,8 +64,8 @@ const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
     'en-au': padelEnAuCopy,
   },
   padel_americano: {
-    default: padelDefaultCopy,
-    'en-au': padelEnAuCopy,
+    default: padelAmericanoDefaultCopy,
+    'en-au': padelAmericanoEnAuCopy,
   },
   pickleball: {
     default: {


### PR DESCRIPTION
## Summary
- add an Americano-specific tips card to the padel recording form so players know how to capture ties
- tailor the padel Americano copy to emphasise doubles pairings and point-based scoring

## Testing
- pnpm test -- --run *(fails: existing Vitest suites depend on mocked API responses and error with network/permission issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d93c9fa860832394992fa243aa8b94