### PR TITLE
Preserve scroll position when loading more matches

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -242,6 +242,7 @@ export default function HomePageClient({
 
   const loadMoreMatches = async () => {
     if (!hasMore || loadingMore) return;
+    const previousScrollPosition = window.scrollY;
     setPaginationError(false);
     setLoadingMore(true);
     try {
@@ -256,7 +257,13 @@ export default function HomePageClient({
         throw new Error('Failed to fetch more matches');
       }
       const result = await parseMatchesResponse(r, pageSize);
-      setMatches((prev) => [...prev, ...result.enriched]);
+      setMatches((prev) => {
+        const updatedMatches = [...prev, ...result.enriched];
+        requestAnimationFrame(() => {
+          window.scrollTo({ top: previousScrollPosition, behavior: 'auto' });
+        });
+        return updatedMatches;
+      });
       setHasMore(result.hasMore);
       setNextOffset(result.nextOffset);
       setPageSize(result.limit ?? pageSize);


### PR DESCRIPTION
## Summary
- capture the current scroll position before loading more matches
- restore the saved scroll position after the match list updates to avoid jumping to the top of the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1d97b7e88323a27d6d0fa10db94b