### PR TITLE
Add accessible captions to match score tables

### DIFF
--- a/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
+++ b/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
@@ -74,6 +74,9 @@ function renderRacketSummary(
 
   return (
     <table className="scoreboard-table" aria-label="Racket scoreboard">
+      <caption className="sr-only">
+        Set, game, and point totals for each side
+      </caption>
       <thead>
         <tr>
           <th scope="col">Side</th>
@@ -130,6 +133,7 @@ function renderDiscGolfSummary(summary: SummaryData) {
 
   return (
     <table className="scoreboard-table" aria-label="Disc golf scoreboard">
+      <caption className="sr-only">Hole-by-hole disc golf scores by side</caption>
       <thead>
         <tr>
           <th scope="col">Side</th>
@@ -203,6 +207,7 @@ function renderBowlingSummary(summary: SummaryData) {
 
     return (
       <table className="scoreboard-table" aria-label="Bowling scoreboard">
+        <caption className="sr-only">Frame scores for each bowler</caption>
         <thead>
           <tr>
             <th scope="col">Player</th>
@@ -258,6 +263,7 @@ function renderBowlingSummary(summary: SummaryData) {
 
   return (
     <table className="scoreboard-table" aria-label="Bowling scoreboard">
+      <caption className="sr-only">Frame-by-frame bowling summary</caption>
       <thead>
         <tr>
           <th scope="col">Frame</th>

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -875,6 +875,7 @@ export default async function MatchDetailPage({
                 className="match-detail-summary-table"
                 aria-label="Score totals"
               >
+                <caption className="sr-only">Score totals by side</caption>
                 <thead>
                   <tr>
                     <th scope="col">Side</th>


### PR DESCRIPTION
## Summary
- add screen-reader-only captions to match detail score summary and scoreboard tables
- ensure table headers retain row and column scopes for assistive technologies

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68db56b5421083238604c5a0e39afa4f