### PR TITLE
Fix pagination offset when revalidating matches

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -263,14 +263,12 @@ export default function HomePageClient({
   useEffect(() => {
     if (!matchPage) return;
 
+    const previousMatches = matches;
+    const nextPageMatches = matchPage.enriched;
     let hasAdditionalMatches = false;
+    let nextMatches: EnrichedMatch[] = nextPageMatches;
 
-    setMatches((previousMatches) => {
-      const nextPageMatches = matchPage.enriched;
-      if (!previousMatches.length) {
-        return nextPageMatches;
-      }
-
+    if (previousMatches.length) {
       const nextIds = new Set(nextPageMatches.map((match) => match.id));
       const preservedMatches: EnrichedMatch[] = [];
 
@@ -291,16 +289,20 @@ export default function HomePageClient({
         }
 
         if (isSameOrder) {
-          return previousMatches;
+          nextMatches = previousMatches;
         }
       }
 
-      if (!preservedMatches.length && previousMatches.length === nextPageMatches.length) {
-        return nextPageMatches;
+      if (nextMatches === nextPageMatches) {
+        if (!preservedMatches.length && previousMatches.length === nextPageMatches.length) {
+          nextMatches = nextPageMatches;
+        } else {
+          nextMatches = [...nextPageMatches, ...preservedMatches];
+        }
       }
+    }
 
-      return [...nextPageMatches, ...preservedMatches];
-    });
+    setMatches(nextMatches);
 
     if (typeof matchPage.limit === 'number') {
       setPageSize((currentPageSize) =>


### PR DESCRIPTION
## Summary
- derive the merged matches list synchronously to know whether older pages are preserved during a revalidation
- only reset the next page offset when no additional matches are retained so pagination keeps advancing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db32debd7083239d63d24d5daf03a3