### PR TITLE
Expand match detail page with metadata cards

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -795,6 +795,156 @@ textarea {
   font-size: 0.9rem;
 }
 
+.match-detail-layout {
+  margin-top: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 900px) {
+  .match-detail-layout {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  }
+}
+
+.match-detail-card {
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.match-detail-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-accent-red);
+}
+
+.match-detail-result {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.match-detail-result .match-participants {
+  font-weight: 500;
+}
+
+.match-detail-participants {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.match-detail-participant {
+  padding: 12px;
+  border: 1px solid rgba(10, 31, 68, 0.12);
+  border-radius: 8px;
+  background: rgba(10, 31, 68, 0.04);
+  display: grid;
+  gap: 8px;
+}
+
+.match-detail-participant--winner {
+  border-color: rgba(46, 139, 87, 0.4);
+  background: rgba(46, 139, 87, 0.12);
+}
+
+.match-detail-participant__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.match-detail-participant__label {
+  font-weight: 600;
+}
+
+.match-detail-participant__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--color-success);
+  color: #fff;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.match-detail-empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
+.match-detail-summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.match-detail-summary-table th,
+.match-detail-summary-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(10, 31, 68, 0.08);
+}
+
+.match-detail-summary-table thead th {
+  text-align: left;
+  background: rgba(10, 31, 68, 0.05);
+  font-weight: 600;
+}
+
+.match-detail-summary-table th:first-child,
+.match-detail-summary-table td:first-child {
+  text-align: left;
+}
+
+.match-detail-summary-table td {
+  text-align: center;
+}
+
+.match-detail-summary-table tbody tr:nth-child(even) th,
+.match-detail-summary-table tbody tr:nth-child(even) td {
+  background: rgba(10, 31, 68, 0.02);
+}
+
+.match-detail-summary-row--winner th,
+.match-detail-summary-row--winner td {
+  background: rgba(46, 139, 87, 0.12);
+  font-weight: 600;
+}
+
+.match-detail-info {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.match-detail-info__item {
+  display: grid;
+  gap: 4px;
+}
+
+.match-detail-info__term {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.match-detail-info__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(10, 31, 68, 0.75);
+}
+
 .auth-form {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- add participant winner detection, score aggregation, and logistics details to the match detail view
- style the new match detail cards and summary table for clarity across breakpoints
- cover the expanded layout with a dedicated test that asserts the new participants, totals, and rules link

## Testing
- pnpm test -- --run "src/app/matches/[mid]/page.test.tsx"

------
https://chatgpt.com/codex/tasks/task_e_68db4c4c210c8323b234bc6bcfe2ef85