### PR TITLE
Improve affordance of sport list links

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -518,18 +518,27 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  color: inherit;
-  text-decoration: none;
+  color: var(--color-accent-blue);
+  text-decoration: underline;
+  text-decoration-color: rgba(26, 115, 232, 0.45);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.2em;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    text-decoration-color 0.2s ease;
+}
+
+.sport-link:hover,
+.sport-link:focus-visible {
+  background-color: rgba(26, 115, 232, 0.12);
+  color: var(--color-accent-blue);
+  text-decoration-color: currentColor;
 }
 
 .sport-link:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
-}
-
-.sport-link:hover .sport-name,
-.sport-link:focus-visible .sport-name {
-  text-decoration: underline;
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 3px;
 }
 
 .sport-icon {


### PR DESCRIPTION
## Summary
- underline sport list links by default and use the blue accent color
- add hover and focus background treatments to make the links feel clickable
- adjust focus outline to keep the updated style accessible

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(fails: API fetches require the backend service)*

------
https://chatgpt.com/codex/tasks/task_e_68db1c91409483238e5ea3b864304544