### PR TITLE
feat: add infinite scroll pagination to leaderboards

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -3,9 +3,58 @@ import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import Leaderboard from "./leaderboard";
-import { apiUrl } from "../../lib/api";
 import * as api from "../../lib/api";
 import { USER_SETTINGS_STORAGE_KEY } from "../user-settings";
+
+const mockIntersectionObservers: MockIntersectionObserver[] = [];
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  elements = new Set<Element>();
+  observe = vi.fn((element: Element) => {
+    this.elements.add(element);
+  });
+  unobserve = vi.fn((element: Element) => {
+    this.elements.delete(element);
+  });
+  disconnect = vi.fn(() => {
+    this.elements.clear();
+  });
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    mockIntersectionObservers.push(this);
+  }
+
+  trigger(isIntersecting = true) {
+    const entries = Array.from(this.elements).map((element) =>
+      ({
+        isIntersecting,
+        target: element,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        time: 0,
+        boundingClientRect: element.getBoundingClientRect(),
+        intersectionRect: element.getBoundingClientRect(),
+        rootBounds: null,
+      }) as IntersectionObserverEntry,
+    );
+    if (entries.length === 0) {
+      const dummy = document.createElement("div");
+      entries.push(
+        ({
+          isIntersecting,
+          target: dummy,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          time: 0,
+          boundingClientRect: dummy.getBoundingClientRect(),
+          intersectionRect: dummy.getBoundingClientRect(),
+          rootBounds: null,
+        }) as IntersectionObserverEntry,
+      );
+    }
+    this.callback(entries, this as unknown as IntersectionObserver);
+  }
+}
 
 const replaceMock = vi.fn();
 let mockPathname = "/leaderboard";
@@ -28,6 +77,9 @@ describe("Leaderboard", () => {
   let fetchClubsSpy: vi.SpiedFunction<typeof api.fetchClubs>;
 
   beforeEach(() => {
+    mockIntersectionObservers.length = 0;
+    // @ts-expect-error - assign test mock
+    global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
     updateMockLocation("/leaderboard");
     replaceMock.mockReset();
     replaceMock.mockImplementation((nextHref: string) => {
@@ -42,6 +94,9 @@ describe("Leaderboard", () => {
   });
 
   afterEach(() => {
+    // @ts-expect-error - cleanup IntersectionObserver mock
+    delete global.IntersectionObserver;
+    mockIntersectionObservers.length = 0;
     vi.clearAllMocks();
     vi.restoreAllMocks();
     // @ts-expect-error - cleanup mocked fetch between tests
@@ -65,8 +120,13 @@ describe("Leaderboard", () => {
     expect(screen.getByRole("tab", { name: "Disc Golf" })).toBeInTheDocument();
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
-    const urls = fetchMock.mock.calls.map((c) => c[0]);
-    expect(urls).toContain(apiUrl("/v0/leaderboards?sport=disc_golf"));
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    const discGolfRequest = urls.find((url) => url.includes("sport=disc_golf"));
+    expect(discGolfRequest).toBeDefined();
+    const params = new URL(discGolfRequest as string, "https://example.test").searchParams;
+    expect(params.get("sport")).toBe("disc_golf");
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("offset")).toBe("0");
   });
 
   it("keeps the tab navigation scrollable without a dropdown on wide viewports", async () => {
@@ -162,8 +222,13 @@ describe("Leaderboard", () => {
     render(<Leaderboard sport="padel" country="SE" />);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(fetchMock).toHaveBeenCalledWith(
-      apiUrl("/v0/leaderboards?sport=padel&country=SE"),
+    const [requestUrl, requestOptions] = fetchMock.mock.calls[0] ?? [];
+    const params = new URL(requestUrl as string, "https://example.test").searchParams;
+    expect(params.get("sport")).toBe("padel");
+    expect(params.get("country")).toBe("SE");
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("offset")).toBe("0");
+    expect(requestOptions).toEqual(
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
@@ -178,8 +243,13 @@ describe("Leaderboard", () => {
     render(<Leaderboard sport="padel" clubId="club-a" />);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(fetchMock).toHaveBeenCalledWith(
-      apiUrl("/v0/leaderboards?sport=padel&clubId=club-a"),
+    const [clubUrl, clubOptions] = fetchMock.mock.calls[0] ?? [];
+    const clubParams = new URL(clubUrl as string, "https://example.test").searchParams;
+    expect(clubParams.get("sport")).toBe("padel");
+    expect(clubParams.get("clubId")).toBe("club-a");
+    expect(clubParams.get("limit")).toBe("50");
+    expect(clubParams.get("offset")).toBe("0");
+    expect(clubOptions).toEqual(
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
@@ -194,10 +264,74 @@ describe("Leaderboard", () => {
     render(<Leaderboard sport="all" country="SE" clubId="club-a" />);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
-    const urls = fetchMock.mock.calls.map((c) => c[0]);
-    expect(urls).toContain(
-      apiUrl("/v0/leaderboards?sport=disc_golf&country=SE&clubId=club-a")
-    );
+    const combinedUrls = fetchMock.mock.calls.map((c) => c[0] as string);
+    const discGolfUrl = combinedUrls.find((url) => url.includes("sport=disc_golf"));
+    expect(discGolfUrl).toBeDefined();
+    const search = new URL(discGolfUrl as string, "https://example.test").searchParams;
+    expect(search.get("sport")).toBe("disc_golf");
+    expect(search.get("country")).toBe("SE");
+    expect(search.get("clubId")).toBe("club-a");
+    expect(search.get("limit")).toBe("50");
+    expect(search.get("offset")).toBe("0");
+  });
+
+  it("loads additional pages when the sentinel intersects", async () => {
+    const firstPage = {
+      leaders: [
+        {
+          rank: 1,
+          playerId: "p1",
+          playerName: "Alice",
+          rating: 1200,
+          setsWon: 10,
+          setsLost: 2,
+        },
+        {
+          rank: 2,
+          playerId: "p2",
+          playerName: "Bob",
+          rating: 1100,
+          setsWon: 8,
+          setsLost: 4,
+        },
+      ],
+      total: 3,
+      limit: 2,
+      offset: 0,
+    };
+    const secondPage = {
+      leaders: [
+        {
+          rank: 3,
+          playerId: "p3",
+          playerName: "Cara",
+          rating: 1000,
+          setsWon: 6,
+          setsLost: 6,
+        },
+      ],
+      total: 3,
+      limit: 2,
+      offset: 2,
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => firstPage })
+      .mockResolvedValueOnce({ ok: true, json: async () => secondPage });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="padel" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Cara")).not.toBeInTheDocument();
+
+    await act(async () => {
+      mockIntersectionObservers.forEach((observer) => observer.trigger());
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Cara")).toBeInTheDocument();
   });
 
   it("lets users apply structured region filters", async () => {

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -70,6 +70,7 @@ const formatSportLabel = (sportId: string) =>
 
 const RESULTS_TABLE_ID = "leaderboard-results";
 const LEADERBOARD_TIMEOUT_MS = 15000;
+const PAGE_SIZE = 50;
 
 const canonicalizePathname = (pathname: string) => {
   if (pathname === "/" || pathname === "") {
@@ -172,13 +173,24 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const [leaders, setLeaders] = useState<Leader[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const resultsCacheRef = useRef<Map<string, Leader[]>>(new Map());
+  type CachedLeaderboard = {
+    leaders: Leader[];
+    total: number;
+    nextOffset: number;
+  };
+  const resultsCacheRef = useRef<Map<string, CachedLeaderboard>>(new Map());
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreAbortRef = useRef<AbortController | null>(null);
 
   const resultsCount = leaders.length;
   const hasResults = resultsCount > 0;
   const statusMessage = loading
     ? "Loading leaderboard results…"
-    : error
+    : isLoadingMore
+      ? "Loading more leaderboard results…"
+      : error
       ? `Error loading leaderboard: ${error}`
       : hasResults
         ? `Loaded ${resultsCount} leaderboard ${resultsCount === 1 ? "entry" : "entries"}.`
@@ -422,10 +434,14 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   }, [appliedCountry, preferencesApplied, router, sport]);
 
   const buildUrl = useCallback(
-    (sportId: string) => {
+    (sportId: string, pagination?: { limit?: number; offset?: number }) => {
       const params = new URLSearchParams({ sport: sportId });
       if (appliedCountry) params.set("country", appliedCountry);
       if (appliedClubId) params.set("clubId", appliedClubId);
+      const limit = pagination?.limit ?? PAGE_SIZE;
+      const offset = pagination?.offset ?? 0;
+      params.set("limit", String(limit));
+      params.set("offset", String(offset));
       return apiUrl(`/v0/leaderboards?${params.toString()}`);
     },
     [appliedCountry, appliedClubId],
@@ -435,6 +451,123 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     () => getSportDisplayName(sport),
     [sport],
   );
+
+  const parseLeaderboardResponse = useCallback(
+    (raw: unknown, fallbackOffset: number) => {
+      if (Array.isArray(raw)) {
+        const leaders = raw as Leader[];
+        return { leaders, total: leaders.length, offset: fallbackOffset };
+      }
+      if (raw && typeof raw === "object") {
+        const obj = raw as {
+          leaders?: Leader[];
+          total?: number;
+          offset?: number;
+        };
+        const leaders = Array.isArray(obj.leaders) ? obj.leaders : [];
+        const total = typeof obj.total === "number" ? obj.total : leaders.length;
+        const offset = typeof obj.offset === "number" ? obj.offset : fallbackOffset;
+        return { leaders, total, offset };
+      }
+      return { leaders: [] as Leader[], total: 0, offset: fallbackOffset };
+    },
+    [],
+  );
+
+  const mergeLeaders = useCallback((existing: Leader[], incoming: Leader[]) => {
+    if (!existing.length) {
+      return [...incoming];
+    }
+    if (!incoming.length) {
+      return [...existing];
+    }
+    const byId = new Map<ID, Leader>();
+    existing.forEach((leader) => {
+      byId.set(leader.playerId, leader);
+    });
+    incoming.forEach((leader) => {
+      byId.set(leader.playerId, leader);
+    });
+    return Array.from(byId.values()).sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  }, []);
+
+  const getCacheKey = useCallback(
+    (sportId: LeaderboardSport) =>
+      [sportId, appliedCountry || "", appliedClubId || ""].join("::"),
+    [appliedCountry, appliedClubId],
+  );
+
+  const getCachedLeaders = useCallback(
+    (sportId: LeaderboardSport) => resultsCacheRef.current.get(getCacheKey(sportId)),
+    [getCacheKey],
+  );
+
+  const storeCachedLeaders = useCallback(
+    (
+      sportId: LeaderboardSport,
+      page: { leaders: Leader[]; total: number; offset: number },
+    ) => {
+      const key = getCacheKey(sportId);
+      const previous = resultsCacheRef.current.get(key);
+      const merged = mergeLeaders(previous?.leaders ?? [], page.leaders);
+      const nextOffset = page.offset + page.leaders.length;
+      const total = page.total;
+      resultsCacheRef.current.set(key, {
+        leaders: merged,
+        total,
+        nextOffset: Math.max(previous?.nextOffset ?? 0, nextOffset),
+      });
+    },
+    [getCacheKey, mergeLeaders],
+  );
+
+  const combineLeaders = useCallback(
+    (entries: { sportId: LeaderboardSport; leaders: Leader[] }[]) =>
+      entries
+        .flatMap(({ sportId, leaders: source }) =>
+          source.map((leader) => ({ ...leader, sport: sportId })),
+        )
+        .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
+        .map((leader, index) => ({ ...leader, rank: index + 1 })),
+    [],
+  );
+
+  const computeHasMoreForSport = useCallback(
+    (sportId: LeaderboardSport) => {
+      if (sportId === ALL_SPORTS) {
+        return SPORTS.some((id) => {
+          const cached = getCachedLeaders(id);
+          return Boolean(cached && cached.nextOffset < cached.total);
+        });
+      }
+      const cached = getCachedLeaders(sportId);
+      return Boolean(cached && cached.nextOffset < cached.total);
+    },
+    [getCachedLeaders],
+  );
+
+  const refreshLeadersFromCache = useCallback(
+    (sportId: LeaderboardSport) => {
+      if (sportId === ALL_SPORTS) {
+        const entries = SPORTS.map((id) => ({
+          sportId: id,
+          leaders: getCachedLeaders(id)?.leaders ?? [],
+        }));
+        setLeaders(combineLeaders(entries));
+        setHasMore(computeHasMoreForSport(ALL_SPORTS));
+        return;
+      }
+      const cached = getCachedLeaders(sportId);
+      setLeaders(cached?.leaders ?? []);
+      setHasMore(computeHasMoreForSport(sportId));
+    },
+    [combineLeaders, computeHasMoreForSport, getCachedLeaders],
+  );
+
+  useEffect(() => {
+    loadMoreAbortRef.current?.abort();
+    setIsLoadingMore(false);
+  }, [sport, appliedCountry, appliedClubId]);
 
   type NavItem = { id: LeaderboardSport; label: string };
   const navItems: NavItem[] = useMemo(
@@ -665,43 +798,21 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       controller.abort();
     }, LEADERBOARD_TIMEOUT_MS);
     (async () => {
-      const getCacheKey = (sportId: LeaderboardSport) =>
-        [sportId, appliedCountry || "", appliedClubId || ""].join("::");
-      const getCachedLeaders = (sportId: LeaderboardSport) =>
-        resultsCacheRef.current.get(getCacheKey(sportId));
-      const storeCachedLeaders = (
-        sportId: LeaderboardSport,
-        data: Leader[],
-      ) => {
-        resultsCacheRef.current.set(getCacheKey(sportId), data);
-      };
-      const combineLeaders = (
-        entries: { sportId: LeaderboardSport; leaders: Leader[] }[],
-      ) =>
-        entries
-          .flatMap(({ sportId, leaders: source }) =>
-            source.map((leader) => ({ ...leader, sport: sportId })),
-          )
-          .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
-          .map((leader, index) => ({ ...leader, rank: index + 1 }));
-
       setError(null);
       let hadCachedResultsForCurrentView = false;
       try {
         if (sport === ALL_SPORTS) {
           const cachedEntries = SPORTS.map((s) => {
             const cached = getCachedLeaders(s);
-            return cached ? { sportId: s, leaders: cached } : null;
+            return cached ? { sportId: s, leaders: cached.leaders } : null;
           }).filter(Boolean) as { sportId: LeaderboardSport; leaders: Leader[] }[];
-          const missingSports = SPORTS.filter(
-            (s) => !resultsCacheRef.current.has(getCacheKey(s)),
-          );
+          const missingSports = SPORTS.filter((s) => !getCachedLeaders(s));
 
           if (cachedEntries.length > 0) {
             hadCachedResultsForCurrentView = true;
-            const combinedCached = combineLeaders(cachedEntries);
             if (!cancelled) {
-              setLeaders(combinedCached);
+              setLeaders(combineLeaders(cachedEntries));
+              setHasMore(computeHasMoreForSport(ALL_SPORTS));
               setLoading(missingSports.length > 0);
             }
             if (missingSports.length === 0) {
@@ -711,24 +822,23 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             setLoading(true);
           }
 
-          const fetchedEntries = await Promise.all(
+          await Promise.all(
             missingSports.map(async (s) => {
               const res = await fetch(buildUrl(s), {
                 signal: controller.signal,
               });
               if (!res.ok) {
-                return { sportId: s, leaders: [] as Leader[] };
+                storeCachedLeaders(s, { leaders: [], total: 0, offset: 0 });
+                return;
               }
               const data = await res.json();
-              const arr = (Array.isArray(data) ? data : data.leaders ?? []) as Leader[];
-              storeCachedLeaders(s, arr);
-              return { sportId: s, leaders: arr };
+              const page = parseLeaderboardResponse(data, 0);
+              storeCachedLeaders(s, page);
             }),
           );
 
-          const combined = combineLeaders([...cachedEntries, ...fetchedEntries]);
           if (!cancelled) {
-            setLeaders(combined);
+            refreshLeadersFromCache(ALL_SPORTS);
             setLoading(false);
           }
         } else if (sport === MASTER_SPORT) {
@@ -736,28 +846,32 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           if (cached) {
             hadCachedResultsForCurrentView = true;
             if (!cancelled) {
-              setLeaders(cached);
+              setLeaders(cached.leaders);
+              setHasMore(computeHasMoreForSport(MASTER_SPORT));
               setLoading(false);
             }
             return;
           }
           setLoading(true);
-          const res = await fetch(apiUrl(`/v0/leaderboards/master`), {
-            signal: controller.signal,
-          });
+          const res = await fetch(
+            apiUrl(`/v0/leaderboards/master?limit=${PAGE_SIZE}&offset=0`),
+            { signal: controller.signal },
+          );
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
           const data = await res.json();
-          const arr = (Array.isArray(data) ? data : data.leaders ?? []) as Leader[];
-          storeCachedLeaders(MASTER_SPORT, arr);
+          const page = parseLeaderboardResponse(data, 0);
+          storeCachedLeaders(MASTER_SPORT, page);
           if (!cancelled) {
-            setLeaders(arr);
+            setLeaders(page.leaders);
+            setHasMore(computeHasMoreForSport(MASTER_SPORT));
           }
         } else {
           const cached = getCachedLeaders(sport);
           if (cached) {
             hadCachedResultsForCurrentView = true;
             if (!cancelled) {
-              setLeaders(cached);
+              setLeaders(cached.leaders);
+              setHasMore(computeHasMoreForSport(sport));
               setLoading(false);
             }
             return;
@@ -768,9 +882,12 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           });
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
           const data = await res.json();
-          const arr = (Array.isArray(data) ? data : data.leaders ?? []) as Leader[];
-          storeCachedLeaders(sport, arr);
-          if (!cancelled) setLeaders(arr);
+          const page = parseLeaderboardResponse(data, 0);
+          storeCachedLeaders(sport, page);
+          if (!cancelled) {
+            setLeaders(page.leaders);
+            setHasMore(computeHasMoreForSport(sport));
+          }
         }
       } catch (err) {
         if (cancelled) {
@@ -787,8 +904,8 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         const fallbackMessage = didTimeout
           ? "Loading the leaderboard took too long. Please try again."
           : appliedCountry || appliedClubId
-          ? "We couldn't load the leaderboard for this region."
-          : "We couldn't load the leaderboard right now.";
+            ? "We couldn't load the leaderboard for this region."
+            : "We couldn't load the leaderboard right now.";
         setError(fallbackMessage);
       } finally {
         clearTimeout(timeoutId);
@@ -801,7 +918,156 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [sport, appliedCountry, appliedClubId, buildUrl, preferencesApplied]);
+  }, [
+    sport,
+    appliedCountry,
+    appliedClubId,
+    buildUrl,
+    preferencesApplied,
+    getCachedLeaders,
+    storeCachedLeaders,
+    combineLeaders,
+    computeHasMoreForSport,
+    parseLeaderboardResponse,
+    refreshLeadersFromCache,
+  ]);
+
+  const loadMore = useCallback(async () => {
+    if (loading || isLoadingMore || !hasMore) {
+      return;
+    }
+    const controller = new AbortController();
+    loadMoreAbortRef.current?.abort();
+    loadMoreAbortRef.current = controller;
+    setIsLoadingMore(true);
+    try {
+      if (sport === ALL_SPORTS) {
+        const sportsToFetch = SPORTS.filter((id) => {
+          const cached = getCachedLeaders(id);
+          return cached ? cached.nextOffset < cached.total : true;
+        });
+        if (sportsToFetch.length === 0) {
+          setHasMore(false);
+          setIsLoadingMore(false);
+          return;
+        }
+        await Promise.all(
+          sportsToFetch.map(async (id) => {
+            const cached = getCachedLeaders(id);
+            const offset = cached?.nextOffset ?? 0;
+            if (cached && offset >= cached.total) {
+              return;
+            }
+            const res = await fetch(buildUrl(id, { offset }), {
+              signal: controller.signal,
+            });
+            if (!res.ok) {
+              throw new Error(`${res.status} ${res.statusText}`);
+            }
+            const data = await res.json();
+            const page = parseLeaderboardResponse(data, offset);
+            storeCachedLeaders(id, page);
+          }),
+        );
+        if (!controller.signal.aborted) {
+          refreshLeadersFromCache(ALL_SPORTS);
+        }
+      } else if (sport === MASTER_SPORT) {
+        const cached = getCachedLeaders(MASTER_SPORT);
+        const offset = cached?.nextOffset ?? 0;
+        if (cached && offset >= cached.total) {
+          setHasMore(false);
+        } else {
+          const res = await fetch(
+            apiUrl(`/v0/leaderboards/master?limit=${PAGE_SIZE}&offset=${offset}`),
+            { signal: controller.signal },
+          );
+          if (!res.ok) {
+            throw new Error(`${res.status} ${res.statusText}`);
+          }
+          const data = await res.json();
+          const page = parseLeaderboardResponse(data, offset);
+          storeCachedLeaders(MASTER_SPORT, page);
+          if (!controller.signal.aborted) {
+            refreshLeadersFromCache(MASTER_SPORT);
+          }
+        }
+      } else {
+        const cached = getCachedLeaders(sport);
+        const offset = cached?.nextOffset ?? 0;
+        if (cached && offset >= cached.total) {
+          setHasMore(false);
+        } else {
+          const res = await fetch(buildUrl(sport, { offset }), {
+            signal: controller.signal,
+          });
+          if (!res.ok) {
+            throw new Error(`${res.status} ${res.statusText}`);
+          }
+          const data = await res.json();
+          const page = parseLeaderboardResponse(data, offset);
+          storeCachedLeaders(sport, page);
+          if (!controller.signal.aborted) {
+            refreshLeadersFromCache(sport);
+          }
+        }
+      }
+      if (!controller.signal.aborted) {
+        setError(null);
+      }
+    } catch (err) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      const abortError = err as DOMException;
+      if (abortError?.name === "AbortError") {
+        return;
+      }
+      console.error("Failed to load additional leaderboard results", err);
+      setError("We couldn't load additional results. Please try again.");
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoadingMore(false);
+        setHasMore(computeHasMoreForSport(sport));
+      }
+    }
+  }, [
+    loading,
+    isLoadingMore,
+    hasMore,
+    sport,
+    getCachedLeaders,
+    buildUrl,
+    parseLeaderboardResponse,
+    storeCachedLeaders,
+    refreshLeadersFromCache,
+    computeHasMoreForSport,
+  ]);
+
+  useEffect(() => {
+    if (!hasMore) {
+      return;
+    }
+    const target = loadMoreRef.current;
+    if (!target) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          loadMore();
+        }
+      });
+    }, { rootMargin: "200px" });
+    observer.observe(target);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, loadMore, leaders.length]);
+
+  useEffect(() => () => {
+    loadMoreAbortRef.current?.abort();
+  }, []);
 
   const tableStyle = useMemo(
     () => ({
@@ -1189,8 +1455,23 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               })}
             </tbody>
           </table>
+          {hasMore ? (
+            <div
+              ref={loadMoreRef}
+              aria-hidden="true"
+              style={{ width: "100%", height: "1px" }}
+            />
+          ) : null}
         </div>
       )}
+      {isLoadingMore ? (
+        <p
+          aria-live="polite"
+          style={{ marginTop: "0.75rem", fontSize: "0.85rem", color: "#555" }}
+        >
+          Loading more results…
+        </p>
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add cached pagination and infinite scroll to the leaderboard component so additional pages load as users approach the table end
- extend leaderboard tests with an IntersectionObserver mock, updated query expectations, and coverage for the load-more flow

## Testing
- pnpm vitest run src/app/leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db3e12388883239fbc131da51077da