### PR TITLE
Fix locale canonicalisation for player history date formatting

### DIFF
--- a/apps/web/src/lib/i18n.test.ts
+++ b/apps/web/src/lib/i18n.test.ts
@@ -7,6 +7,8 @@ import {
   formatDateTime,
   getStoredTimeZone,
   NEUTRAL_FALLBACK_LOCALE,
+  normalizeLocale,
+  parseAcceptLanguage,
   resolveFormatterLocale,
   resolveTimeZone,
   storeTimeZonePreference,
@@ -71,5 +73,21 @@ describe('formatter helpers', () => {
 
   it('formats dates with the neutral fallback when locale hints are missing', () => {
     expect(formatDateTime('2001-11-21T09:30:00Z', '')).toBe('21 Nov 2001, 09:30');
+  });
+});
+
+describe('locale helpers', () => {
+  it('canonicalises locales with underscores and casing differences', () => {
+    expect(normalizeLocale('en_au')).toBe('en-AU');
+    expect(normalizeLocale('EN_us')).toBe('en-US');
+  });
+
+  it('applies canonicalisation to fallbacks', () => {
+    expect(normalizeLocale(undefined, 'en_gb')).toBe('en-GB');
+    expect(normalizeLocale(null, '')).toBe('');
+  });
+
+  it('parses Accept-Language values that include underscores', () => {
+    expect(parseAcceptLanguage('en_US,en_AU;q=0.8')).toBe('en-AU');
   });
 });


### PR DESCRIPTION
## Summary
- canonicalise locale inputs and fallbacks when resolving server locales
- normalise Accept-Language parsing to honour Australian preferences even when headers use underscores
- extend locale helper tests to cover canonicalisation and Accept-Language parsing edge cases

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68db5571c32483239d6925e6560ffea3