### PR TITLE
Improve player photo upload UX

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -170,6 +170,46 @@ img {
   gap: 0.35rem;
 }
 
+.photo-upload__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(10, 31, 68, 0.7);
+}
+
+.photo-upload__spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgba(10, 31, 68, 0.15);
+  border-top-color: var(--color-accent-blue);
+  border-radius: 999px;
+  animation: photo-upload-spin 0.8s linear infinite;
+}
+
+.photo-upload__message {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.photo-upload__message--success {
+  color: var(--color-success);
+}
+
+.photo-upload__message--error {
+  color: var(--color-accent-red);
+}
+
+@keyframes photo-upload-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .form-field--checkbox {
   flex-direction: row;
   align-items: center;

--- a/apps/web/src/app/players/[id]/PhotoUpload.tsx
+++ b/apps/web/src/app/players/[id]/PhotoUpload.tsx
@@ -11,26 +11,72 @@ interface Props {
 export default function PhotoUpload({ playerId, initialUrl }: Props) {
   const [url, setUrl] = useState<string | null | undefined>(initialUrl);
   const [uploading, setUploading] = useState(false);
+  const [status, setStatus] = useState<
+    | { type: 'idle'; message: null }
+    | { type: 'success' | 'error'; message: string }
+  >({ type: 'idle', message: null });
 
   const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    setStatus({ type: 'idle', message: null });
+
+    const allowedTypes = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+      'image/avif',
+    ];
+    const maxSize = 5 * 1024 * 1024; // 5MB
+
+    if (file.type && !allowedTypes.includes(file.type)) {
+      setStatus({
+        type: 'error',
+        message: 'Please choose a JPEG, PNG, GIF, WebP, or AVIF image.',
+      });
+      e.target.value = '';
+      return;
+    }
+
+    if (file.size > maxSize) {
+      setStatus({
+        type: 'error',
+        message: 'Please choose an image smaller than 5MB.',
+      });
+      e.target.value = '';
+      return;
+    }
+
     const form = new FormData();
     form.append('file', file);
     setUploading(true);
-    const r = await apiFetch(`/v0/players/${playerId}/photo`, {
-      method: 'POST',
-      body: form,
-    });
-    if (r.ok) {
+    try {
+      const r = await apiFetch(`/v0/players/${playerId}/photo`, {
+        method: 'POST',
+        body: form,
+      });
+      if (!r.ok) {
+        throw new Error(`Upload failed with status ${r.status}`);
+      }
       const data = (await r.json()) as { photo_url?: string };
       setUrl(
         typeof data.photo_url === 'string' && data.photo_url
           ? ensureAbsoluteApiUrl(data.photo_url)
           : null
       );
+      setStatus({ type: 'success', message: 'Photo updated successfully.' });
+    } catch (error) {
+      console.error('Failed to upload player photo', error);
+      setStatus({
+        type: 'error',
+        message: 'Unable to upload the photo right now. Please try again.',
+      });
+    } finally {
+      setUploading(false);
+      e.target.value = '';
     }
-    setUploading(false);
   };
 
   return (
@@ -52,9 +98,24 @@ export default function PhotoUpload({ playerId, initialUrl }: Props) {
           type="file"
           accept="image/*"
           onChange={onChange}
+          disabled={uploading}
         />
       </label>
-      {uploading && <span>Uploading…</span>}
+      {uploading && (
+        <div className="photo-upload__status" role="status" aria-live="polite">
+          <span className="photo-upload__spinner" aria-hidden="true" />
+          <span>Uploading photo…</span>
+        </div>
+      )}
+      {status.type !== 'idle' && status.message && (
+        <p
+          className={`photo-upload__message photo-upload__message--${status.type}`}
+          role={status.type === 'error' ? 'alert' : 'status'}
+          aria-live={status.type === 'error' ? 'assertive' : 'polite'}
+        >
+          {status.message}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add upload status messaging, error handling, and client-side validation to the player photo uploader
- disable the file input while requests are in flight and surface API errors
- add styles for the photo upload spinner and feedback states

## Testing
- pnpm test -- run

------
https://chatgpt.com/codex/tasks/task_e_68db56a123448323b96f8be322daf171