### PR TITLE
Respect previous page when redirecting after login

### DIFF
--- a/apps/web/src/app/admin/badges/page.tsx
+++ b/apps/web/src/app/admin/badges/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { apiFetch, isAdmin } from '../../../lib/api';
+import { rememberLoginRedirect } from '../../../lib/loginRedirect';
 
 type BadgeApi = {
   id: string;
@@ -54,6 +55,7 @@ export default function AdminBadgesPage() {
 
   useEffect(() => {
     if (!isAdmin()) {
+      rememberLoginRedirect();
       window.location.href = '/login';
       return;
     }

--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -9,6 +9,7 @@ import MatchParticipants from "../../../components/MatchParticipants";
 import { useLocale, useTimeZone } from "../../../lib/LocaleContext";
 import { formatDate } from "../../../lib/i18n";
 import { resolveParticipantGroups } from "../../../lib/participants";
+import { rememberLoginRedirect } from "../../../lib/loginRedirect";
 
 type MatchRow = {
   id: string;
@@ -151,6 +152,7 @@ export default function AdminMatchesPage() {
 
   useEffect(() => {
     if (!isAdmin()) {
+      rememberLoginRedirect();
       window.location.href = ensureTrailingSlash("/login");
       return;
     }

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { currentUsername, isAdmin, logout } from '../lib/api';
 import { ensureTrailingSlash } from '../lib/routes';
+import { rememberLoginRedirect } from '../lib/loginRedirect';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -170,7 +171,10 @@ export default function Header() {
                 href={ensureTrailingSlash('/login')}
                 className={linkClassName('/login')}
                 aria-current={linkAriaCurrent('/login')}
-                onClick={() => setOpen(false)}
+                onClick={() => {
+                  rememberLoginRedirect();
+                  setOpen(false);
+                }}
               >
                 Login
               </Link>

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -17,6 +17,7 @@ import {
   type NormalizedMatchSummary,
 } from "../../lib/player-stats";
 import { useDebounce } from "../../lib/useDebounce";
+import { rememberLoginRedirect } from "../../lib/loginRedirect";
 
 const NAME_REGEX = /^[A-Za-z0-9 '-]{1,50}$/;
 
@@ -542,7 +543,11 @@ export default function PlayersPage() {
       ) : (
         <div className="player-list__admin-note">
           <p>Sign in as an admin to add players.</p>
-          <Link className="button-secondary inline-block mt-2" href="/login">
+          <Link
+            className="button-secondary inline-block mt-2"
+            href="/login"
+            onClick={() => rememberLoginRedirect()}
+          >
             Login
           </Link>
         </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/api";
 import { ensureTrailingSlash } from "../../lib/routes";
 import type { PlayerLocationPayload } from "../../lib/api";
+import { rememberLoginRedirect } from "../../lib/loginRedirect";
 import ClubSelect from "../../components/ClubSelect";
 import {
   COUNTRY_OPTIONS,
@@ -272,6 +273,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (!isLoggedIn()) {
+      rememberLoginRedirect();
       router.push(ensureTrailingSlash("/login"));
       return;
     }
@@ -295,6 +297,7 @@ export default function ProfilePage() {
           if (!active) return;
           const status = (playerErr as Error & { status?: number }).status;
           if (status === 401) {
+            rememberLoginRedirect();
             router.push(ensureTrailingSlash("/login"));
             return;
           }
@@ -310,6 +313,7 @@ export default function ProfilePage() {
         }
       } catch {
         if (!active) return;
+        rememberLoginRedirect();
         router.push(ensureTrailingSlash("/login"));
         return;
       } finally {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -13,6 +13,7 @@ import {
   usesTwentyFourHourClock,
 } from "../../../lib/i18n";
 import { buildPlayedAtISOString } from "../../../lib/datetime";
+import { rememberLoginRedirect } from "../../../lib/loginRedirect";
 
 interface Player {
   id: string;
@@ -192,6 +193,7 @@ export default function RecordPadelPage() {
         setGlobalError("Failed to load players");
         const status = (err as { status?: number }).status;
         if (status === 401) {
+          rememberLoginRedirect();
           router.push(ensureTrailingSlash("/login"));
         }
       }

--- a/apps/web/src/lib/loginRedirect.ts
+++ b/apps/web/src/lib/loginRedirect.ts
@@ -1,0 +1,102 @@
+const LOGIN_REDIRECT_COOKIE = 'cst-login-redirect';
+const COOKIE_MAX_AGE_SECONDS = 60 * 5;
+
+function getDocument(): Document | null {
+  return typeof document === 'undefined' ? null : document;
+}
+
+function getWindow(): Window | null {
+  return typeof window === 'undefined' ? null : window;
+}
+
+function readCookie(doc: Document): string | null {
+  const prefix = `${LOGIN_REDIRECT_COOKIE}=`;
+  const entries = doc.cookie ? doc.cookie.split('; ') : [];
+  for (const entry of entries) {
+    if (entry.startsWith(prefix)) {
+      const value = entry.slice(prefix.length);
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function clearCookie(doc: Document, win: Window | null) {
+  const secure = win?.location.protocol === 'https:' ? '; secure' : '';
+  doc.cookie = `${LOGIN_REDIRECT_COOKIE}=; path=/; max-age=0; samesite=lax${secure}`;
+}
+
+function writeCookie(doc: Document, win: Window, value: string) {
+  const secure = win.location.protocol === 'https:' ? '; secure' : '';
+  doc.cookie = `${LOGIN_REDIRECT_COOKIE}=${encodeURIComponent(
+    value,
+  )}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; samesite=lax${secure}`;
+}
+
+function normalizeTarget(raw: string | null, win: Window): string | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw, win.location.origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== win.location.origin) {
+    return null;
+  }
+  const path = `${url.pathname}${url.search}${url.hash}`;
+  if (!path) return null;
+  if (path === '/login' || path.startsWith('/login/')) {
+    return null;
+  }
+  return path;
+}
+
+function currentPath(win: Window): string {
+  return `${win.location.pathname}${win.location.search}${win.location.hash}`;
+}
+
+export function rememberLoginRedirect(target?: string | URL | null): void {
+  const doc = getDocument();
+  const win = getWindow();
+  if (!doc || !win) return;
+  const raw =
+    target instanceof URL
+      ? target.toString()
+      : target ?? currentPath(win);
+  const normalized = normalizeTarget(raw, win);
+  if (!normalized) {
+    clearCookie(doc, win);
+    return;
+  }
+  writeCookie(doc, win, normalized);
+}
+
+export function rememberLoginReferrer(): void {
+  const doc = getDocument();
+  const win = getWindow();
+  if (!doc || !win) return;
+  rememberLoginRedirect(doc.referrer || null);
+}
+
+export function consumeLoginRedirect(): string | null {
+  const doc = getDocument();
+  const win = getWindow();
+  if (!doc || !win) return null;
+  const raw = readCookie(doc);
+  clearCookie(doc, win);
+  if (!raw) return null;
+  return normalizeTarget(raw, win);
+}
+
+export function peekLoginRedirect(): string | null {
+  const doc = getDocument();
+  const win = getWindow();
+  if (!doc || !win) return null;
+  const raw = readCookie(doc);
+  return normalizeTarget(raw, win);
+}


### PR DESCRIPTION
## Summary
- add a login redirect helper that records the referring page in a short-lived cookie
- update the login/signup flow and all login navigation paths to restore users to the recorded page when possible
- cover the new redirect behavior in the login and admin badges tests

## Testing
- pnpm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db420b14dc8323bfff92cd0ec93430