### PR TITLE
Fix lint issues across the web app

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -331,18 +331,16 @@ export default function HomePageClient({
   useEffect(() => {
     if (!matchPage) return;
 
-    setMatches((previousMatches) => {
-      const { matches: nextMatches, hasAdditionalMatches } = mergeMatchPageWithPrevious(
-        previousMatches,
-        matchPage.enriched,
-      );
+    const { matches: nextMatches, hasAdditionalMatches } = mergeMatchPageWithPrevious(
+      matches,
+      matchPage.enriched,
+    );
 
-      setNextOffset((currentNextOffset) =>
-        resolveNextOffset(currentNextOffset, matchPage.nextOffset, hasAdditionalMatches),
-      );
+    setMatches(nextMatches);
 
-      return nextMatches;
-    });
+    setNextOffset((currentNextOffset) =>
+      resolveNextOffset(currentNextOffset, matchPage.nextOffset, hasAdditionalMatches),
+    );
 
     if (typeof matchPage.limit === 'number') {
       setPageSize((currentPageSize) =>
@@ -353,7 +351,7 @@ export default function HomePageClient({
     setHasMore(matchPage.hasMore);
 
     setMatchError(false);
-  }, [matchPage]);
+  }, [matchPage, matches]);
 
   const matchesLoading =
     !matchError && matches.length === 0 && matchesIsLoading;

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -14,7 +14,6 @@ import { ensureTrailingSlash } from "../../lib/routes";
 import { resolveServerLocale } from "../../lib/server-locale";
 import {
   enrichMatches,
-  type EnrichedMatch,
   type MatchRow,
   type MatchSummaryData,
 } from "../../lib/matches";

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -46,11 +46,7 @@ import {
   saveUserSettings,
   type UserSettings,
 } from "../user-settings";
-import {
-  normalizeTimeZone,
-  resolveTimeZone,
-  DEFAULT_TIME_ZONE,
-} from "../../lib/i18n";
+import { normalizeTimeZone, DEFAULT_TIME_ZONE } from "../../lib/i18n";
 import {
   ALL_SPORTS,
   MASTER_SPORT,

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -201,7 +201,6 @@ describe("RecordPadelPage", () => {
 
     const playerA1 = await screen.findByRole("combobox", { name: "Player A 1" });
     const playerB1 = await screen.findByRole("combobox", { name: "Player B 1" });
-    const playerB2 = await screen.findByRole("combobox", { name: "Player B 2" });
     const saveButton = screen.getByRole("button", { name: /save/i });
 
     fireEvent.change(playerA1, {

--- a/apps/web/src/app/tournaments/create-tournament-form.tsx
+++ b/apps/web/src/app/tournaments/create-tournament-form.tsx
@@ -227,20 +227,6 @@ export default function CreateTournamentForm({
     }
   };
 
-  if (!loggedIn) {
-    return (
-      <section className="card" style={{ padding: 16 }}>
-        <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 12 }}>
-          Sign in to create an Americano tournament
-        </h2>
-        <p className="form-hint">
-          Log in to create padel Americano tournaments, schedule matches, and share them
-          with your club.
-        </p>
-      </section>
-    );
-  }
-
   const selectedCount = selectedPlayers.length;
   const filteredPlayers = useMemo(() => {
     const trimmedSearch = playerSearch.trim().toLowerCase();
@@ -302,6 +288,20 @@ export default function CreateTournamentForm({
     selectedCount >= MIN_AMERICANO_PLAYERS
       ? `Ready to schedule with ${selectedCount} player${selectedCount === 1 ? "" : "s"}. Use the search box to adjust the roster.`
       : `Use the search box to add at least ${MIN_AMERICANO_PLAYERS} players before generating the Americano schedule.`;
+
+  if (!loggedIn) {
+    return (
+      <section className="card" style={{ padding: 16 }}>
+        <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 12 }}>
+          Sign in to create an Americano tournament
+        </h2>
+        <p className="form-hint">
+          Log in to create padel Americano tournaments, schedule matches, and share them
+          with your club.
+        </p>
+      </section>
+    );
+  }
 
   const title = admin
     ? "Admin: Create Americano tournament"

--- a/apps/web/src/components/__tests__/MultiSelect.test.tsx
+++ b/apps/web/src/components/__tests__/MultiSelect.test.tsx
@@ -36,7 +36,7 @@ describe('MultiSelect', () => {
       { id: 'p4', name: 'Drew' },
     ];
 
-    const listbox = renderComponent(options);
+    renderComponent(options);
 
     const user = userEvent.setup();
     const searchInput = screen.getByLabelText('Search players');


### PR DESCRIPTION
## Summary
- update the home page match refresh effect to follow hook dependency rules
- remove unused imports and variables reported by lint
- move the tournament creation hooks before the conditional return to avoid conditional hook execution

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68db3b5822b88323a7105e19848adef9