### PR TITLE
Disable bowling add player button at limit

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -131,6 +131,12 @@ img {
   background: rgba(26, 115, 232, 0.08);
 }
 
+.button-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: transparent;
+}
+
 .link-button {
   background: none;
   border: none;

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -389,6 +389,8 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   const [bowlingValidationErrors, setBowlingValidationErrors] = useState<
     (string | null)[]
   >([null]);
+  const bowlingMaxReached =
+    bowlingEntries.length >= MAX_BOWLING_PLAYERS;
   const bowlingInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const pendingBowlingFocusRef = useRef<string | null>(null);
   const [scoreA, setScoreA] = useState("0");
@@ -686,6 +688,9 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
   };
 
   const handleAddBowlingPlayer = () => {
+    if (bowlingMaxReached) {
+      return;
+    }
     flushSync(() => {
       setBowlingEntries((prev) => [
         ...prev,
@@ -1226,15 +1231,21 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
                 );
               })}
             </div>
-            {bowlingEntries.length < MAX_BOWLING_PLAYERS && (
+            <div className="form-field">
               <button
                 type="button"
                 className="button-secondary"
                 onClick={handleAddBowlingPlayer}
+                disabled={bowlingMaxReached}
               >
                 Add player
               </button>
-            )}
+              {bowlingMaxReached && (
+                <p className="form-hint" role="status">
+                  Maximum {MAX_BOWLING_PLAYERS} players
+                </p>
+              )}
+            </div>
           </fieldset>
         ) : (
           <>


### PR DESCRIPTION
## Summary
- prevent adding more than six bowling players by disabling the add button once the limit is reached
- surface a "Maximum 6 players" helper message and add disabled styling for the secondary button state

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db34ff87f48323ba28dd8a632d0831