### PR TITLE
Fix time zone detection to rely on client locale hints

### DIFF
--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -476,7 +476,7 @@ export default async function MatchDetailPage({
   const cookieStore = cookies();
   const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
-  const timeZone = resolveTimeZone(timeZoneCookie);
+  const timeZone = resolveTimeZone(timeZoneCookie, locale);
 
   const parts = match.participants ?? [];
   const uniqueIds = Array.from(

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -133,7 +133,7 @@ export default async function MatchesPage(
   const cookieStore = cookies();
   const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
-  const timeZone = resolveTimeZone(timeZoneCookie);
+  const timeZone = resolveTimeZone(timeZoneCookie, locale);
 
   try {
     const { rows, hasMore, nextOffset, totalCount } = await getMatches(

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -445,7 +445,7 @@ export default async function PlayerPage({
   const cookieStore = cookies();
   const { locale } = resolveServerLocale({ cookieStore });
   const timeZoneCookie = cookieStore.get(TIME_ZONE_COOKIE_KEY)?.value ?? null;
-  const timeZone = resolveTimeZone(timeZoneCookie);
+  const timeZone = resolveTimeZone(timeZoneCookie, locale);
   let player: Player;
   try {
     player = await getPlayer(params.id);

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -47,7 +47,12 @@ import {
   saveUserSettings,
   type UserSettings,
 } from "../user-settings";
-import { normalizeTimeZone, DEFAULT_TIME_ZONE } from "../../lib/i18n";
+import {
+  normalizeTimeZone,
+  DEFAULT_TIME_ZONE,
+  detectTimeZone,
+} from "../../lib/i18n";
+import { useLocale } from "../../lib/LocaleContext";
 import {
   ALL_SPORTS,
   MASTER_SPORT,
@@ -191,6 +196,7 @@ function formatSportOption(id: string): string {
 
 export default function ProfilePage() {
   const router = useRouter();
+  const currentLocale = useLocale();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -1101,13 +1107,9 @@ export default function ProfilePage() {
                 setPreferencesFeedback(null);
                 setMessage(null);
                 setError(null);
-                let detected: string | null = null;
-                try {
-                  detected =
-                    Intl.DateTimeFormat().resolvedOptions().timeZone ?? null;
-                } catch {
-                  detected = null;
-                }
+                const detected = detectTimeZone(
+                  preferences.preferredLocale || currentLocale,
+                );
                 const normalized = normalizeTimeZone(
                   detected ?? DEFAULT_TIME_ZONE,
                   DEFAULT_TIME_ZONE,

--- a/apps/web/src/lib/LocaleContext.tsx
+++ b/apps/web/src/lib/LocaleContext.tsx
@@ -106,7 +106,7 @@ export function LocaleProvider({
     normalizeLocale(locale, NEUTRAL_FALLBACK_LOCALE),
   );
   const [currentTimeZone, setCurrentTimeZone] = useState(() =>
-    resolveTimeZone(timeZone),
+    resolveTimeZone(timeZone, locale),
   );
 
   useEffect(() => {
@@ -156,6 +156,7 @@ export function LocaleProvider({
       );
       const nextTimeZone = resolveTimeZone(
         preferredSettingsTimeZone || cookieTimeZone || null,
+        nextLocale,
       );
       setCurrentTimeZone((prev) => (prev === nextTimeZone ? prev : nextTimeZone));
       storeTimeZonePreference(nextTimeZone);

--- a/apps/web/src/lib/i18n.test.ts
+++ b/apps/web/src/lib/i18n.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearStoredTimeZone,
   DEFAULT_TIME_ZONE,
+  detectTimeZone,
   formatDateTime,
   getStoredTimeZone,
   NEUTRAL_FALLBACK_LOCALE,
@@ -40,6 +41,19 @@ describe('time zone resolution', () => {
     expect(resolveTimeZone('')).toBe(DEFAULT_TIME_ZONE);
 
     spy.mockRestore();
+  });
+
+  it('falls back to a locale-associated time zone when detection cannot run', () => {
+    const originalWindow = global.window;
+    // @ts-expect-error - simulate a non-browser environment where window is unavailable
+    delete (global as { window?: typeof window }).window;
+
+    try {
+      expect(detectTimeZone('en-AU')).toBe('Australia/Melbourne');
+      expect(resolveTimeZone(null, 'en-AU')).toBe('Australia/Melbourne');
+    } finally {
+      global.window = originalWindow;
+    }
   });
 
   it('ignores invalid stored values', () => {


### PR DESCRIPTION
## Summary
- add locale-aware helpers for detecting and resolving time zones so server rendering falls back to regional defaults when the browser cannot report one
- pass locale hints through server-rendered pages and the locale provider to ensure the new resolver is used consistently
- refresh the profile preferences UI to use the shared detector and extend tests for the new behavior

## Testing
- pnpm exec vitest run src/lib/i18n.test.ts src/lib/LocaleContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db48cd089083239f5279e6e8aaa949