### PR TITLE
Wrap leaderboard tables in a scrollable container

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -18,6 +18,7 @@
   /* Navigation */
   --color-nav-bg: #0a1f44;
   --color-nav-text: #ffffff;
+  --leaderboard-table-header-bg: var(--color-surface);
 }
 
 *,
@@ -1081,6 +1082,38 @@ textarea {
 
 .bowling-total {
   font-weight: 700;
+}
+
+.leaderboard-table-wrapper {
+  margin-top: 1rem;
+  overflow-x: auto;
+  padding-inline: clamp(0.5rem, 4vw, 2rem);
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  min-width: 560px;
+}
+
+.leaderboard-table-wrapper::-webkit-scrollbar {
+  height: 8px;
+}
+
+.leaderboard-table-wrapper::-webkit-scrollbar-thumb {
+  background: rgba(10, 31, 68, 0.25);
+  border-radius: 999px;
+}
+
+.leaderboard-table-wrapper::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@media (min-width: 768px) {
+  .leaderboard-table-wrapper {
+    padding-inline: clamp(0.5rem, 2vw, 1.5rem);
+  }
 }
 
 .leaderboard-nav {

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -99,6 +99,17 @@ describe("Leaderboard", () => {
     );
   });
 
+  it("renders the leaderboard table inside a scrollable wrapper while loading", () => {
+    const pendingFetch = new Promise<Response>(() => {});
+    global.fetch = vi.fn().mockReturnValue(pendingFetch) as unknown as typeof fetch;
+
+    render(<Leaderboard sport="padel" />);
+
+    const table = screen.getByRole("table");
+    expect(table).toHaveClass("leaderboard-table");
+    expect(table.parentElement).toHaveClass("leaderboard-table-wrapper");
+  });
+
   it("falls back to a dropdown when the tab navigation overflows", async () => {
     const fetchMock = vi
       .fn()
@@ -376,11 +387,20 @@ describe("Leaderboard", () => {
 
     const table = await screen.findByRole("table");
     expect(table).toHaveAttribute("id", "leaderboard-results");
+    expect(table).toHaveClass("leaderboard-table");
+    expect(table.parentElement).toHaveClass("leaderboard-table-wrapper");
 
     const headers = screen.getAllByRole("columnheader");
     headers.forEach((header) => {
       expect(header).toHaveAttribute("scope", "col");
     });
+
+    const stickyHeader = screen.getByRole("columnheader", { name: "#" });
+    expect(stickyHeader).toHaveStyle("position: sticky");
+    expect(stickyHeader).toHaveStyle("top: 0");
+    expect(stickyHeader).toHaveStyle(
+      "background: var(--leaderboard-table-header-bg)",
+    );
 
     expect(screen.getByRole("columnheader", { name: "#" })).toHaveAttribute(
       "aria-sort",

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -603,52 +603,76 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     };
   }, [sport, appliedCountry, appliedClubId, buildUrl, preferencesApplied]);
 
+  const tableStyle = useMemo(
+    () => ({
+      width: "100%",
+      borderCollapse: "collapse" as const,
+      fontSize: "0.9rem",
+    }),
+    [],
+  );
+
+  const headerCellStyle = useMemo(
+    () => ({
+      position: "sticky" as const,
+      top: 0,
+      zIndex: 1,
+      textAlign: "left" as const,
+      padding: "4px 16px 4px 0",
+      background: "var(--leaderboard-table-header-bg)",
+    }),
+    [],
+  );
+
+  const lastHeaderCellStyle = useMemo(
+    () => ({
+      ...headerCellStyle,
+      padding: "4px 0",
+    }),
+    [headerCellStyle],
+  );
+
+  const cellStyle = useMemo(
+    () => ({
+      padding: "4px 16px 4px 0",
+    }),
+    [],
+  );
+
+  const lastCellStyle = useMemo(
+    () => ({
+      padding: "4px 0",
+    }),
+    [],
+  );
+
   const TableHeader = () => (
     <thead>
       <tr>
-        <th
-          scope="col"
-          aria-sort="ascending"
-          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-        >
+        <th scope="col" aria-sort="ascending" style={headerCellStyle}>
           #
         </th>
-        <th scope="col" style={{ textAlign: "left", padding: "4px 16px 4px 0" }}>
+        <th scope="col" style={headerCellStyle}>
           Player
         </th>
         {sport === ALL_SPORTS && (
-          <th
-            scope="col"
-            style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-          >
+          <th scope="col" style={headerCellStyle}>
             Sport
           </th>
         )}
-        <th
-          scope="col"
-          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-        >
+        <th scope="col" style={headerCellStyle}>
           Rating
         </th>
-        <th
-          scope="col"
-          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-        >
+        <th scope="col" style={headerCellStyle}>
           W
         </th>
-        <th
-          scope="col"
-          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-        >
+        <th scope="col" style={headerCellStyle}>
           L
         </th>
-        <th
-          scope="col"
-          style={{ textAlign: "left", padding: "4px 16px 4px 0" }}
-        >
+        <th scope="col" style={headerCellStyle}>
           Matches
         </th>
-        <th scope="col" style={{ textAlign: "left", padding: "4px 0" }}>
+        <th scope="col" style={lastHeaderCellStyle}>
           Win%
         </th>
       </tr>
@@ -850,49 +874,43 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       )}
 
       {loading ? (
-        <table
-          id={RESULTS_TABLE_ID}
-          style={{
-            width: "100%",
-            borderCollapse: "collapse",
-            marginTop: "1rem",
-            fontSize: "0.9rem",
-          }}
-        >
-          <TableHeader />
-          <tbody>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <tr key={`skeleton-${i}`} style={{ borderTop: "1px solid #ccc" }}>
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "12px", height: "1em" }} />
-                </td>
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "120px", height: "1em" }} />
-                </td>
-                {sport === ALL_SPORTS && (
-                  <td style={{ padding: "4px 16px 4px 0" }}>
-                    <div className="skeleton" style={{ width: "80px", height: "1em" }} />
+        <div className="leaderboard-table-wrapper">
+          <table id={RESULTS_TABLE_ID} className="leaderboard-table" style={tableStyle}>
+            <TableHeader />
+            <tbody>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <tr key={`skeleton-${i}`} style={{ borderTop: "1px solid #ccc" }}>
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "12px", height: "1em" }} />
                   </td>
-                )}
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "40px", height: "1em" }} />
-                </td>
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "20px", height: "1em" }} />
-                </td>
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "20px", height: "1em" }} />
-                </td>
-                <td style={{ padding: "4px 16px 4px 0" }}>
-                  <div className="skeleton" style={{ width: "30px", height: "1em" }} />
-                </td>
-                <td style={{ padding: "4px 0" }}>
-                  <div className="skeleton" style={{ width: "40px", height: "1em" }} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "120px", height: "1em" }} />
+                  </td>
+                  {sport === ALL_SPORTS && (
+                    <td style={cellStyle}>
+                      <div className="skeleton" style={{ width: "80px", height: "1em" }} />
+                    </td>
+                  )}
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "40px", height: "1em" }} />
+                  </td>
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "20px", height: "1em" }} />
+                  </td>
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "20px", height: "1em" }} />
+                  </td>
+                  <td style={cellStyle}>
+                    <div className="skeleton" style={{ width: "30px", height: "1em" }} />
+                  </td>
+                  <td style={lastCellStyle}>
+                    <div className="skeleton" style={{ width: "40px", height: "1em" }} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : leaders.length === 0 ? (
         error ? (
           <div
@@ -912,46 +930,36 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           <EmptyState {...emptyStateContent} />
         )
       ) : (
-        <table
-          id={RESULTS_TABLE_ID}
-          style={{
-            width: "100%",
-            borderCollapse: "collapse",
-            marginTop: "1rem",
-            fontSize: "0.9rem",
-          }}
-        >
-          <TableHeader />
-          <tbody>
-            {leaders.map((row) => {
-              const won = row.setsWon ?? 0;
-              const lost = row.setsLost ?? 0;
-              const total = won + lost;
-              const winPct = total > 0 ? Math.round((won / total) * 100) : null;
-              return (
-                <tr
-                  key={`${row.rank}-${row.playerId}-${row.sport ?? ""}`}
-                  style={{ borderTop: "1px solid #ccc" }}
-                >
-                  <td style={{ padding: "4px 16px 4px 0" }}>{row.rank}</td>
-                  <td style={{ padding: "4px 16px 4px 0" }}>{row.playerName}</td>
-                  {sport === ALL_SPORTS && (
-                    <td style={{ padding: "4px 16px 4px 0" }}>{row.sport}</td>
-                  )}
-                  <td style={{ padding: "4px 16px 4px 0" }}>
-                    {row.rating != null ? Math.round(row.rating) : "—"}
-                  </td>
-                  <td style={{ padding: "4px 16px 4px 0" }}>{row.setsWon ?? "—"}</td>
-                  <td style={{ padding: "4px 16px 4px 0" }}>{row.setsLost ?? "—"}</td>
-                  <td style={{ padding: "4px 16px 4px 0" }}>{total || "—"}</td>
-                  <td style={{ padding: "4px 0" }}>
-                    {winPct != null ? `${winPct}%` : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="leaderboard-table-wrapper">
+          <table id={RESULTS_TABLE_ID} className="leaderboard-table" style={tableStyle}>
+            <TableHeader />
+            <tbody>
+              {leaders.map((row) => {
+                const won = row.setsWon ?? 0;
+                const lost = row.setsLost ?? 0;
+                const total = won + lost;
+                const winPct = total > 0 ? Math.round((won / total) * 100) : null;
+                return (
+                  <tr
+                    key={`${row.rank}-${row.playerId}-${row.sport ?? ""}`}
+                    style={{ borderTop: "1px solid #ccc" }}
+                  >
+                    <td style={cellStyle}>{row.rank}</td>
+                    <td style={cellStyle}>{row.playerName}</td>
+                    {sport === ALL_SPORTS && <td style={cellStyle}>{row.sport}</td>}
+                    <td style={cellStyle}>
+                      {row.rating != null ? Math.round(row.rating) : "—"}
+                    </td>
+                    <td style={cellStyle}>{row.setsWon ?? "—"}</td>
+                    <td style={cellStyle}>{row.setsLost ?? "—"}</td>
+                    <td style={cellStyle}>{total || "—"}</td>
+                    <td style={lastCellStyle}>{winPct != null ? `${winPct}%` : "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- wrap leaderboard tables and skeleton loaders in a horizontal scroll container with sticky column headers
- add responsive scroll styling and header background variables for the leaderboard table
- extend leaderboard tests to assert the scroll wrapper and sticky header styles

## Testing
- npx vitest run src/app/leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9fe4e158c83239c2e061691e5eb1e