### PR TITLE
Ensure neutral locale fallback for date formatting

### DIFF
--- a/apps/web/src/lib/i18n.test.ts
+++ b/apps/web/src/lib/i18n.test.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearStoredTimeZone,
   DEFAULT_TIME_ZONE,
+  formatDateTime,
   getStoredTimeZone,
+  NEUTRAL_FALLBACK_LOCALE,
+  resolveFormatterLocale,
   resolveTimeZone,
   storeTimeZonePreference,
   TIME_ZONE_COOKIE_KEY,
@@ -43,5 +46,16 @@ describe('time zone resolution', () => {
     storeTimeZonePreference('Invalid/Zone');
     expect(getStoredTimeZone()).toBeNull();
     expect(resolveTimeZone(null)).toBe(DEFAULT_TIME_ZONE);
+  });
+});
+
+describe('formatter helpers', () => {
+  it('falls back to a neutral locale when no locale is provided', () => {
+    expect(resolveFormatterLocale(undefined)).toBe(NEUTRAL_FALLBACK_LOCALE);
+    expect(resolveFormatterLocale('')).toBe(NEUTRAL_FALLBACK_LOCALE);
+  });
+
+  it('formats dates with the neutral fallback when locale hints are missing', () => {
+    expect(formatDateTime('2001-11-21T09:30:00Z', '')).toBe('21 Nov 2001, 09:30');
   });
 });

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -392,6 +392,18 @@ const DATE_TIME_PRESETS = {
 
 type DateTimePreset = keyof typeof DATE_TIME_PRESETS;
 
+export function resolveFormatterLocale(
+  locale: string | null | undefined,
+): string {
+  return normalizeLocale(locale, NEUTRAL_FALLBACK_LOCALE);
+}
+
+export function resolveFormatterTimeZone(
+  preferredTimeZone?: string | null,
+): string {
+  return resolveTimeZone(preferredTimeZone);
+}
+
 export function formatDate(
   value: Date | string | number | null | undefined,
   locale: string,
@@ -401,13 +413,13 @@ export function formatDate(
   if (!value) return '—';
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) return '—';
-  const normalizedLocale = normalizeLocale(locale, '');
+  const normalizedLocale = resolveFormatterLocale(locale);
   const baseOptions = ensureOptions(options, { dateStyle: 'medium' });
   const formatterOptions: Intl.DateTimeFormatOptions = {
     ...baseOptions,
   };
   if (!formatterOptions.timeZone) {
-    formatterOptions.timeZone = resolveTimeZone(preferredTimeZone);
+    formatterOptions.timeZone = resolveFormatterTimeZone(preferredTimeZone);
   }
   const localeForFormatter = normalizedLocale || undefined;
 


### PR DESCRIPTION
## Summary
- add formatter helpers to centralize locale and time zone resolution for formatters
- ensure date formatting falls back to the neutral locale when no preference is provided
- cover the new formatter helpers with dedicated tests

## Testing
- pnpm vitest run src/lib/i18n.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db2094346083239c9387ac5a66d646