### PR TITLE
feat(web): add country and club selectors to leaderboard filters

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -12,6 +12,8 @@ import {
   useRef,
   useState,
 } from "react";
+import CountrySelect from "../../components/CountrySelect";
+import ClubSelect from "../../components/ClubSelect";
 import { apiUrl } from "../../lib/api";
 import { ensureTrailingSlash, recordPathForSport } from "../../lib/routes";
 import { loadUserSettings } from "../user-settings";
@@ -754,29 +756,30 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             alignItems: "flex-end",
           }}
         >
-          <div style={{ display: "flex", flexDirection: "column", minWidth: "120px" }}>
+          <div style={{ display: "flex", flexDirection: "column", minWidth: "160px" }}>
             <label style={{ fontSize: "0.85rem", fontWeight: 600 }} htmlFor="leaderboard-country">
               Country
             </label>
-            <input
+            <CountrySelect
               id="leaderboard-country"
               value={draftCountry}
-              onChange={(event) => setDraftCountry(event.target.value.toUpperCase())}
-              placeholder="e.g. SE"
-              maxLength={5}
+              onChange={(next) => setDraftCountry(normalizeCountry(next))}
+              placeholder="Select a country"
               style={{ padding: "0.35rem", border: "1px solid #ccc", borderRadius: "4px" }}
             />
           </div>
-          <div style={{ display: "flex", flexDirection: "column", minWidth: "140px" }}>
-            <label style={{ fontSize: "0.85rem", fontWeight: 600 }} htmlFor="leaderboard-club">
+          <div style={{ display: "flex", flexDirection: "column", minWidth: "220px" }}>
+            <label style={{ fontSize: "0.85rem", fontWeight: 600 }} htmlFor="leaderboard-club-search">
               Club
             </label>
-            <input
-              id="leaderboard-club"
+            <ClubSelect
               value={draftClubId}
-              onChange={(event) => setDraftClubId(event.target.value)}
-              placeholder="e.g. club-123"
-              style={{ padding: "0.35rem", border: "1px solid #ccc", borderRadius: "4px" }}
+              onChange={(next) => setDraftClubId(normalizeClubId(next))}
+              placeholder="Search for a club"
+              searchInputId="leaderboard-club-search"
+              selectId="leaderboard-club-select"
+              ariaLabel="Club"
+              className="leaderboard-club-select"
             />
           </div>
           <div style={{ display: "flex", gap: "0.5rem" }}>

--- a/apps/web/src/components/CountrySelect.tsx
+++ b/apps/web/src/components/CountrySelect.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { type ChangeEvent, type SelectHTMLAttributes } from "react";
+
+import { COUNTRY_OPTIONS } from "../lib/countries";
+
+export type CountrySelectProps = {
+  value: string;
+  onChange: (countryCode: string) => void;
+  placeholder?: string;
+  includeEmptyOption?: boolean;
+} & Omit<SelectHTMLAttributes<HTMLSelectElement>, "value" | "onChange">;
+
+export default function CountrySelect({
+  value,
+  onChange,
+  placeholder = "Select a country",
+  includeEmptyOption = true,
+  ...rest
+}: CountrySelectProps) {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextValue = event.target.value.trim().toUpperCase();
+    onChange(nextValue);
+  };
+
+  return (
+    <select value={value} onChange={handleChange} {...rest}>
+      {includeEmptyOption ? <option value="">{placeholder}</option> : null}
+      {COUNTRY_OPTIONS.map((option) => (
+        <option key={option.code} value={option.code}>
+          {option.name}
+        </option>
+      ))}
+    </select>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable CountrySelect component that maps COUNTRY_OPTIONS to a dropdown
- reuse CountrySelect and the shared ClubSelect within the leaderboard filter form while keeping normalization
- update leaderboard tests to work with the selectors and verify query-string updates

## Testing
- pnpm exec vitest run src/app/leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9f6af892883239b19a563876d11ca