### PR TITLE
Preserve cached all-sports results after partial load

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -840,6 +840,11 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           }
 
           refreshLeadersFromCache(ALL_SPORTS);
+          hadCachedResultsForCurrentView =
+            hadCachedResultsForCurrentView ||
+            SPORTS.some(
+              (id) => (getCachedLeaders(id)?.leaders.length ?? 0) > 0,
+            );
           setLoading(false);
 
           const rejected = results.filter(


### PR DESCRIPTION
## Summary
- mark the all-sports view as having cached data after refreshing from partial fetch successes
- prevent the catch block from clearing partially loaded leaderboard results when some sport requests fail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db454acda083238c927a3ac8f5b033