### PR TITLE
Style padel Americano guidance and update fixtures link

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -198,6 +198,29 @@ img {
   margin: 0;
 }
 
+.padel-americano-tips {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.padel-americano-tips__intro,
+.padel-americano-tips__footer {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.padel-americano-tips__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  line-height: 1.6;
+}
+
+.padel-americano-tips__list li {
+  margin: 0;
+}
+
 .form-hint {
   font-size: 0.8rem;
   color: rgba(10, 31, 68, 0.7);

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   useCallback,
   useEffect,
@@ -870,14 +871,17 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   return (
     <main className="container">
       {isPadelAmericano && (
-        <section className="card" aria-labelledby="padel-americano-tips-heading">
-          <h2 id="padel-americano-tips-heading" className="heading" style={{ marginBottom: "0.75rem" }}>
+        <section
+          className="card padel-americano-tips"
+          aria-labelledby="padel-americano-tips-heading"
+        >
+          <h2 id="padel-americano-tips-heading" className="heading">
             Recording a padel Americano tie
           </h2>
-          <p style={{ marginTop: 0 }}>
+          <p className="padel-americano-tips__intro">
             Review the Americano rotation before saving each tie so every player pairing is captured accurately.
           </p>
-          <ul>
+          <ul className="padel-americano-tips__list">
             <li>
               <strong>Sign in first:</strong> logging in keeps all of your Americano ties together and lets you resume an unfinished session.
             </li>
@@ -890,10 +894,11 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
             <li>
               <strong>Note session details:</strong> record the date, start time and venue so everyone can find the tie later. Mark it as friendly for social hits.
             </li>
-            <li>
-              <strong>Need fixtures?</strong> Generate a full Americano schedule from the <a href="/tournaments/">tournaments page</a> before logging results here.
-            </li>
           </ul>
+          <p className="padel-americano-tips__footer">
+            <strong>Need fixtures?</strong> Generate a full Americano schedule from the{" "}
+            <Link href="/tournaments/">tournaments page</Link> before logging results here.
+          </p>
         </section>
       )}
       <form onSubmit={handleSubmit} className="form-stack">


### PR DESCRIPTION
## Summary
- style the padel Americano tips card with consistent spacing and typography helpers
- move the fixtures guidance below the tips list and link it to the tournaments page via Next.js routing

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68db272980488323a26fc9b6d55f8aab