### PR TITLE
Add notification preferences, push delivery, and UI integration

### DIFF
--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,54 @@
+const DEFAULT_TITLE = "Cross Sport Tracker";
+
+self.addEventListener("push", (event) => {
+  if (!event.data) {
+    return;
+  }
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch (error) {
+    payload = { body: event.data.text() };
+  }
+
+  const notification = typeof payload === "object" && payload !== null ? payload : {};
+  const title = notification.title || DEFAULT_TITLE;
+  const body = notification.body;
+  const data = notification.notification || notification;
+
+  const options = {
+    body,
+    data,
+    tag: data?.id || undefined,
+    renotify: false,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const data = event.notification.data || {};
+  const targetUrl = data.url || data.payload?.url;
+
+  if (!targetUrl) {
+    return;
+  }
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        for (const client of clients) {
+          if (client.url === targetUrl && "focus" in client) {
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(targetUrl);
+        }
+        return undefined;
+      })
+  );
+});

--- a/backend/alembic/versions/0027_notifications.py
+++ b/backend/alembic/versions/0027_notifications.py
@@ -1,0 +1,98 @@
+"""Notification and push subscription tables."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0027_notifications"
+down_revision = "0026_padel_americano_leaderboard"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_preference",
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column(
+            "notify_on_profile_comments",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "notify_on_match_results",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "push_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+    op.create_table(
+        "notification",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_notification_user_id",
+        "notification",
+        ["user_id"],
+    )
+
+    op.create_table(
+        "push_subscription",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("endpoint", sa.Text(), nullable=False),
+        sa.Column("p256dh", sa.String(), nullable=False),
+        sa.Column("auth", sa.String(), nullable=False),
+        sa.Column("content_encoding", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("endpoint", name="uq_push_subscription_endpoint"),
+    )
+    op.create_index(
+        "ix_push_subscription_user_id",
+        "push_subscription",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_push_subscription_user_id", table_name="push_subscription")
+    op.drop_table("push_subscription")
+    op.drop_index("ix_notification_user_id", table_name="notification")
+    op.drop_table("notification")
+    op.drop_table("notification_preference")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,10 @@
 import os
 
 API_PREFIX = os.getenv("API_PREFIX", "/api")
+VAPID_PUBLIC_KEY = os.getenv("VAPID_PUBLIC_KEY")
+VAPID_PRIVATE_KEY = os.getenv("VAPID_PRIVATE_KEY")
+VAPID_SUBJECT = (
+    os.getenv("VAPID_SUBJECT")
+    or os.getenv("NOTIFICATION_CONTACT_EMAIL")
+    or "mailto:admin@example.com"
+)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from .routers import (
     auth,
     badges,
     clubs,
+    notifications,
 )
 from .routes import player as player_pages
 from .exceptions import DomainException, ProblemDetail
@@ -146,6 +147,7 @@ v0_router.include_router(tournaments.router)
 v0_router.include_router(auth.router)
 v0_router.include_router(badges.router)
 v0_router.include_router(clubs.router)
+v0_router.include_router(notifications.router)
 
 api_router.include_router(v0_router)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -235,3 +235,49 @@ class Comment(Base):
     deleted_at = Column(DateTime, nullable=True)
 
     user = relationship("User")
+
+
+class NotificationPreference(Base):
+    __tablename__ = "notification_preference"
+
+    user_id = Column(String, ForeignKey("user.id"), primary_key=True)
+    notify_on_profile_comments = Column(Boolean, nullable=False, default=False)
+    notify_on_match_results = Column(Boolean, nullable=False, default=False)
+    push_enabled = Column(Boolean, nullable=False, default=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class PushSubscription(Base):
+    __tablename__ = "push_subscription"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("user.id"), nullable=False)
+    endpoint = Column(Text, nullable=False, unique=True)
+    p256dh = Column(String, nullable=False)
+    auth = Column(String, nullable=False)
+    content_encoding = Column(String, nullable=False, default="aes128gcm")
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class Notification(Base):
+    __tablename__ = "notification"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("user.id"), nullable=False, index=True)
+    type = Column(String, nullable=False)
+    payload = Column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    read_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -42,6 +42,7 @@ from ..services import (
     update_player_metrics,
     recompute_stage_standings,
 )
+from ..services.notifications import notify_match_recorded
 from ..exceptions import http_problem
 from .auth import get_current_user
 from ..time_utils import coerce_utc
@@ -399,6 +400,7 @@ async def create_match(
         await player_stats_cache.invalidate_players(all_player_ids)
     if summary is not None:
         await broadcast(mid, {"summary": match.details})
+    await notify_match_recorded(session, match, side_players, actor=user)
     return MatchIdOut(id=mid)
 
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,262 @@
+"""Notification preference and delivery endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..db_errors import is_missing_table_error
+from ..exceptions import http_problem
+from ..models import Notification, NotificationPreference, PushSubscription, User
+from ..schemas import (
+    NotificationListOut,
+    NotificationOut,
+    NotificationPreferenceOut,
+    NotificationPreferenceUpdate,
+    PushSubscriptionCreate,
+    PushSubscriptionOut,
+)
+from ..services.notifications import (
+    delete_push_subscriptions,
+    register_push_subscription,
+)
+from ..time_utils import coerce_utc
+from .auth import get_current_user
+
+
+router = APIRouter(
+    prefix="/notifications",
+    tags=["notifications"],
+)
+
+
+@router.get("/preferences", response_model=NotificationPreferenceOut)
+async def get_notification_preferences(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    try:
+        prefs = await session.get(NotificationPreference, user.id)
+        if not prefs:
+            prefs = NotificationPreference(user_id=user.id)
+            session.add(prefs)
+            await session.commit()
+            await session.refresh(prefs)
+
+        subs = (
+            await session.execute(
+                select(PushSubscription).where(PushSubscription.user_id == user.id)
+            )
+        ).scalars().all()
+    except SQLAlchemyError as exc:
+        await _rollback_if_active(session)
+        if is_missing_table_error(exc):
+            return NotificationPreferenceOut(
+                notifyOnProfileComments=False,
+                notifyOnMatchResults=False,
+                pushEnabled=False,
+                subscriptions=[],
+            )
+        raise
+
+    return NotificationPreferenceOut(
+        notifyOnProfileComments=bool(prefs.notify_on_profile_comments),
+        notifyOnMatchResults=bool(prefs.notify_on_match_results),
+        pushEnabled=bool(prefs.push_enabled),
+        subscriptions=[
+            PushSubscriptionOut(
+                id=s.id,
+                endpoint=s.endpoint,
+                createdAt=coerce_utc(s.created_at),
+            )
+            for s in subs
+        ],
+    )
+
+
+@router.put("/preferences", response_model=NotificationPreferenceOut)
+async def update_notification_preferences(
+    body: NotificationPreferenceUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    if not body.model_fields_set:
+        raise http_problem(
+            status_code=400,
+            detail="no fields provided",
+            code="notification_preferences_empty",
+        )
+
+    try:
+        prefs = await session.get(NotificationPreference, user.id)
+        if not prefs:
+            prefs = NotificationPreference(user_id=user.id)
+            session.add(prefs)
+
+        if body.notify_on_profile_comments is not None:
+            prefs.notify_on_profile_comments = body.notify_on_profile_comments
+        if body.notify_on_match_results is not None:
+            prefs.notify_on_match_results = body.notify_on_match_results
+        if body.push_enabled is not None:
+            prefs.push_enabled = body.push_enabled
+
+        await session.commit()
+        await session.refresh(prefs)
+
+        if not prefs.push_enabled:
+            await delete_push_subscriptions(session, user.id)
+
+        subs = (
+            await session.execute(
+                select(PushSubscription).where(PushSubscription.user_id == user.id)
+            )
+        ).scalars().all()
+    except SQLAlchemyError as exc:
+        await _rollback_if_active(session)
+        if is_missing_table_error(exc):
+            return NotificationPreferenceOut(
+                notifyOnProfileComments=body.notify_on_profile_comments or False,
+                notifyOnMatchResults=body.notify_on_match_results or False,
+                pushEnabled=body.push_enabled or False,
+                subscriptions=[],
+            )
+        raise
+
+    return NotificationPreferenceOut(
+        notifyOnProfileComments=bool(prefs.notify_on_profile_comments),
+        notifyOnMatchResults=bool(prefs.notify_on_match_results),
+        pushEnabled=bool(prefs.push_enabled),
+        subscriptions=[
+            PushSubscriptionOut(
+                id=s.id,
+                endpoint=s.endpoint,
+                createdAt=coerce_utc(s.created_at),
+            )
+            for s in subs
+        ],
+    )
+
+
+@router.post(
+    "/subscriptions",
+    response_model=PushSubscriptionOut,
+    status_code=201,
+)
+async def create_push_subscription(
+    body: PushSubscriptionCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    subscription = await register_push_subscription(
+        session,
+        user.id,
+        endpoint=body.endpoint,
+        p256dh=body.keys.p256dh,
+        auth=body.keys.auth,
+        content_encoding=body.content_encoding,
+    )
+    if not subscription:
+        raise http_problem(
+            status_code=503,
+            detail="push subscriptions unavailable",
+            code="push_subscriptions_unavailable",
+        )
+
+    return PushSubscriptionOut(
+        id=subscription.id,
+        endpoint=subscription.endpoint,
+        createdAt=coerce_utc(subscription.created_at),
+    )
+
+
+@router.delete("/subscriptions", status_code=204)
+async def remove_push_subscriptions(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    await delete_push_subscriptions(session, user.id)
+    return Response(status_code=204)
+
+
+@router.get("", response_model=NotificationListOut)
+async def list_notifications(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
+    try:
+        total_unread = (
+            await session.execute(
+                select(func.count()).select_from(Notification).where(
+                    Notification.user_id == user.id,
+                    Notification.read_at.is_(None),
+                )
+            )
+        ).scalar_one()
+
+        stmt = (
+            select(Notification)
+            .where(Notification.user_id == user.id)
+            .order_by(Notification.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    except SQLAlchemyError as exc:
+        await _rollback_if_active(session)
+        if is_missing_table_error(exc):
+            return NotificationListOut(items=[], unreadCount=0)
+        raise
+
+    return NotificationListOut(
+        items=[
+            NotificationOut(
+                id=row.id,
+                type=row.type,
+                payload=row.payload,
+                createdAt=coerce_utc(row.created_at),
+                readAt=coerce_utc(row.read_at) if row.read_at else None,
+            )
+            for row in rows
+        ],
+        unreadCount=total_unread,
+    )
+
+
+@router.post("/{notification_id}/read", status_code=204)
+async def mark_notification_read(
+    notification_id: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    try:
+        notification = await session.get(Notification, notification_id)
+        if not notification or notification.user_id != user.id:
+            raise http_problem(
+                status_code=404,
+                detail="notification not found",
+                code="notification_not_found",
+            )
+
+        if notification.read_at is None:
+            notification.read_at = func.now()
+            await session.commit()
+    except SQLAlchemyError as exc:
+        await _rollback_if_active(session)
+        if is_missing_table_error(exc):
+            return Response(status_code=204)
+        raise
+
+    return Response(status_code=204)
+
+
+async def _rollback_if_active(session: AsyncSession) -> None:
+    try:
+        if session.in_transaction():
+            await session.rollback()
+    except SQLAlchemyError:
+        pass

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -71,6 +71,7 @@ from ..services import (
     compute_streaks,
     rolling_win_percentage,
 )
+from ..services.notifications import notify_profile_comment
 from ..services.photo_uploads import (
     ALLOWED_PHOTO_TYPES as DEFAULT_ALLOWED_PHOTO_TYPES,
     CHUNK_SIZE as DEFAULT_CHUNK_SIZE,
@@ -894,6 +895,7 @@ async def add_comment(
     session.add(comment)
     await session.commit()
     await session.refresh(comment)
+    await notify_profile_comment(session, comment, user)
     return CommentOut(
         id=comment.id,
         playerId=comment.player_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from datetime import datetime
 import re
 from urllib.parse import urlparse
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, Field, model_validator, field_validator, ConfigDict
 
 from .location_utils import normalize_location_fields, continent_for_country
 from .time_utils import require_utc
@@ -497,6 +497,57 @@ class CommentListOut(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+
+class PushSubscriptionCreate(BaseModel):
+    endpoint: str
+    keys: PushSubscriptionKeys
+    content_encoding: str | None = Field(default=None, alias="contentEncoding")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PushSubscriptionOut(BaseModel):
+    id: str
+    endpoint: str
+    createdAt: datetime
+
+
+class NotificationPreferenceOut(BaseModel):
+    notifyOnProfileComments: bool
+    notifyOnMatchResults: bool
+    pushEnabled: bool
+    subscriptions: List[PushSubscriptionOut] = Field(default_factory=list)
+
+
+class NotificationPreferenceUpdate(BaseModel):
+    notify_on_profile_comments: bool | None = Field(
+        default=None, alias="notifyOnProfileComments"
+    )
+    notify_on_match_results: bool | None = Field(
+        default=None, alias="notifyOnMatchResults"
+    )
+    push_enabled: bool | None = Field(default=None, alias="pushEnabled")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class NotificationOut(BaseModel):
+    id: str
+    type: str
+    payload: Dict[str, Any]
+    createdAt: datetime
+    readAt: Optional[datetime] = None
+
+
+class NotificationListOut(BaseModel):
+    items: List[NotificationOut]
+    unreadCount: int
 
 class VersusRecord(BaseModel):
     """Win/loss record versus or with another player."""

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,402 @@
+"""Utilities for persisting and delivering user notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Iterable, Mapping
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import VAPID_PRIVATE_KEY, VAPID_PUBLIC_KEY, VAPID_SUBJECT
+from ..db_errors import is_missing_table_error
+from ..models import (
+    Comment,
+    Match,
+    Notification,
+    NotificationPreference,
+    Player,
+    PushSubscription,
+    User,
+)
+from ..time_utils import coerce_utc
+
+try:  # pragma: no cover - optional dependency in some environments
+    from pywebpush import WebPushException, webpush
+except Exception:  # pragma: no cover
+    WebPushException = None  # type: ignore[assignment]
+    webpush = None  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def notify_profile_comment(
+    session: AsyncSession,
+    comment: Comment,
+    author: User,
+) -> None:
+    """Create a notification when someone comments on a player's profile."""
+
+    try:
+        player = await session.get(Player, comment.player_id)
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "player"):
+            LOGGER.debug("Notification tables unavailable; skipping profile comment notification")
+            return
+        raise
+
+    if not player or not player.user_id or player.user_id == author.id:
+        return
+
+    preview = (comment.content or "").strip()
+    if len(preview) > 140:
+        preview = preview[:137].rstrip() + "…"
+
+    body = f"{author.username} commented on your profile."
+    payload = {
+        "title": "New profile comment",
+        "body": body,
+        "url": f"/players/{player.id}/",
+        "playerId": player.id,
+        "playerName": player.name,
+        "commentId": comment.id,
+        "commentPreview": preview,
+        "authorUsername": author.username,
+    }
+
+    await _create_notification(
+        session,
+        player.user_id,
+        notification_type="profile_comment",
+        payload=payload,
+        preference_field="notify_on_profile_comments",
+    )
+
+
+async def notify_match_recorded(
+    session: AsyncSession,
+    match: Match,
+    participants: Mapping[str, Iterable[str]],
+    actor: User | None = None,
+) -> None:
+    """Create notifications for users involved in a recorded match."""
+
+    participant_ids: set[str] = set()
+    for ids in participants.values():
+        participant_ids.update(pid for pid in ids if pid)
+
+    if not participant_ids:
+        return
+
+    try:
+        rows = await session.execute(
+            select(Player).where(Player.id.in_(participant_ids))
+        )
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "player"):
+            LOGGER.debug("Notification tables unavailable; skipping match notification")
+            return
+        raise
+
+    players = rows.scalars().all()
+    if not players:
+        return
+
+    player_by_id = {p.id: p for p in players if p.id}
+    users_to_players: dict[str, list[Player]] = {}
+    for player in players:
+        if not player.user_id:
+            continue
+        users_to_players.setdefault(player.user_id, []).append(player)
+
+    if not users_to_players:
+        return
+
+    sport_label = _format_sport(match.sport_id)
+    participant_payload = [
+        {
+            "side": side,
+            "playerIds": list(ids),
+            "playerNames": [player_by_id.get(pid).name for pid in ids if pid in player_by_id],
+        }
+        for side, ids in participants.items()
+    ]
+
+    for user_id, owned_players in users_to_players.items():
+        if actor and actor.id == user_id:
+            continue
+
+        player_names = ", ".join(sorted({p.name for p in owned_players if p.name}))
+        if not player_names:
+            player_names = "your player"
+
+        body = f"A new {sport_label} match involving {player_names} was recorded."
+        payload = {
+            "title": "Match recorded",
+            "body": body,
+            "url": f"/matches/{match.id}/",
+            "matchId": match.id,
+            "sportId": match.sport_id,
+            "playerIds": [p.id for p in owned_players],
+            "playerNames": [p.name for p in owned_players],
+            "participants": participant_payload,
+            "summary": match.details or {},
+        }
+
+        await _create_notification(
+            session,
+            user_id,
+            notification_type="match_recorded",
+            payload=payload,
+            preference_field="notify_on_match_results",
+        )
+
+
+async def _create_notification(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    notification_type: str,
+    payload: dict,
+    preference_field: str,
+) -> None:
+    prefs = await _get_or_create_preferences(session, user_id)
+    if not prefs or not getattr(prefs, preference_field, False):
+        return
+
+    notification = Notification(
+        id=uuid.uuid4().hex,
+        user_id=user_id,
+        type=notification_type,
+        payload=payload,
+    )
+    session.add(notification)
+
+    try:
+        await session.commit()
+        await session.refresh(notification)
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "notification"):
+            LOGGER.debug("Notification tables unavailable; skipping notification persistence")
+            return
+        raise
+
+    if prefs.push_enabled:
+        subscriptions = await _list_push_subscriptions(session, user_id)
+        if subscriptions:
+            await _dispatch_push_notifications(session, subscriptions, notification)
+
+
+async def _get_or_create_preferences(
+    session: AsyncSession, user_id: str
+) -> NotificationPreference | None:
+    try:
+        prefs = await session.get(NotificationPreference, user_id)
+        if prefs:
+            return prefs
+        prefs = NotificationPreference(user_id=user_id)
+        session.add(prefs)
+        await session.commit()
+        await session.refresh(prefs)
+        return prefs
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "notification_preference"):
+            LOGGER.debug("Notification preference table unavailable; skipping preference creation")
+            return None
+        raise
+
+
+async def _list_push_subscriptions(
+    session: AsyncSession, user_id: str
+) -> list[PushSubscription]:
+    try:
+        rows = await session.execute(
+            select(PushSubscription).where(PushSubscription.user_id == user_id)
+        )
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "push_subscription"):
+            LOGGER.debug("Push subscription table unavailable; skipping push delivery")
+            return []
+        raise
+    return list(rows.scalars())
+
+
+async def register_push_subscription(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    endpoint: str,
+    p256dh: str,
+    auth: str,
+    content_encoding: str | None = None,
+) -> PushSubscription | None:
+    if not endpoint:
+        return None
+
+    encoding = content_encoding or "aes128gcm"
+
+    try:
+        existing = (
+            await session.execute(
+                select(PushSubscription).where(PushSubscription.endpoint == endpoint)
+            )
+        ).scalar_one_or_none()
+
+        if existing:
+            existing.user_id = user_id
+            existing.p256dh = p256dh
+            existing.auth = auth
+            existing.content_encoding = encoding
+            await session.commit()
+            await session.refresh(existing)
+            return existing
+
+        subscription = PushSubscription(
+            id=uuid.uuid4().hex,
+            user_id=user_id,
+            endpoint=endpoint,
+            p256dh=p256dh,
+            auth=auth,
+            content_encoding=encoding,
+        )
+        session.add(subscription)
+        await session.commit()
+        await session.refresh(subscription)
+        return subscription
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "push_subscription"):
+            LOGGER.debug("Push subscription table unavailable; skipping registration")
+            return None
+        raise
+
+
+async def delete_push_subscriptions(session: AsyncSession, user_id: str) -> None:
+    try:
+        await session.execute(
+            delete(PushSubscription).where(PushSubscription.user_id == user_id)
+        )
+        await session.commit()
+    except SQLAlchemyError as exc:  # pragma: no cover - handled gracefully
+        await _safe_rollback(session)
+        if is_missing_table_error(exc, "push_subscription"):
+            LOGGER.debug("Push subscription table unavailable; skipping delete")
+            return
+        raise
+
+
+def _format_sport(sport_id: str | None) -> str:
+    if not sport_id:
+        return "sport"
+    parts = [part for part in sport_id.replace("_", " ").split() if part]
+    return " ".join(word.capitalize() for word in parts) or sport_id
+
+
+async def _dispatch_push_notifications(
+    session: AsyncSession,
+    subscriptions: list[PushSubscription],
+    notification: Notification,
+) -> None:
+    if not _push_available():
+        return
+
+    payload = {
+        "id": notification.id,
+        "type": notification.type,
+        "createdAt": coerce_utc(notification.created_at).isoformat(),
+        "readAt": coerce_utc(notification.read_at).isoformat()
+        if notification.read_at
+        else None,
+        "payload": notification.payload,
+    }
+
+    invalid_ids: list[str] = []
+    for subscription in subscriptions:
+        try:
+            await _send_push(subscription, payload)
+        except _InvalidSubscriptionError:
+            invalid_ids.append(subscription.id)
+        except Exception:  # pragma: no cover - unexpected push failure
+            LOGGER.exception("Failed to send push notification")
+
+    if invalid_ids:
+        try:
+            await session.execute(
+                delete(PushSubscription).where(PushSubscription.id.in_(invalid_ids))
+            )
+            await session.commit()
+        except SQLAlchemyError as exc:  # pragma: no cover
+            await _safe_rollback(session)
+            if is_missing_table_error(exc, "push_subscription"):
+                LOGGER.debug("Push subscription table unavailable while pruning invalid entries")
+                return
+            raise
+
+
+def _push_available() -> bool:
+    return bool(webpush and VAPID_PRIVATE_KEY and VAPID_PUBLIC_KEY)
+
+
+class _InvalidSubscriptionError(Exception):
+    """Raised when a push subscription is no longer valid."""
+
+
+async def _send_push(subscription: PushSubscription, payload: dict) -> None:
+    if not _push_available():  # pragma: no cover - guarded earlier
+        return
+
+    data = {
+        "title": payload.get("payload", {}).get("title")
+        if isinstance(payload.get("payload"), dict)
+        else None,
+        "body": payload.get("payload", {}).get("body")
+        if isinstance(payload.get("payload"), dict)
+        else None,
+        "url": payload.get("payload", {}).get("url")
+        if isinstance(payload.get("payload"), dict)
+        else None,
+        "notification": payload,
+    }
+
+    async def _deliver() -> None:
+        assert webpush is not None  # for mypy
+        assert VAPID_PRIVATE_KEY is not None
+        subscription_info = {
+            "endpoint": subscription.endpoint,
+            "keys": {"p256dh": subscription.p256dh, "auth": subscription.auth},
+        }
+        try:
+            await asyncio.to_thread(
+                webpush,
+                subscription_info=subscription_info,
+                data=json.dumps(data),
+                vapid_private_key=VAPID_PRIVATE_KEY,
+                vapid_claims={"sub": VAPID_SUBJECT},
+                vapid_public_key=VAPID_PUBLIC_KEY,
+                content_encoding=subscription.content_encoding,
+            )
+        except WebPushException as exc:  # pragma: no cover - depends on external service
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in {404, 410}:
+                raise _InvalidSubscriptionError from exc
+            LOGGER.warning("Web push delivery failed: %s", exc)
+
+    await _deliver()
+
+
+async def _safe_rollback(session: AsyncSession) -> None:
+    try:
+        if session.in_transaction():
+            await session.rollback()
+    except SQLAlchemyError:  # pragma: no cover - best effort
+        pass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ matplotlib>=3.7,<4.0
 slowapi>=0.1,<1.0
 passlib[bcrypt]>=1.7,<2.0
 Pillow>=10.0,<12.0
+pywebpush>=1.14.0,<2.0

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,156 @@
+import asyncio
+import os
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import db
+from app.models import Sport
+from app.routers import auth, matches, notifications, players
+
+
+os.environ.setdefault("ADMIN_SECRET", "admintest")
+
+
+TEST_PASSWORD = "Str0ng!Pass!"
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _signup_user(client: TestClient, *, is_admin: bool = False) -> tuple[str, str]:
+    username = f"user_{uuid.uuid4().hex[:8]}"
+    payload: dict[str, object] = {"username": username, "password": TEST_PASSWORD}
+    headers: dict[str, str] = {}
+    if is_admin:
+        payload["is_admin"] = True
+        headers["X-Admin-Secret"] = os.environ["ADMIN_SECRET"]
+    resp = client.post("/auth/signup", json=payload, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    return data["access_token"], username
+
+
+def _create_player_for_user(client: TestClient, token: str) -> dict:
+    resp = client.post("/players/me", headers=_auth_headers(token))
+    if resp.status_code in (200, 201):
+        return resp.json()
+    if resp.status_code == 400:
+        existing = client.get("/players/me", headers=_auth_headers(token))
+        assert existing.status_code == 200
+        return existing.json()
+    assert False, f"unexpected status {resp.status_code}: {resp.text}"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_sports():
+    async def _insert() -> None:
+        async with db.AsyncSessionLocal() as session:
+            session.add(Sport(id="padel", name="Padel"))
+            await session.commit()
+
+    asyncio.run(_insert())
+
+
+def test_comment_and_match_notifications_flow():
+    app = FastAPI()
+    app.include_router(auth.router)
+    app.include_router(players.router)
+    app.include_router(matches.router)
+    app.include_router(notifications.router)
+
+    with TestClient(app) as client:
+        auth.limiter.reset()
+        owner_token, _ = _signup_user(client)
+        opponent_token, _ = _signup_user(client)
+        admin_token, _ = _signup_user(client, is_admin=True)
+
+        owner_player = _create_player_for_user(client, owner_token)
+        opponent_player = _create_player_for_user(client, opponent_token)
+
+        # Preferences default to opt-out
+        pref_resp = client.get(
+            "/notifications/preferences",
+            headers=_auth_headers(owner_token),
+        )
+        assert pref_resp.status_code == 200
+        pref_data = pref_resp.json()
+        assert pref_data["notifyOnProfileComments"] is False
+        assert pref_data["notifyOnMatchResults"] is False
+
+        # Enable comment notifications for owner
+        update_resp = client.put(
+            "/notifications/preferences",
+            json={"notifyOnProfileComments": True},
+            headers=_auth_headers(owner_token),
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["notifyOnProfileComments"] is True
+
+        # Comment from another user triggers a notification
+        comment_resp = client.post(
+            f"/players/{owner_player['id']}/comments",
+            json={"content": "Nice game!"},
+            headers=_auth_headers(opponent_token),
+        )
+        assert comment_resp.status_code == 200
+
+        notif_resp = client.get(
+            "/notifications",
+            headers=_auth_headers(owner_token),
+        )
+        assert notif_resp.status_code == 200
+        notif_data = notif_resp.json()
+        types = [item["type"] for item in notif_data["items"]]
+        assert "profile_comment" in types
+
+        # Enable match notifications for both players
+        client.put(
+            "/notifications/preferences",
+            json={"notifyOnMatchResults": True},
+            headers=_auth_headers(owner_token),
+        )
+        client.put(
+            "/notifications/preferences",
+            json={"notifyOnMatchResults": True},
+            headers=_auth_headers(opponent_token),
+        )
+
+        match_payload = {
+            "sport": "padel",
+            "participants": [
+                {"side": "A", "playerIds": [owner_player["id"]]},
+                {"side": "B", "playerIds": [opponent_player["id"]]},
+            ],
+            "bestOf": 3,
+            "sets": [[6, 4], [6, 3]],
+            "isFriendly": False,
+        }
+        match_resp = client.post(
+            "/matches",
+            json=match_payload,
+            headers=_auth_headers(admin_token),
+        )
+        assert match_resp.status_code == 200
+
+        owner_notifs = client.get(
+            "/notifications",
+            headers=_auth_headers(owner_token),
+        ).json()
+        assert "match_recorded" in [item["type"] for item in owner_notifs["items"]]
+
+        opponent_notifs = client.get(
+            "/notifications",
+            headers=_auth_headers(opponent_token),
+        ).json()
+        match_ids = [item for item in opponent_notifs["items"] if item["type"] == "match_recorded"]
+        assert match_ids, "Opponent should receive match notification"
+
+        mark_resp = client.post(
+            f"/notifications/{match_ids[0]['id']}/read",
+            headers=_auth_headers(opponent_token),
+        )
+        assert mark_resp.status_code == 204


### PR DESCRIPTION
## Summary
- add database models, migration, and FastAPI endpoints for user notifications, push subscriptions, and preference updates
- implement notification service logic and integrate match/comment hooks to create notifications and trigger push delivery
- expose notification settings and push opt-in on the profile page, update API client, add service worker, and expand tests

## Testing
- pytest
- CI=1 pnpm vitest run src/app/profile/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db22e6eb108323b77aef17880fe492