### PR TITLE
Improve sport link hover contrast

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -532,7 +532,7 @@ textarea {
 .sport-link:hover,
 .sport-link:focus-visible {
   background-color: rgba(26, 115, 232, 0.12);
-  color: var(--color-accent-blue);
+  color: var(--color-text);
   text-decoration-color: currentColor;
 }
 


### PR DESCRIPTION
## Summary
- switch the sport link hover/focus text color to the default body text so the tinted background keeps ≥4.5:1 contrast

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db1e6ddff48323b4ac510cf936eb14