### PR TITLE
Use functional match state update to avoid stale pagination data

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -263,46 +263,48 @@ export default function HomePageClient({
   useEffect(() => {
     if (!matchPage) return;
 
-    const previousMatches = matches;
     const nextPageMatches = matchPage.enriched;
     let hasAdditionalMatches = false;
-    let nextMatches: EnrichedMatch[] = nextPageMatches;
 
-    if (previousMatches.length) {
-      const nextIds = new Set(nextPageMatches.map((match) => match.id));
-      const preservedMatches: EnrichedMatch[] = [];
+    setMatches((previousMatches) => {
+      let nextMatches: EnrichedMatch[] = nextPageMatches;
 
-      for (const match of previousMatches) {
-        if (!nextIds.has(match.id)) {
-          preservedMatches.push(match);
-          hasAdditionalMatches = true;
-        }
-      }
+      if (previousMatches.length) {
+        const nextIds = new Set(nextPageMatches.map((match) => match.id));
+        const preservedMatches: EnrichedMatch[] = [];
 
-      if (!hasAdditionalMatches && previousMatches.length === nextPageMatches.length) {
-        let isSameOrder = true;
-        for (let index = 0; index < previousMatches.length; index += 1) {
-          if (previousMatches[index]?.id !== nextPageMatches[index]?.id) {
-            isSameOrder = false;
-            break;
+        for (const match of previousMatches) {
+          if (!nextIds.has(match.id)) {
+            preservedMatches.push(match);
+            hasAdditionalMatches = true;
           }
         }
 
-        if (isSameOrder) {
-          nextMatches = previousMatches;
+        if (!hasAdditionalMatches && previousMatches.length === nextPageMatches.length) {
+          let isSameOrder = true;
+          for (let index = 0; index < previousMatches.length; index += 1) {
+            if (previousMatches[index]?.id !== nextPageMatches[index]?.id) {
+              isSameOrder = false;
+              break;
+            }
+          }
+
+          if (isSameOrder) {
+            nextMatches = previousMatches;
+          }
+        }
+
+        if (nextMatches === nextPageMatches) {
+          if (!preservedMatches.length && previousMatches.length === nextPageMatches.length) {
+            nextMatches = nextPageMatches;
+          } else {
+            nextMatches = [...nextPageMatches, ...preservedMatches];
+          }
         }
       }
 
-      if (nextMatches === nextPageMatches) {
-        if (!preservedMatches.length && previousMatches.length === nextPageMatches.length) {
-          nextMatches = nextPageMatches;
-        } else {
-          nextMatches = [...nextPageMatches, ...preservedMatches];
-        }
-      }
-    }
-
-    setMatches(nextMatches);
+      return nextMatches;
+    });
 
     if (typeof matchPage.limit === 'number') {
       setPageSize((currentPageSize) =>


### PR DESCRIPTION
## Summary
- derive match list updates from the latest state when processing new pages
- prevent overwriting appended matches during revalidation by using the functional setState form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db36ca4044832385d887a8f83a445d