### PR TITLE
Add coming soon fallback for tournaments scheduler page

### DIFF
--- a/apps/web/src/app/__tests__/tournaments.page.test.tsx
+++ b/apps/web/src/app/__tests__/tournaments.page.test.tsx
@@ -213,6 +213,21 @@ describe('Tournaments client view', () => {
     expect(screen.getByText('Billie')).toBeInTheDocument();
   });
 
+  it('shows a coming soon message when tournaments are unavailable', async () => {
+    render(
+      <TournamentsClient
+        initialTournaments={[]}
+        loadError={false}
+        comingSoon
+      />
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: /coming soon/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/tournament name/i)).toBeNull();
+  });
+
   it('allows bulk selecting and clearing filtered players', async () => {
     const playerList = [
       { id: 'p1', name: 'Alex' },

--- a/apps/web/src/app/tournaments/page.tsx
+++ b/apps/web/src/app/tournaments/page.tsx
@@ -1,15 +1,25 @@
 import TournamentsClient from "./tournaments-client";
-import { listTournaments, type TournamentSummary } from "../../lib/api";
+import {
+  listTournaments,
+  type ApiError,
+  type TournamentSummary,
+} from "../../lib/api";
 
 export default async function TournamentsPage() {
   let tournaments: TournamentSummary[] = [];
   let loadError = false;
+  let comingSoon = false;
 
   try {
     tournaments = await listTournaments({ cache: "no-store" });
   } catch (err) {
-    console.error("Failed to load tournaments", err);
-    loadError = true;
+    const apiError = err as ApiError | undefined;
+    if (apiError?.status === 404) {
+      comingSoon = true;
+    } else {
+      console.error("Failed to load tournaments", err);
+      loadError = true;
+    }
   }
 
   return (
@@ -21,6 +31,7 @@ export default async function TournamentsPage() {
       <TournamentsClient
         initialTournaments={tournaments}
         loadError={loadError}
+        comingSoon={comingSoon}
       />
     </main>
   );

--- a/apps/web/src/app/tournaments/tournaments-client.tsx
+++ b/apps/web/src/app/tournaments/tournaments-client.tsx
@@ -16,11 +16,13 @@ import CreateTournamentForm from "./create-tournament-form";
 interface TournamentsClientProps {
   initialTournaments: TournamentSummary[];
   loadError?: boolean;
+  comingSoon?: boolean;
 }
 
 export default function TournamentsClient({
   initialTournaments,
   loadError = false,
+  comingSoon = false,
 }: TournamentsClientProps) {
   const [tournaments, setTournaments] = useState(initialTournaments);
   const [admin, setAdmin] = useState(() => isAdmin());
@@ -104,66 +106,78 @@ export default function TournamentsClient({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-      <CreateTournamentForm onCreated={handleTournamentCreated} />
-      <section
-        aria-labelledby="tournament-list-heading"
-        style={{ display: "flex", flexDirection: "column", gap: 16 }}
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <h2 id="tournament-list-heading" className="subheading">
-            Existing tournaments
-          </h2>
-          <p className="form-hint">
-            Browse previously created tournaments and manage their stages.
+      {comingSoon ? (
+        <section className="card" style={{ padding: 16 }}>
+          <h2 className="subheading">Coming soon</h2>
+          <p className="form-hint" style={{ marginTop: 8 }}>
+            The Americano tournament scheduler is still being set up. Check
+            back soon to generate rotations and manage fixtures.
           </p>
-        </div>
-        {error && (
-          <p className="error" role="alert">
-            {error}
-          </p>
-        )}
-        {emptyMessage ? (
-          <p className={loadError ? "error" : "form-hint"}>{emptyMessage}</p>
-        ) : (
-          <ul style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {tournaments.map((tournament) => (
-              <li key={tournament.id} className="card" style={{ padding: 16 }}>
-                <div
-                  style={{ display: "flex", flexDirection: "column", gap: 8 }}
-                >
-                  <div>
-                    <h3 style={{ fontSize: 18, fontWeight: 600 }}>
-                      {tournament.name}
-                    </h3>
-                    <p className="form-hint">Sport: {tournament.sport}</p>
-                    {tournament.clubId && (
-                      <p className="form-hint">Club: {tournament.clubId}</p>
-                    )}
-                  </div>
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                    <Link
-                      href={ensureTrailingSlash(`/tournaments/${tournament.id}`)}
-                      className="link-button"
+        </section>
+      ) : (
+        <>
+          <CreateTournamentForm onCreated={handleTournamentCreated} />
+          <section
+            aria-labelledby="tournament-list-heading"
+            style={{ display: "flex", flexDirection: "column", gap: 16 }}
+          >
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <h2 id="tournament-list-heading" className="subheading">
+                Existing tournaments
+              </h2>
+              <p className="form-hint">
+                Browse previously created tournaments and manage their stages.
+              </p>
+            </div>
+            {error && (
+              <p className="error" role="alert">
+                {error}
+              </p>
+            )}
+            {emptyMessage ? (
+              <p className={loadError ? "error" : "form-hint"}>{emptyMessage}</p>
+            ) : (
+              <ul style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                {tournaments.map((tournament) => (
+                  <li key={tournament.id} className="card" style={{ padding: 16 }}>
+                    <div
+                      style={{ display: "flex", flexDirection: "column", gap: 8 }}
                     >
-                      View tournament
-                    </Link>
-                    {canDelete(tournament) && (
-                      <button
-                        type="button"
-                        className="link-button"
-                        onClick={() => handleDelete(tournament)}
-                        disabled={deletingId === tournament.id}
-                      >
-                        {deletingId === tournament.id ? "Deleting…" : "Delete"}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                      <div>
+                        <h3 style={{ fontSize: 18, fontWeight: 600 }}>
+                          {tournament.name}
+                        </h3>
+                        <p className="form-hint">Sport: {tournament.sport}</p>
+                        {tournament.clubId && (
+                          <p className="form-hint">Club: {tournament.clubId}</p>
+                        )}
+                      </div>
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Link
+                          href={ensureTrailingSlash(`/tournaments/${tournament.id}`)}
+                          className="link-button"
+                        >
+                          View tournament
+                        </Link>
+                        {canDelete(tournament) && (
+                          <button
+                            type="button"
+                            className="link-button"
+                            onClick={() => handleDelete(tournament)}
+                            disabled={deletingId === tournament.id}
+                          >
+                            {deletingId === tournament.id ? "Deleting…" : "Delete"}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- detect a missing tournaments API and flag the scheduler page as coming soon
- hide the tournament creation UI and show a coming soon card when scheduling is unavailable
- cover the new behaviour with a Vitest assertion

## Testing
- pnpm vitest run tournaments

------
https://chatgpt.com/codex/tasks/task_e_68db324a8dc48323ac1a7a18d3ce127c