### PR TITLE
Add CSRF protection for player comments

### DIFF
--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -119,9 +119,12 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
     } catch (err) {
       const apiError = err as ApiError;
       const message =
-        apiError?.parsedMessage ||
-        apiError?.message ||
-        "We couldn't post your comment. Please try again.";
+        apiError?.code === "auth_csrf_missing" ||
+        apiError?.code === "auth_csrf_invalid"
+          ? "Your session expired. Please refresh and try again."
+          : apiError?.parsedMessage ||
+            apiError?.message ||
+            "We couldn't post your comment. Please try again.";
       setFeedback({ type: "error", message });
     } finally {
       setSubmitting(false);
@@ -157,9 +160,12 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
     } catch (err) {
       const apiError = err as ApiError;
       const message =
-        apiError?.parsedMessage ||
-        apiError?.message ||
-        "We couldn't delete the comment. Please try again.";
+        apiError?.code === "auth_csrf_missing" ||
+        apiError?.code === "auth_csrf_invalid"
+          ? "Your session expired. Please refresh and try again."
+          : apiError?.parsedMessage ||
+            apiError?.message ||
+            "We couldn't delete the comment. Please try again.";
       setFeedback({ type: "error", message });
     }
   }

--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -80,7 +80,7 @@ from ..services.photo_uploads import (
     save_photo_upload,
 )
 from .admin import require_admin
-from .auth import get_current_user
+from .auth import get_current_user, get_current_user_with_csrf
 from ..location_utils import normalize_location_fields, continent_for_country
 from ..time_utils import coerce_utc
 
@@ -880,7 +880,7 @@ async def add_comment(
     player_id: str,
     body: CommentCreate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_with_csrf),
 ):
     p = await session.get(Player, player_id)
     if not p or p.deleted_at is not None:
@@ -910,7 +910,7 @@ async def delete_comment(
     player_id: str,
     comment_id: str,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_with_csrf),
 ):
     comment = await session.get(Comment, comment_id)
     if not comment or comment.player_id != player_id or comment.deleted_at is not None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -448,6 +448,7 @@ class TokenOut(BaseModel):
     """Returned on successful authentication."""
     access_token: str
     refresh_token: str
+    csrf_token: str
 
 
 class UserOut(BaseModel):


### PR DESCRIPTION
## Summary
- issue CSRF secrets with every access token and expose a CSRF-aware authentication helper
- require the CSRF token on player comment create/delete endpoints and surface friendly errors in the UI
- attach CSRF headers from the web client and add targeted test coverage across backend and frontend

## Testing
- `pytest tests/test_comments.py tests/test_notifications.py`
- `CI=1 pnpm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68db48d697148323b5bd475c9812f7a4