### PR TITLE
Improve tournament error handling and messaging

### DIFF
--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -224,8 +224,14 @@ export default async function MatchesPage(
     );
   } catch (err) {
     const apiError = err as ApiError | null;
-    let message = "Failed to load matches.";
+    const fallbackMessage = "Failed to load matches. Try again later.";
+    let message = fallbackMessage;
     const code = typeof apiError?.code === "string" ? apiError.code : null;
+    const serverDetail =
+      typeof apiError?.parsedMessage === "string" &&
+      apiError.parsedMessage.trim().length > 0
+        ? apiError.parsedMessage.trim()
+        : null;
     if (code) {
       const mapped = MATCH_ERROR_COPY[code];
       if (mapped) {
@@ -237,8 +243,9 @@ export default async function MatchesPage(
           apiError?.parsedMessage ?? apiError?.message ?? null
         );
       }
-    } else if (apiError?.parsedMessage) {
-      console.error("Unhandled matches error message", apiError.parsedMessage);
+    } else if (serverDetail) {
+      message = `${fallbackMessage} (${serverDetail})`;
+      console.error("Unhandled matches error message", serverDetail);
     }
     return (
       <main className="container">

--- a/apps/web/src/app/tournaments/[id]/page.tsx
+++ b/apps/web/src/app/tournaments/[id]/page.tsx
@@ -29,25 +29,46 @@ async function fetchTournament(id: string): Promise<TournamentSummary> {
   }
 }
 
-async function fetchStages(tournamentId: string): Promise<StageSummary[]> {
-  try {
-    const res = await apiFetch(`/v0/tournaments/${tournamentId}/stages`, {
-      cache: "no-store",
-    });
-    return (await res.json()) as StageSummary[];
-  } catch (error) {
-    console.error("Failed to load tournament stages", error);
-    return [];
+function formatErrorMessage(error: unknown, fallback: string): string {
+  const apiError = error as ApiError | undefined;
+  const parsed = apiError?.parsedMessage ?? null;
+  const detailed =
+    typeof parsed === "string" && parsed.trim().length > 0
+      ? parsed.trim()
+      : typeof apiError?.message === "string"
+      ? apiError.message
+      : null;
+
+  if (detailed && detailed !== fallback) {
+    return `${fallback} (${detailed})`;
   }
+
+  return fallback;
 }
 
-async function fetchPlayersByIds(ids: string[]): Promise<Map<string, PlayerInfo>> {
+async function fetchStages(tournamentId: string): Promise<StageSummary[]> {
+  const res = await apiFetch(`/v0/tournaments/${tournamentId}/stages`, {
+    cache: "no-store",
+  });
+  return (await res.json()) as StageSummary[];
+}
+
+const PLAYER_LOOKUP_INCOMPLETE_MESSAGE =
+  "Some player names could not be loaded. Names that are missing will appear as 'Unknown player'.";
+const PLAYER_LOOKUP_FAILED_MESSAGE =
+  "We couldn't load player details. Names will appear as 'Unknown player'. Try again later.";
+
+async function fetchPlayersByIds(
+  ids: string[]
+): Promise<{ map: Map<string, PlayerInfo>; error: string | null }> {
   const uniqueIds = Array.from(new Set(ids)).filter(Boolean);
   const map = new Map<string, PlayerInfo>();
   if (uniqueIds.length === 0) {
-    return map;
+    return { map, error: null };
   }
 
+  let errorMessage: string | null = null;
+  const missing = new Set(uniqueIds);
   try {
     const res = await apiFetch(
       `/v0/players/by-ids?ids=${uniqueIds.map(encodeURIComponent).join(",")}`,
@@ -56,11 +77,21 @@ async function fetchPlayersByIds(ids: string[]): Promise<Map<string, PlayerInfo>
     const players = (await res.json()) as PlayerInfo[];
     players.forEach((player) => {
       if (player.id) {
-        map.set(player.id, withAbsolutePhotoUrl(player));
+        const normalizedName =
+          typeof player.name === "string" && player.name.trim().length > 0
+            ? player.name
+            : null;
+        if (normalizedName) {
+          missing.delete(player.id);
+          map.set(player.id, withAbsolutePhotoUrl(player));
+        } else {
+          map.set(player.id, { id: player.id, name: "Unknown player" });
+        }
       }
     });
   } catch (error) {
     console.error("Failed to load player names for stage", error);
+    errorMessage = formatErrorMessage(error, PLAYER_LOOKUP_FAILED_MESSAGE);
   }
 
   uniqueIds.forEach((id) => {
@@ -69,7 +100,18 @@ async function fetchPlayersByIds(ids: string[]): Promise<Map<string, PlayerInfo>
     }
   });
 
-  return map;
+  if (errorMessage) {
+    return { map, error: errorMessage };
+  }
+
+  if (missing.size > 0) {
+    console.warn(
+      `Player names missing for ids: ${Array.from(missing).join(", ")}`
+    );
+    return { map, error: PLAYER_LOOKUP_INCOMPLETE_MESSAGE };
+  }
+
+  return { map, error: null };
 }
 
 function describeStageType(stage: StageSummary): string {
@@ -83,12 +125,44 @@ export default async function TournamentDetailPage({
   params: { id: string };
 }) {
   const tournament = await fetchTournament(params.id);
-  const stages = await fetchStages(params.id);
+  let stages: StageSummary[] = [];
+  let stagesError: string | null = null;
+
+  try {
+    stages = await fetchStages(params.id);
+  } catch (error) {
+    console.error("Failed to load tournament stages", error);
+    stagesError = formatErrorMessage(
+      error,
+      "Failed to load tournament stages. Try again later."
+    );
+  }
+
+  if (stagesError) {
+    return (
+      <main className="container">
+        <nav aria-label="Breadcrumb" style={{ marginBottom: 12 }}>
+          <Link
+            href={ensureTrailingSlash("/tournaments")}
+            className="link-button"
+          >
+            ← Back to tournaments
+          </Link>
+        </nav>
+        <h1 className="heading">{tournament.name}</h1>
+        <p className="error" role="alert">
+          {stagesError}
+        </p>
+      </main>
+    );
+  }
 
   const stageData = await Promise.all(
     stages.map(async (stage) => {
       let matches: StageScheduleMatch[] = [];
       let standings: StageStandingsResponse | null = null;
+      let matchesError: string | null = null;
+      let standingsError: string | null = null;
 
       try {
         matches = await listStageMatches(params.id, stage.id, {
@@ -96,6 +170,10 @@ export default async function TournamentDetailPage({
         });
       } catch (error) {
         console.error("Failed to load matches for stage", error);
+        matchesError = formatErrorMessage(
+          error,
+          "Failed to load matches for this stage. Try again later."
+        );
       }
 
       try {
@@ -104,6 +182,10 @@ export default async function TournamentDetailPage({
         });
       } catch (error) {
         console.error("Failed to load standings for stage", error);
+        standingsError = formatErrorMessage(
+          error,
+          "Failed to load standings for this stage. Try again later."
+        );
       }
 
       const playerIds = new Set<string>();
@@ -114,13 +196,18 @@ export default async function TournamentDetailPage({
       });
       standings?.standings.forEach((row) => playerIds.add(row.playerId));
 
-      const players = await fetchPlayersByIds(Array.from(playerIds));
+      const { map: players, error: playerError } = await fetchPlayersByIds(
+        Array.from(playerIds)
+      );
 
       return {
         stage,
         matches,
         standings: standings?.standings ?? [],
         players,
+        matchesError,
+        standingsError,
+        playerError,
       };
     })
   );
@@ -146,24 +233,41 @@ export default async function TournamentDetailPage({
         <p className="form-hint">No stages have been configured yet.</p>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-          {stageData.map(({ stage, matches, standings, players }) => (
-            <section key={stage.id} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-              <h2 style={{ fontSize: 20, fontWeight: 700 }}>
-                Stage: {describeStageType(stage)}
-              </h2>
-              <StageScheduleTable
-                matches={matches}
-                playerLookup={players}
-                title="Scheduled matches"
-                emptyLabel="Matches will appear once the stage has been scheduled."
-              />
-              <StageStandings
-                standings={standings}
-                playerLookup={players}
-                title="Leaderboard"
-              />
-            </section>
-          ))}
+          {stageData.map(
+            ({
+              stage,
+              matches,
+              standings,
+              players,
+              matchesError,
+              standingsError,
+              playerError,
+            }) => (
+              <section key={stage.id} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <h2 style={{ fontSize: 20, fontWeight: 700 }}>
+                  Stage: {describeStageType(stage)}
+                </h2>
+                {playerError && (
+                  <p className="error" role="alert">
+                    {playerError}
+                  </p>
+                )}
+                <StageScheduleTable
+                  matches={matches}
+                  playerLookup={players}
+                  title="Scheduled matches"
+                  emptyLabel="Matches will appear once the stage has been scheduled."
+                  error={matchesError ?? undefined}
+                />
+                <StageStandings
+                  standings={standings}
+                  playerLookup={players}
+                  title="Leaderboard"
+                  error={standingsError ?? undefined}
+                />
+              </section>
+            )
+          )}
         </div>
       )}
     </main>

--- a/apps/web/src/app/tournaments/stage-schedule.tsx
+++ b/apps/web/src/app/tournaments/stage-schedule.tsx
@@ -23,6 +23,7 @@ interface StageScheduleTableProps {
   playerLookup: PlayerLookup;
   title?: string;
   emptyLabel?: string;
+  error?: string;
 }
 
 export default function StageScheduleTable({
@@ -30,7 +31,19 @@ export default function StageScheduleTable({
   playerLookup,
   title = "Stage schedule",
   emptyLabel = "No matches have been scheduled yet.",
+  error,
 }: StageScheduleTableProps) {
+  if (error) {
+    return (
+      <section className="card" style={{ padding: 16 }}>
+        <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>{title}</h3>
+        <p className="error" role="alert">
+          {error}
+        </p>
+      </section>
+    );
+  }
+
   if (!matches.length) {
     return <p className="form-hint">{emptyLabel}</p>;
   }

--- a/apps/web/src/app/tournaments/stage-standings.tsx
+++ b/apps/web/src/app/tournaments/stage-standings.tsx
@@ -18,13 +18,26 @@ interface StageStandingsProps {
   standings: StageStanding[];
   playerLookup: PlayerLookup;
   title?: string;
+  error?: string;
 }
 
 export default function StageStandings({
   standings,
   playerLookup,
   title = "Stage standings",
+  error,
 }: StageStandingsProps) {
+  if (error) {
+    return (
+      <section className="card" style={{ padding: 16 }}>
+        <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>{title}</h3>
+        <p className="error" role="alert">
+          {error}
+        </p>
+      </section>
+    );
+  }
+
   if (!standings.length) {
     return (
       <p className="form-hint">

--- a/apps/web/src/app/tournaments/tournaments-client.tsx
+++ b/apps/web/src/app/tournaments/tournaments-client.tsx
@@ -43,7 +43,7 @@ export default function TournamentsClient({
 
   const emptyMessage = useMemo(() => {
     if (loadError) {
-      return "Unable to load tournaments.";
+      return "Unable to load tournaments. Please try again later.";
     }
     if (tournaments.length === 0) {
       return "No tournaments have been created yet.";


### PR DESCRIPTION
## Summary
- surface tournament-stage API failures with detailed problem messages and stage-level alerts
- display load errors in stage schedule/standings tables and carry player lookup issues to the UI
- clarify matches and tournament list fallback messaging when data cannot be fetched

## Testing
- pnpm --filter @cst/web lint
- pnpm --filter @cst/web test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68db48edc3188323b4feffa9b44c97f3