### PR TITLE
Improve accessibility of player charts

### DIFF
--- a/apps/web/src/components/charts/MatchHeatmap.tsx
+++ b/apps/web/src/components/charts/MatchHeatmap.tsx
@@ -81,9 +81,63 @@ export function MatchHeatmap({ data, xLabels, yLabels }: MatchHeatmapProps) {
       legend: { display: false },
     },
   };
+  const totalMatches = data.reduce((sum, point) => sum + point.v, 0);
+  const busiest = data.reduce<HeatmapDatum | null>(
+    (current, point) => (current && current.v >= point.v ? current : point),
+    data[0] ?? null,
+  );
+  const busiestDay =
+    typeof busiest?.x === 'number' ? xLabels[busiest.x] ?? `${busiest.x}` : undefined;
+  const busiestTime =
+    typeof busiest?.y === 'number' ? yLabels[busiest.y] ?? `${busiest.y}` : undefined;
+  const summary =
+    totalMatches > 0 && busiest && busiestDay && busiestTime
+      ? `Heatmap showing ${totalMatches} matches played across days of the week and hours of the day. The busiest period is ${busiestDay} at ${busiestTime} with ${busiest.v} matches.`
+      : 'Heatmap showing match activity by day of week and hour of day. No activity data is available.';
+  const sortedEntries = [...data].sort((a, b) => {
+    if (a.x === b.x) {
+      return a.y - b.y;
+    }
+    return a.x - b.x;
+  });
   return (
     <div style={{ position: 'relative', width: '100%', height: '300px' }}>
-      <Chart type="matrix" data={chartData} options={options} />
+      <Chart
+        role="img"
+        aria-label={summary}
+        type="matrix"
+        data={chartData}
+        options={options}
+      />
+      {totalMatches > 0 ? (
+        <table className="sr-only">
+          <caption>Matches by day and start hour</caption>
+          <thead>
+            <tr>
+              <th scope="col">Day</th>
+              <th scope="col">Hour</th>
+              <th scope="col">Matches</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedEntries.map((point) => {
+              const dayLabel =
+                typeof point.x === 'number' ? xLabels[point.x] ?? `${point.x}` : `${point.x}`;
+              const hourLabel =
+                typeof point.y === 'number' ? yLabels[point.y] ?? `${point.y}` : `${point.y}`;
+              return (
+                <tr key={`${point.x}-${point.y}`}>
+                  <td>{dayLabel}</td>
+                  <td>{hourLabel}</td>
+                  <td>{point.v}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <p className="sr-only">No heatmap data is available.</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/charts/RankingHistoryChart.tsx
+++ b/apps/web/src/components/charts/RankingHistoryChart.tsx
@@ -50,9 +50,44 @@ export function RankingHistoryChart({ data }: { data: RankingPoint[] }) {
       },
     },
   };
+  const ranks = data.map((d) => d.rank);
+  const minRank = ranks.length ? Math.min(...ranks) : null;
+  const maxRank = ranks.length ? Math.max(...ranks) : null;
+  const firstDate = data[0]?.date;
+  const lastDate = data[data.length - 1]?.date;
+  const summary =
+    ranks.length > 0
+      ? `Line chart showing the player's ranking history from ${firstDate} to ${lastDate}. Rankings range between ${minRank} and ${maxRank}, with lower numbers indicating a better rank.`
+      : 'Line chart showing the player\'s ranking history. No ranking data is available.';
   return (
     <div style={{ position: 'relative', width: '100%', height: '300px' }}>
-      <Line data={chartData} options={options} />
+      <Line
+        role="img"
+        aria-label={summary}
+        data={chartData}
+        options={options}
+      />
+      {data.length > 0 ? (
+        <table className="sr-only">
+          <caption>Ranking by match date</caption>
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Rank</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((point, index) => (
+              <tr key={`${point.date}-${index}`}>
+                <td>{point.date}</td>
+                <td>{point.rank}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="sr-only">No ranking data is available.</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/charts/WinRateChart.tsx
+++ b/apps/web/src/components/charts/WinRateChart.tsx
@@ -54,9 +54,45 @@ export function WinRateChart({ data }: { data: WinRatePoint[] }) {
     },
   };
 
+  const winRates = data.map((d) => Math.round(d.winRate * 100));
+  const minRate = winRates.length ? Math.min(...winRates) : null;
+  const maxRate = winRates.length ? Math.max(...winRates) : null;
+  const firstDate = data[0]?.date;
+  const lastDate = data[data.length - 1]?.date;
+  const summary =
+    winRates.length > 0
+      ? `Line chart showing the player's win rate percentage over time from ${firstDate} to ${lastDate}. The win rate ranges from ${minRate}% to ${maxRate}%.`
+      : 'Line chart showing the player\'s win rate percentage over time. No win rate data is available.';
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '300px' }}>
-      <Line data={chartData} options={options} />
+      <Line
+        role="img"
+        aria-label={summary}
+        data={chartData}
+        options={options}
+      />
+      {data.length > 0 ? (
+        <table className="sr-only">
+          <caption>Win rate by match date</caption>
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Win rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((point, index) => (
+              <tr key={`${point.date}-${index}`}>
+                <td>{point.date}</td>
+                <td>{Math.round(point.winRate * 100)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="sr-only">No win rate data is available.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add descriptive aria labels to player performance, ranking, and activity charts
- expose screen-reader friendly data tables that summarize chart contents
- derive narrative summaries that highlight key ranges and totals for each visualization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db4c001b048323a44ccb680b141ebb