### PR TITLE
feat(web): centralize server locale resolution

### DIFF
--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -13,9 +13,10 @@ vi.mock('../../lib/api', async () => {
   };
 });
 
-vi.mock('next/headers', () => ({
-  headers: () => ({
-    get: () => 'en-GB',
+vi.mock('../../lib/server-locale', () => ({
+  resolveServerLocale: () => ({
+    locale: 'en-GB',
+    acceptLanguage: 'en-GB',
   }),
 }));
 

--- a/apps/web/src/app/__tests__/matches.server.test.tsx
+++ b/apps/web/src/app/__tests__/matches.server.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LOCALE_COOKIE_KEY } from '../../lib/i18n';
+
+const { mockHeadersGet, mockCookiesGet } = vi.hoisted(() => {
+  return {
+    mockHeadersGet: vi.fn<(name: string) => string | null>(),
+    mockCookiesGet: vi.fn<
+      (name: string) => { value: string } | undefined
+    >(),
+  };
+});
+
+vi.mock('next/headers', () => ({
+  headers: () => ({
+    get: mockHeadersGet,
+  }),
+  cookies: () => ({
+    get: mockCookiesGet,
+  }),
+}));
+
+import { resolveServerLocale } from '../../lib/server-locale';
+
+describe('resolveServerLocale', () => {
+  beforeEach(() => {
+    mockHeadersGet.mockReset();
+    mockCookiesGet.mockReset();
+  });
+
+  it('prefers the locale cookie over the Accept-Language header', () => {
+    mockHeadersGet.mockReturnValue('en-US,fr;q=0.8');
+    mockCookiesGet.mockImplementation((name: string) =>
+      name === LOCALE_COOKIE_KEY ? { value: 'de-DE' } : undefined,
+    );
+
+    const { locale } = resolveServerLocale();
+
+    expect(locale).toBe('de-DE');
+  });
+
+  it('falls back to the Accept-Language header when no cookie is set', () => {
+    mockHeadersGet.mockReturnValue('fr-CA');
+    mockCookiesGet.mockReturnValue(undefined);
+
+    const { locale } = resolveServerLocale();
+
+    expect(locale).toBe('fr-CA');
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,14 +4,10 @@ import Header from './header';
 import ChunkErrorReload from '../components/ChunkErrorReload';
 import ToastProvider from '../components/ToastProvider';
 import SessionBanner from '../components/SessionBanner';
-import { headers, cookies } from 'next/headers';
+import { cookies } from 'next/headers';
 import { LocaleProvider } from '../lib/LocaleContext';
-import {
-  parseAcceptLanguage,
-  normalizeLocale,
-  LOCALE_COOKIE_KEY,
-  TIME_ZONE_COOKIE_KEY,
-} from '../lib/i18n';
+import { TIME_ZONE_COOKIE_KEY } from '../lib/i18n';
+import { resolveServerLocale } from '../lib/server-locale';
 
 export const metadata = {
   title: 'cross-sport-tracker',
@@ -23,15 +19,9 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const headerList = headers();
-  const acceptLanguage = headerList.get('accept-language');
   const cookieStore = cookies();
-  const cookieLocale = cookieStore.get(LOCALE_COOKIE_KEY)?.value ?? null;
+  const { locale, acceptLanguage } = resolveServerLocale({ cookieStore });
   const cookieTimeZone = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
-  const locale = normalizeLocale(
-    cookieLocale,
-    parseAcceptLanguage(acceptLanguage),
-  );
 
   return (
     <html lang={locale}>

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { headers, cookies } from "next/headers";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary from "./live-summary";
@@ -8,7 +8,6 @@ import { PlayerInfo } from "../../../components/PlayerName";
 import {
   formatDate,
   formatDateTime,
-  parseAcceptLanguage,
   resolveTimeZone,
   TIME_ZONE_COOKIE_KEY,
 } from "../../../lib/i18n";
@@ -24,6 +23,7 @@ import {
   isRecord,
 } from "../../../lib/match-summary";
 import { resolveParticipantGroups } from "../../../lib/participants";
+import { resolveServerLocale } from "../../../lib/server-locale";
 
 export const dynamic = "force-dynamic";
 
@@ -474,7 +474,7 @@ export default async function MatchDetailPage({
     );
   }
   const cookieStore = cookies();
-  const locale = parseAcceptLanguage(headers().get("accept-language"));
+  const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
   const timeZone = resolveTimeZone(timeZoneCookie);
 

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { headers, cookies } from "next/headers";
+import { cookies } from "next/headers";
 import { apiFetch, withAbsolutePhotoUrl, type ApiError } from "../../lib/api";
 import Pager from "./pager";
 import { PlayerInfo } from "../../components/PlayerName";
@@ -7,13 +7,13 @@ import MatchParticipants from "../../components/MatchParticipants";
 import {
   formatDate,
   formatDateTime,
-  parseAcceptLanguage,
   resolveTimeZone,
   TIME_ZONE_COOKIE_KEY,
 } from "../../lib/i18n";
 import { hasTimeComponent } from "../../lib/datetime";
 import { ensureTrailingSlash } from "../../lib/routes";
 import { resolveParticipantGroups } from "../../lib/participants";
+import { resolveServerLocale } from "../../lib/server-locale";
 
 export const dynamic = "force-dynamic";
 
@@ -236,7 +236,7 @@ export default async function MatchesPage(
   const limit = Number(searchParams.limit) || 25;
   const offset = Number(searchParams.offset) || 0;
   const cookieStore = cookies();
-  const locale = parseAcceptLanguage(headers().get('accept-language'));
+  const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
   const timeZone = resolveTimeZone(timeZoneCookie);
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,8 +8,7 @@ import {
   type EnrichedMatch,
   type MatchRow,
 } from '../lib/matches';
-import { headers } from 'next/headers';
-import { parseAcceptLanguage } from '../lib/i18n';
+import { resolveServerLocale } from '../lib/server-locale';
 
 type Sport = { id: string; name: string };
 
@@ -21,7 +20,7 @@ export default async function HomePage() {
   let matchPageSize = 5;
   let sportError = false;
   let matchError = false;
-  const locale = parseAcceptLanguage(headers().get('accept-language'));
+  const { locale } = resolveServerLocale();
 
   const MATCHES_LIMIT = 5;
 

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { headers, cookies } from "next/headers";
+import { cookies } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { apiFetch, fetchClubs, withAbsolutePhotoUrl } from "../../../lib/api";
@@ -12,10 +12,10 @@ import MatchParticipants from "../../../components/MatchParticipants";
 import PhotoUpload from "./PhotoUpload";
 import {
   formatDate,
-  parseAcceptLanguage,
   resolveTimeZone,
   TIME_ZONE_COOKIE_KEY,
 } from "../../../lib/i18n";
+import { resolveServerLocale } from "../../../lib/server-locale";
 import {
   formatMatchRecord,
   normalizeMatchSummary,
@@ -443,7 +443,7 @@ export default async function PlayerPage({
   searchParams: { view?: string };
 }) {
   const cookieStore = cookies();
-  const locale = parseAcceptLanguage(headers().get("accept-language"));
+  const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
   const timeZone = resolveTimeZone(timeZoneCookie);
   let player: Player;

--- a/apps/web/src/lib/server-locale.ts
+++ b/apps/web/src/lib/server-locale.ts
@@ -1,0 +1,31 @@
+import { cookies, headers } from 'next/headers';
+import {
+  LOCALE_COOKIE_KEY,
+  normalizeLocale,
+  parseAcceptLanguage,
+} from './i18n';
+
+export type ResolveServerLocaleOptions = {
+  cookieStore?: ReturnType<typeof cookies>;
+  acceptLanguage?: string | null;
+};
+
+export function resolveServerLocale(
+  options: ResolveServerLocaleOptions = {},
+): { locale: string; acceptLanguage: string | null } {
+  const cookieStore = options.cookieStore ?? cookies();
+  const acceptLanguage =
+    options.acceptLanguage !== undefined
+      ? options.acceptLanguage
+      : headers().get('accept-language');
+
+  const cookieLocale = cookieStore.get(LOCALE_COOKIE_KEY)?.value ?? null;
+
+  return {
+    locale: normalizeLocale(
+      cookieLocale,
+      parseAcceptLanguage(acceptLanguage),
+    ),
+    acceptLanguage,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared `resolveServerLocale` helper that prefers the locale cookie and falls back to the Accept-Language header
- update server components to consume the shared locale resolver when formatting content
- backfill tests to cover the cookie preference and update existing page tests to mock the helper

## Testing
- pnpm test *(fails: existing Vitest suites currently red in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f3b26ca08323b34dccd96f1ff4a0