### PR TITLE
Fix match refresh effect to avoid dependency loop

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../lib/api';
 import {
@@ -226,7 +226,6 @@ export default function HomePageClient({
   const [pageSize, setPageSize] = useState(initialPageSize);
   const [loadingMore, setLoadingMore] = useState(false);
   const [paginationError, setPaginationError] = useState(false);
-  const matchesRef = useRef(matches);
   const localeFromContext = useLocale();
   const timeZone = useTimeZone();
   const activeLocale =
@@ -330,33 +329,30 @@ export default function HomePageClient({
   }, [matchesError]);
 
   useEffect(() => {
-    matchesRef.current = matches;
-  }, [matches]);
-
-  useEffect(() => {
     if (!matchPage) return;
 
-    const { matches: nextMatches, hasAdditionalMatches } = mergeMatchPageWithPrevious(
-      matchesRef.current,
-      matchPage.enriched,
-    );
-
-    matchesRef.current = nextMatches;
-    setMatches(nextMatches);
-
-    setNextOffset((currentNextOffset) =>
-      resolveNextOffset(currentNextOffset, matchPage.nextOffset, hasAdditionalMatches),
-    );
-
-    if (typeof matchPage.limit === 'number') {
-      setPageSize((currentPageSize) =>
-        matchPage.limit !== currentPageSize ? matchPage.limit : currentPageSize,
+    setMatches((previousMatches) => {
+      const { matches: nextMatches, hasAdditionalMatches } = mergeMatchPageWithPrevious(
+        previousMatches,
+        matchPage.enriched,
       );
-    }
 
-    setHasMore(matchPage.hasMore);
+      setNextOffset((currentNextOffset) =>
+        resolveNextOffset(currentNextOffset, matchPage.nextOffset, hasAdditionalMatches),
+      );
 
-    setMatchError(false);
+      if (typeof matchPage.limit === 'number') {
+        setPageSize((currentPageSize) =>
+          matchPage.limit !== currentPageSize ? matchPage.limit : currentPageSize,
+        );
+      }
+
+      setHasMore(matchPage.hasMore);
+
+      setMatchError(false);
+
+      return nextMatches;
+    });
   }, [matchPage]);
 
   const matchesLoading =


### PR DESCRIPTION
## Summary
- update the match merging effect to use a functional state update and avoid dependency loops
- remove the now-unnecessary matches ref that triggered repeated revalidations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db44d41d4c8323b2691e499c2e140a