### PR TITLE
feat(web): store and apply time zone preference

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -6,7 +6,7 @@ import { apiFetch, isAdmin, withAbsolutePhotoUrl } from "../../../lib/api";
 import { ensureTrailingSlash } from "../../../lib/routes";
 import { PlayerInfo } from "../../../components/PlayerName";
 import MatchParticipants from "../../../components/MatchParticipants";
-import { useLocale } from "../../../lib/LocaleContext";
+import { useLocale, useTimeZone } from "../../../lib/LocaleContext";
 import { formatDate } from "../../../lib/i18n";
 import { resolveParticipantGroups } from "../../../lib/participants";
 
@@ -127,9 +127,10 @@ export default function AdminMatchesPage() {
   const [matches, setMatches] = useState<EnrichedMatch[]>([]);
   const [error, setError] = useState<string | null>(null);
   const locale = useLocale();
+  const timeZone = useTimeZone();
   const formatMatchDate = useMemo(
-    () => (value: Date | string) => formatDate(value, locale),
-    [locale],
+    () => (value: Date | string) => formatDate(value, locale, undefined, timeZone),
+    [locale, timeZone],
   );
 
   const load = useCallback(async () => {

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -10,7 +10,7 @@ import {
   type MatchRow,
 } from '../lib/matches';
 import MatchParticipants from '../components/MatchParticipants';
-import { useLocale } from '../lib/LocaleContext';
+import { useLocale, useTimeZone } from '../lib/LocaleContext';
 import { ensureTrailingSlash, recordPathForSport } from '../lib/routes';
 import { formatDateTime, NEUTRAL_FALLBACK_LOCALE } from '../lib/i18n';
 
@@ -135,12 +135,13 @@ export default function HomePageClient({
   const [loadingMore, setLoadingMore] = useState(false);
   const [paginationError, setPaginationError] = useState(false);
   const localeFromContext = useLocale();
+  const timeZone = useTimeZone();
   const activeLocale =
     localeFromContext || initialLocale || NEUTRAL_FALLBACK_LOCALE;
   const formatMatchDate = useMemo(
     () => (value: Date | string | number | null | undefined) =>
-      formatDateTime(value, activeLocale, 'compact'),
-    [activeLocale],
+      formatDateTime(value, activeLocale, 'compact', timeZone),
+    [activeLocale, timeZone],
   );
 
   const parseMatchesResponse = async (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import {
   parseAcceptLanguage,
   normalizeLocale,
   LOCALE_COOKIE_KEY,
+  TIME_ZONE_COOKIE_KEY,
 } from '../lib/i18n';
 
 export const metadata = {
@@ -26,6 +27,7 @@ export default function RootLayout({
   const acceptLanguage = headerList.get('accept-language');
   const cookieStore = cookies();
   const cookieLocale = cookieStore.get(LOCALE_COOKIE_KEY)?.value ?? null;
+  const cookieTimeZone = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
   const locale = normalizeLocale(
     cookieLocale,
     parseAcceptLanguage(acceptLanguage),
@@ -37,7 +39,11 @@ export default function RootLayout({
         <a className="skip-link" href="#main-content">
           Skip to main content
         </a>
-        <LocaleProvider locale={locale} acceptLanguage={acceptLanguage}>
+        <LocaleProvider
+          locale={locale}
+          acceptLanguage={acceptLanguage}
+          timeZone={cookieTimeZone}
+        >
           <ToastProvider>
             <ChunkErrorReload />
             <Header />

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -1,11 +1,17 @@
 import Link from "next/link";
-import { headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary from "./live-summary";
 import MatchParticipants from "../../../components/MatchParticipants";
 import { PlayerInfo } from "../../../components/PlayerName";
-import { formatDate, formatDateTime, parseAcceptLanguage } from "../../../lib/i18n";
+import {
+  formatDate,
+  formatDateTime,
+  parseAcceptLanguage,
+  resolveTimeZone,
+  TIME_ZONE_COOKIE_KEY,
+} from "../../../lib/i18n";
 import { hasTimeComponent } from "../../../lib/datetime";
 import { ensureTrailingSlash } from "../../../lib/routes";
 import {
@@ -467,7 +473,10 @@ export default async function MatchDetailPage({
       </main>
     );
   }
+  const cookieStore = cookies();
   const locale = parseAcceptLanguage(headers().get("accept-language"));
+  const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
+  const timeZone = resolveTimeZone(timeZoneCookie);
 
   const parts = match.participants ?? [];
   const uniqueIds = Array.from(
@@ -519,8 +528,8 @@ export default async function MatchDetailPage({
   const playedAtDate = match.playedAt ? new Date(match.playedAt) : null;
   const playedAtStr = playedAtDate
     ? hasTimeComponent(match.playedAt)
-      ? formatDateTime(playedAtDate, locale)
-      : formatDate(playedAtDate, locale)
+      ? formatDateTime(playedAtDate, locale, undefined, timeZone)
+      : formatDate(playedAtDate, locale, undefined, timeZone)
     : "";
   const playedAtLabel = normalizeLabel(playedAtStr);
   const locationLabel = normalizeLabel(match.location);

--- a/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
@@ -25,6 +25,7 @@ vi.mock("../../../components/charts/MatchHeatmap", () => ({
 
 vi.mock("../../../lib/LocaleContext", () => ({
   useLocale: () => "en-US",
+  useTimeZone: () => "UTC",
 }));
 
 import PlayerCharts from "./PlayerCharts";

--- a/apps/web/src/app/players/[id]/PlayerCharts.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import WinRateChart, { WinRatePoint } from '../../../components/charts/WinRateChart';
 import RankingHistoryChart, { RankingPoint } from '../../../components/charts/RankingHistoryChart';
 import MatchHeatmap, { HeatmapDatum } from '../../../components/charts/MatchHeatmap';
-import { useLocale } from '../../../lib/LocaleContext';
+import { useLocale, useTimeZone } from '../../../lib/LocaleContext';
 import { formatDate } from '../../../lib/i18n';
 
 interface EnrichedMatch {
@@ -20,9 +20,10 @@ function parseMatchDate(value: string | null | undefined): Date | null {
 
 export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) {
   const locale = useLocale();
+  const timeZone = useTimeZone();
   const formatMatchDate = useMemo(
-    () => (value: Date | string) => formatDate(value, locale),
-    [locale],
+    () => (value: Date | string) => formatDate(value, locale, undefined, timeZone),
+    [locale, timeZone],
   );
   const sorted = [...matches].sort((a, b) => {
     const da = parseMatchDate(a.playedAt)?.getTime() ?? 0;

--- a/apps/web/src/app/user-settings.ts
+++ b/apps/web/src/app/user-settings.ts
@@ -1,6 +1,12 @@
 import { ALL_SPORTS, SPORT_OPTIONS } from "./leaderboard/constants";
 import { COUNTRY_OPTIONS } from "../lib/countries";
-import { normalizeLocale, storeLocalePreference } from "../lib/i18n";
+import {
+  normalizeLocale,
+  storeLocalePreference,
+  normalizeTimeZone,
+  storeTimeZonePreference,
+  clearStoredTimeZone,
+} from "../lib/i18n";
 
 export const USER_SETTINGS_STORAGE_KEY = "cst:user-settings";
 export const USER_SETTINGS_CHANGED_EVENT = "cst:user-settings-change";
@@ -13,6 +19,7 @@ export interface UserSettings {
   defaultLeaderboardCountry: string;
   weeklySummaryEmails: boolean;
   preferredLocale: string;
+  preferredTimeZone: string;
 }
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
@@ -20,6 +27,7 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   defaultLeaderboardCountry: "",
   weeklySummaryEmails: true,
   preferredLocale: "",
+  preferredTimeZone: "",
 };
 
 export function getDefaultUserSettings(): UserSettings {
@@ -76,6 +84,14 @@ function sanitizePreferredLocale(value: unknown): string {
   return normalized;
 }
 
+function sanitizePreferredTimeZone(value: unknown): string {
+  if (typeof value !== "string") {
+    return DEFAULT_USER_SETTINGS.preferredTimeZone;
+  }
+  const normalized = normalizeTimeZone(value, "");
+  return normalized;
+}
+
 export type PartialUserSettings = Partial<UserSettings> | null | undefined;
 
 export function normalizeUserSettings(value: PartialUserSettings): UserSettings {
@@ -91,6 +107,7 @@ export function normalizeUserSettings(value: PartialUserSettings): UserSettings 
       DEFAULT_USER_SETTINGS.weeklySummaryEmails,
     ),
     preferredLocale: sanitizePreferredLocale(record.preferredLocale),
+    preferredTimeZone: sanitizePreferredTimeZone(record.preferredTimeZone),
   };
 }
 
@@ -124,6 +141,7 @@ export function saveUserSettings(settings: PartialUserSettings): UserSettings {
     window.dispatchEvent(new Event(USER_SETTINGS_CHANGED_EVENT));
   }
   storeLocalePreference(normalized.preferredLocale);
+  storeTimeZonePreference(normalized.preferredTimeZone);
   return normalized;
 }
 
@@ -135,7 +153,8 @@ export function areUserSettingsEqual(
     a.defaultLeaderboardSport === b.defaultLeaderboardSport &&
     a.defaultLeaderboardCountry === b.defaultLeaderboardCountry &&
     a.weeklySummaryEmails === b.weeklySummaryEmails &&
-    a.preferredLocale === b.preferredLocale
+    a.preferredLocale === b.preferredLocale &&
+    a.preferredTimeZone === b.preferredTimeZone
   );
 }
 
@@ -147,6 +166,7 @@ export function clearUserSettings(): void {
     // Ignore storage errors.
   }
   storeLocalePreference("");
+  clearStoredTimeZone();
   if (typeof window !== "undefined") {
     window.dispatchEvent(new Event(USER_SETTINGS_CHANGED_EVENT));
   }

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -6,6 +6,7 @@ import {
   formatDateTime,
   LOCALE_STORAGE_KEY,
   LOCALE_COOKIE_KEY,
+  TIME_ZONE_COOKIE_KEY,
 } from './i18n';
 import {
   USER_SETTINGS_CHANGED_EVENT,
@@ -17,6 +18,7 @@ describe('LocaleProvider', () => {
     vi.restoreAllMocks();
     window.localStorage.clear();
     document.cookie = `${LOCALE_COOKIE_KEY}=; path=/; max-age=0`;
+    document.cookie = `${TIME_ZONE_COOKIE_KEY}=; path=/; max-age=0`;
     document.documentElement.lang = '';
   });
 

--- a/apps/web/src/lib/i18n.test.ts
+++ b/apps/web/src/lib/i18n.test.ts
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearStoredTimeZone,
+  DEFAULT_TIME_ZONE,
+  getStoredTimeZone,
+  resolveTimeZone,
+  storeTimeZonePreference,
+  TIME_ZONE_COOKIE_KEY,
+  TIME_ZONE_STORAGE_KEY,
+} from './i18n';
+
+describe('time zone resolution', () => {
+  afterEach(() => {
+    clearStoredTimeZone();
+    window.localStorage.clear();
+    document.cookie = `${TIME_ZONE_COOKIE_KEY}=; path=/; max-age=0`;
+  });
+
+  it('prefers an explicit time zone argument when provided', () => {
+    expect(resolveTimeZone('America/New_York')).toBe('America/New_York');
+  });
+
+  it('prefers stored preferences before falling back to detection', () => {
+    storeTimeZonePreference('Asia/Tokyo');
+    expect(window.localStorage.getItem(TIME_ZONE_STORAGE_KEY)).toBe('Asia/Tokyo');
+    expect(resolveTimeZone(null)).toBe('Asia/Tokyo');
+  });
+
+  it('falls back to UTC when detection is unavailable', () => {
+    const spy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(() => {
+        throw new Error('no detection');
+      });
+
+    expect(resolveTimeZone('')).toBe(DEFAULT_TIME_ZONE);
+
+    spy.mockRestore();
+  });
+
+  it('ignores invalid stored values', () => {
+    storeTimeZonePreference('Invalid/Zone');
+    expect(getStoredTimeZone()).toBeNull();
+    expect(resolveTimeZone(null)).toBe(DEFAULT_TIME_ZONE);
+  });
+});


### PR DESCRIPTION
## Summary
- add time zone storage helpers and update date/time formatting to respect a preferred time zone with a neutral UTC fallback
- capture the preferred time zone in user settings and the profile form, persisting to cookies/localStorage and LocaleProvider
- propagate the stored time zone through server and client rendering paths and add focused unit coverage for the new helpers

## Testing
- pnpm vitest run src/lib/i18n.test.ts src/lib/LocaleContext.test.tsx src/app/players/[id]/PlayerCharts.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9edcbc9648323a4c324648d4ceb7c