### PR TITLE
Toggle signup form on login page

### DIFF
--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -89,15 +89,18 @@ describe('LoginPage signup feedback', () => {
 
     renderWithToast(<LoginPage />);
 
-    const [, signupUsername] = screen.getAllByLabelText('Username');
-    const signupPassword = screen.getAllByLabelText('Password')[1];
-    const confirmPassword = screen.getByLabelText('Confirm Password');
+    fireEvent.click(screen.getByRole('button', { name: /create an account/i }));
+
+    const signupForm = screen.getByTestId('signup-form');
+    const signupUsername = within(signupForm).getByLabelText('Username');
+    const signupPassword = within(signupForm).getByLabelText('Password');
+    const confirmPassword = within(signupForm).getByLabelText('Confirm Password');
 
     fireEvent.change(signupUsername, { target: { value: 'NewUser' } });
     fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
     fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    fireEvent.click(within(signupForm).getByRole('button', { name: /sign up/i }));
 
     await waitFor(() => {
       expect(mockedApiFetch).toHaveBeenCalledWith(
@@ -126,15 +129,18 @@ describe('LoginPage signup feedback', () => {
 
     renderWithToast(<LoginPage />);
 
-    const [, signupUsername] = screen.getAllByLabelText('Username');
-    const signupPassword = screen.getAllByLabelText('Password')[1];
-    const confirmPassword = screen.getByLabelText('Confirm Password');
+    fireEvent.click(screen.getByRole('button', { name: /create an account/i }));
+
+    const signupForm = screen.getByTestId('signup-form');
+    const signupUsername = within(signupForm).getByLabelText('Username');
+    const signupPassword = within(signupForm).getByLabelText('Password');
+    const confirmPassword = within(signupForm).getByLabelText('Confirm Password');
 
     fireEvent.change(signupUsername, { target: { value: 'Existing' } });
     fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
     fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    fireEvent.click(within(signupForm).getByRole('button', { name: /sign up/i }));
 
     const alert = await screen.findByRole('alert');
     expect(
@@ -147,15 +153,18 @@ describe('LoginPage signup feedback', () => {
   it('shows username format guidance when validation fails', async () => {
     renderWithToast(<LoginPage />);
 
-    const [, signupUsername] = screen.getAllByLabelText('Username');
-    const signupPassword = screen.getAllByLabelText('Password')[1];
-    const confirmPassword = screen.getByLabelText('Confirm Password');
+    fireEvent.click(screen.getByRole('button', { name: /create an account/i }));
+
+    const signupForm = screen.getByTestId('signup-form');
+    const signupUsername = within(signupForm).getByLabelText('Username');
+    const signupPassword = within(signupForm).getByLabelText('Password');
+    const confirmPassword = within(signupForm).getByLabelText('Confirm Password');
 
     fireEvent.change(signupUsername, { target: { value: 'Invalid Name' } });
     fireEvent.change(signupPassword, { target: { value: 'Str0ng!Pass!' } });
     fireEvent.change(confirmPassword, { target: { value: 'Str0ng!Pass!' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+    fireEvent.click(within(signupForm).getByRole('button', { name: /sign up/i }));
 
     const alert = await screen.findByRole('alert');
     expect(

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -311,11 +311,13 @@ export default function LoginPage() {
   const [confirmPass, setConfirmPass] = useState("");
   const [loginErrors, setLoginErrors] = useState<string[]>([]);
   const [signupErrors, setSignupErrors] = useState<string[]>([]);
+  const [showSignup, setShowSignup] = useState(false);
   const passwordStrengthLabelId = useId();
   const passwordStrengthHelperId = useId();
   const errorSummaryTitleId = useId();
   const loginErrorTitleId = useId();
   const signupErrorTitleId = useId();
+  const signupFormId = useId();
   const { usernameCharacterRule, usernameEmailOption } = useMemo(
     () => getAuthCopy(locale),
     [locale]
@@ -503,8 +505,26 @@ export default function LoginPage() {
         <button type="submit">Login</button>
       </form>
 
-      <h2 className="heading">Sign Up</h2>
-      <form onSubmit={handleSignup} className="auth-form">
+      <section className="auth-signup">
+        <div className="auth-signup__header">
+          <h2 className="heading">Need an account?</h2>
+          <button
+            type="button"
+            className="auth-signup__toggle"
+            onClick={() => setShowSignup((prev) => !prev)}
+            aria-expanded={showSignup}
+            aria-controls={signupFormId}
+          >
+            {showSignup ? "Hide sign up form" : "Create an account"}
+          </button>
+        </div>
+        {showSignup && (
+          <form
+            id={signupFormId}
+            onSubmit={handleSignup}
+            className="auth-form auth-signup__form"
+            data-testid="signup-form"
+          >
         <div className="form-field">
           <label htmlFor="signup-username" className="form-label">
             Username
@@ -606,7 +626,9 @@ export default function LoginPage() {
           </div>
         )}
         <button type="submit">Sign Up</button>
-      </form>
+          </form>
+        )}
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- hide the sign-up form on the login screen behind an accessible toggle button
- render the registration form only when requested and provide a test id for targeting in tests
- update login page tests to open the sign-up form before interacting with its fields

## Testing
- pnpm test login.page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db210d0ebc83238e64b44d028c8c8d