### PR TITLE
Update auth test for CSRF token tuple

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -386,13 +386,15 @@ def test_create_token_flushes_before_refresh_token():
     )
     session.add(user)
 
-    access, refresh, csrf = asyncio.run(auth.create_token(user, session))
+    access_token, refresh_token, csrf_token = asyncio.run(
+        auth.create_token(user, session)
+    )
 
     assert session.flush_called
     assert any(isinstance(obj, RefreshToken) for obj in session.added)
-    assert access
-    assert refresh
-    assert csrf
+    assert access_token
+    assert refresh_token
+    assert csrf_token
 
 
 def _create_admin_and_user(client: TestClient, user_name: str):


### PR DESCRIPTION
## Summary
- update `test_create_token_flushes_before_refresh_token` to unpack the CSRF token returned by `create_token`

## Testing
- pytest backend/tests/test_auth.py::test_create_token_flushes_before_refresh_token -q

------
https://chatgpt.com/codex/tasks/task_e_68db50421e648323add6c935739b61de