### PR TITLE
feat(web): add virtualized player multi-select

### DIFF
--- a/apps/web/src/app/tournaments/create-tournament-form.tsx
+++ b/apps/web/src/app/tournaments/create-tournament-form.tsx
@@ -244,8 +244,8 @@ export default function CreateTournamentForm({
   const selectedCount = selectedPlayers.length;
   const playerValidationMessage =
     selectedCount >= MIN_AMERICANO_PLAYERS
-      ? `${selectedCount} player${selectedCount === 1 ? "" : "s"} selected`
-      : `Select at least ${MIN_AMERICANO_PLAYERS} players to include in the Americano schedule.`;
+      ? `Ready to schedule with ${selectedCount} player${selectedCount === 1 ? "" : "s"}. Use the search box to adjust the roster.`
+      : `Use the search box to add at least ${MIN_AMERICANO_PLAYERS} players before generating the Americano schedule.`;
 
   const title = admin
     ? "Admin: Create Americano tournament"
@@ -353,6 +353,10 @@ export default function CreateTournamentForm({
           </div>
           <fieldset className="form-fieldset">
             <legend className="form-legend">Players</legend>
+            <p className="form-hint" style={{ marginBottom: 12 }}>
+              Search or arrow through the list to add players. Selected entries are displayed as
+              removable chips above the search field.
+            </p>
             <MultiSelect
               ariaLabel="Available players"
               id="player"

--- a/apps/web/src/components/MultiSelect.tsx
+++ b/apps/web/src/components/MultiSelect.tsx
@@ -75,6 +75,7 @@ export default function MultiSelect({
   const listboxId = id ? `${id}-listbox` : `multi-select-${generatedId}-listbox`;
   const searchInputId = id ? `${id}-search` : `multi-select-${generatedId}-search`;
   const summaryId = `${listboxId}-summary`;
+  const searchDescriptionId = selectedSummaryLabel ? summaryId : undefined;
   const listRef = useRef<HTMLDivElement | null>(null);
   const [internalSearch, setInternalSearch] = useState("");
   const [scrollTop, setScrollTop] = useState(0);
@@ -367,6 +368,7 @@ export default function MultiSelect({
           aria-controls={listboxId}
           aria-activedescendant={activeDescendantId}
           aria-autocomplete="list"
+          aria-describedby={searchDescriptionId}
           autoComplete="off"
         />
       </div>
@@ -376,6 +378,7 @@ export default function MultiSelect({
         aria-multiselectable
         aria-label={ariaLabel}
         aria-describedby={selectedSummaryLabel ? summaryId : undefined}
+        aria-busy={loading}
         ref={listRef}
         onScroll={handleScroll}
         style={{

--- a/apps/web/src/components/__tests__/MultiSelect.test.tsx
+++ b/apps/web/src/components/__tests__/MultiSelect.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import MultiSelect from '../MultiSelect';
+
+describe('MultiSelect', () => {
+  const renderComponent = (
+    options: { id: string; name: string }[],
+    initialSelected: string[] = []
+  ): HTMLElement => {
+    function Wrapper() {
+      const [selected, setSelected] = useState(initialSelected);
+      return (
+        <MultiSelect
+          ariaLabel="Available players"
+          id="players"
+          options={options}
+          searchLabel="Search players"
+          selectedIds={selected}
+          selectedSummaryLabel={`${selected.length} player${selected.length === 1 ? '' : 's'} selected`}
+          onSelectionChange={setSelected}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    return screen.getByRole('listbox', { name: 'Available players' });
+  };
+
+  it('supports keyboard navigation, selection, and deselection', async () => {
+    const options = [
+      { id: 'p1', name: 'Ava' },
+      { id: 'p2', name: 'Ben' },
+      { id: 'p3', name: 'Cora' },
+      { id: 'p4', name: 'Drew' },
+    ];
+
+    const listbox = renderComponent(options);
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByLabelText('Search players');
+
+    await user.click(searchInput);
+
+    await user.keyboard('{ArrowDown}{Enter}');
+    await user.keyboard('{ArrowDown}{Enter}');
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+    expect(removeButtons).toHaveLength(3);
+
+    await user.keyboard('{ArrowUp}{Enter}');
+
+    const remainingButtons = screen.getAllByRole('button', { name: /remove/i });
+    expect(remainingButtons).toHaveLength(2);
+    expect(screen.getByText('Ava')).toBeInTheDocument();
+    expect(screen.getByText('Cora')).toBeInTheDocument();
+
+    await user.keyboard('{Backspace}');
+
+    const chips = screen.getAllByRole('button', { name: /remove/i });
+    expect(chips).toHaveLength(1);
+    expect(screen.getByText('Ava')).toBeInTheDocument();
+  });
+
+  it('filters options and virtualizes long lists to stay responsive', async () => {
+    const options = Array.from({ length: 50 }, (_, index) => ({
+      id: `p${index + 1}`,
+      name: `Player ${index + 1}`,
+    }));
+
+    const listbox = renderComponent(options);
+
+    const user = userEvent.setup();
+    const initialOptions = within(listbox).getAllByRole('option');
+    expect(initialOptions.length).toBeLessThan(options.length);
+
+    listbox.scrollTop = 400;
+    fireEvent.scroll(listbox);
+
+    const searchInput = screen.getByLabelText('Search players');
+    await user.type(searchInput, 'Player 17');
+
+    await screen.findByText('Player 17');
+    expect(within(listbox).getAllByRole('option')).toHaveLength(1);
+    await user.clear(searchInput);
+    await user.type(searchInput, 'zzz');
+    expect(await screen.findByText(/No results for "zzz"/i)).toBeInTheDocument();
+    await waitFor(() => expect(listbox.scrollTop).toBe(0));
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the Americano creation form messaging to guide players through the new searchable multi-select roster picker
- tighten the multi-select accessibility wiring by connecting the search field to its selection summary and exposing loading state
- add focused unit tests that cover keyboard selection, deselection, filtering, and virtualization behaviour for the multi-select

## Testing
- pnpm vitest run src/components/__tests__/MultiSelect.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da4e96ac2c83238943b1f57ae9e80a