### PR TITLE
Fix spacing between player page navigation links

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -622,7 +622,7 @@ export default async function PlayerPage({
               </div>
             ) : null}
 
-            <nav className="mt-4 mb-4 space-x-4">
+            <nav className="mt-4 mb-4 flex flex-wrap gap-4">
               <Link
                 href={`/players/${params.id}?view=timeline`}
                 className={view === "timeline" ? "font-bold" : ""}


### PR DESCRIPTION
## Summary
- ensure the player page navigation uses a flex container with gaps so the Timeline and Season Summary links stay separated, even on narrow screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db200441208323b6ed6d982bcc96d0