### PR TITLE
Implement SWR caching for client data fetching

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -14,7 +14,8 @@
         "next": "14.2.5",
         "react": "18.3.1",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "swr": "^2.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",
@@ -2881,9 +2882,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6718,6 +6717,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7106,6 +7118,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "swr": "^2.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",

--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -20,6 +20,13 @@ vi.mock('../../lib/server-locale', () => ({
   }),
 }));
 
+const cookiesMock = vi.hoisted(() => vi.fn(() => ({ get: vi.fn(() => undefined) })));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => new Headers()),
+  cookies: cookiesMock,
+}));
+
 const mockedApiFetch = vi.mocked(apiFetch);
 
 const makeApiError = (

--- a/apps/web/src/app/matches/[mid]/page.test.tsx
+++ b/apps/web/src/app/matches/[mid]/page.test.tsx
@@ -60,8 +60,11 @@ vi.mock("../../../lib/api", async () => {
   };
 });
 
+const cookiesMock = vi.hoisted(() => vi.fn(() => ({ get: vi.fn(() => undefined) })));
+
 vi.mock("next/headers", () => ({
   headers: vi.fn(() => new Headers()),
+  cookies: cookiesMock,
 }));
 
 vi.mock("next/navigation", () => {

--- a/apps/web/src/app/players/[id]/comments-client.test.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { SWRConfig } from "swr";
 
 const apiMocks = vi.hoisted(() => ({
   apiFetch: vi.fn<
@@ -46,10 +47,18 @@ describe("PlayerComments", () => {
     );
   });
 
-  it("prompts unauthenticated users to log in", async () => {
-    await act(async () => {
-      render(<PlayerComments playerId="player-1" />);
+  function renderComponent() {
+    return act(async () => {
+      render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <PlayerComments playerId="player-1" />
+        </SWRConfig>,
+      );
     });
+  }
+
+  it("prompts unauthenticated users to log in", async () => {
+    await renderComponent();
 
     expect(await screen.findByText("No comments.")).toBeInTheDocument();
     expect(
@@ -57,7 +66,7 @@ describe("PlayerComments", () => {
     ).toBeInTheDocument();
     expect(apiMocks.apiFetch).toHaveBeenCalledWith(
       "/v0/players/player-1/comments",
-      { cache: "no-store" }
+      undefined
     );
   });
 
@@ -97,9 +106,7 @@ describe("PlayerComments", () => {
       );
     });
 
-    await act(async () => {
-      render(<PlayerComments playerId="player-1" />);
-    });
+    await renderComponent();
 
     const textarea = await screen.findByLabelText("Add a comment");
     fireEvent.change(textarea, { target: { value: "Great match!" } });
@@ -138,9 +145,7 @@ describe("PlayerComments", () => {
       );
     });
 
-    await act(async () => {
-      render(<PlayerComments playerId="player-1" />);
-    });
+    await renderComponent();
 
     const textarea = await screen.findByLabelText("Add a comment");
     fireEvent.change(textarea, { target: { value: "Hi" } });

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -13,6 +13,7 @@ import {
 import { flushSync } from "react-dom";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import { invalidateMatchesCache } from "../../../lib/useApiSWR";
 import { useLocale } from "../../../lib/LocaleContext";
 import {
   getDateExample,
@@ -802,6 +803,11 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
+        try {
+          await invalidateMatchesCache();
+        } catch (cacheErr) {
+          console.error("Failed to invalidate match caches", cacheErr);
+        }
         router.push(`/matches`);
       } catch (err) {
         console.error(err);
@@ -858,6 +864,11 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
+      try {
+        await invalidateMatchesCache();
+      } catch (cacheErr) {
+        console.error("Failed to invalidate match caches", cacheErr);
+      }
       router.push(`/matches`);
     } catch (err) {
       console.error(err);

--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { invalidateMatchesCache } from "../../../lib/useApiSWR";
 
 const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
@@ -107,6 +108,11 @@ function DiscGolfForm() {
         throw new Error("Failed to create match");
       }
       const data = (await res.json()) as { id: string };
+      try {
+        await invalidateMatchesCache();
+      } catch (cacheErr) {
+        console.error("Failed to invalidate match caches", cacheErr);
+      }
       navigateToMatch(data.id);
     } catch {
       setMatchPickerError("Failed to start a new match.");

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useId, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import { invalidateMatchesCache } from "../../../lib/useApiSWR";
 import { ensureTrailingSlash } from "../../../lib/routes";
 import { useLocale } from "../../../lib/LocaleContext";
 import {
@@ -367,6 +368,11 @@ export default function RecordPadelPage() {
         });
       }
       setSuccess(true);
+      try {
+        await invalidateMatchesCache();
+      } catch (cacheErr) {
+        console.error("Failed to invalidate match caches", cacheErr);
+      }
       router.push(`/matches`);
     } catch (err) {
       console.error("Failed to save padel match", err);

--- a/apps/web/src/lib/useApiSWR.ts
+++ b/apps/web/src/lib/useApiSWR.ts
@@ -1,0 +1,151 @@
+import useSWR, {
+  mutate,
+  type Key,
+  type MutateOptions,
+  type SWRConfiguration,
+  type SWRResponse,
+} from 'swr';
+import { apiFetch, type ApiError } from './api';
+
+const API_CACHE_KEY_PREFIX = 'api:';
+const DEFAULT_DEDUPING_INTERVAL = 60_000;
+
+function headersToObject(headers?: HeadersInit): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) {
+    const entries: [string, string][] = [];
+    headers.forEach((value, key) => {
+      entries.push([key, value]);
+    });
+    return Object.fromEntries(
+      entries.sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+    );
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(
+      headers
+        .map(([key, value]) => [key, value] as const)
+        .sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+    );
+  }
+  const normalized = Object.entries(headers).sort(([a], [b]) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' }),
+  );
+  return Object.fromEntries(normalized);
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([key, entry]) => [key, entry] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(',')}}`;
+}
+
+function normalizeInit(init?: RequestInit): Record<string, unknown> | undefined {
+  if (!init) return undefined;
+  const { method, cache, credentials, mode, redirect, referrer, referrerPolicy, next } = init;
+  const headers = headersToObject(init.headers);
+  const normalized = removeUndefined({
+    method,
+    cache,
+    credentials,
+    mode,
+    redirect,
+    referrer,
+    referrerPolicy,
+    next,
+    headers,
+  });
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function getApiCacheKey(path: string, init?: RequestInit): string {
+  const normalizedInit = normalizeInit(init);
+  if (!normalizedInit) {
+    return `${API_CACHE_KEY_PREFIX}${path}`;
+  }
+  return `${API_CACHE_KEY_PREFIX}${path}?${stableStringify(normalizedInit)}`;
+}
+
+async function defaultParse<T>(response: Response): Promise<T> {
+  const contentType = response.headers?.get?.('content-type') ?? '';
+  if (contentType.toLowerCase().includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  return (await response.text()) as unknown as T;
+}
+
+type Matcher = string | RegExp | ((key: string) => boolean);
+
+type UseApiSWRConfig<T> = {
+  init?: RequestInit;
+  parse?: (response: Response) => Promise<T>;
+  swr?: SWRConfiguration<T, ApiError>;
+};
+
+function matchesNormalizedKey(normalizedKey: string, matcher: Matcher): boolean {
+  if (typeof matcher === 'string') {
+    return normalizedKey === matcher;
+  }
+  if (matcher instanceof RegExp) {
+    return matcher.test(normalizedKey);
+  }
+  return matcher(normalizedKey);
+}
+
+export function useApiSWR<T>(
+  path: string | null,
+  config?: UseApiSWRConfig<T>,
+): SWRResponse<T, ApiError> {
+  const { init, parse = defaultParse, swr } = config ?? {};
+  const key = path ? getApiCacheKey(path, init) : null;
+  return useSWR<T, ApiError>(
+    key,
+    path
+      ? async () => {
+          const response = await apiFetch(path, init);
+          return parse(response);
+        }
+      : null,
+    {
+      dedupingInterval: DEFAULT_DEDUPING_INTERVAL,
+      keepPreviousData: true,
+      revalidateOnFocus: true,
+      ...(swr ?? {}),
+    },
+  );
+}
+
+export async function invalidateApiResource(
+  matcher: Matcher,
+  options?: Partial<MutateOptions<unknown, ApiError>>,
+) {
+  await mutate(
+    (key: Key) => {
+      if (typeof key !== 'string') return false;
+      if (!key.startsWith(API_CACHE_KEY_PREFIX)) return false;
+      const normalized = key.slice(API_CACHE_KEY_PREFIX.length);
+      return matchesNormalizedKey(normalized, matcher);
+    },
+    undefined,
+    { revalidate: true, ...(options ?? {}) },
+  );
+}
+
+export function invalidateMatchesCache(options?: Partial<MutateOptions<unknown, ApiError>>) {
+  return invalidateApiResource((key) => key.includes('/v0/matches'), options);
+}


### PR DESCRIPTION
## Summary
- add an SWR-based API helper with cache invalidation utilities and adopt it in the home page and player comments views
- trigger match cache invalidation from match creation flows in padel, disc golf, and the shared record form
- refresh affected tests for the new caching behavior and API mocks

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68db26543e9483239ba1d3452bcc68e3