### PR TITLE
Set default locale from Accept-Language and show it in profile

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -52,6 +52,7 @@ import {
   normalizeTimeZone,
   DEFAULT_TIME_ZONE,
   detectTimeZone,
+  storeLocalePreference,
 } from "../../lib/i18n";
 import { useLocale } from "../../lib/LocaleContext";
 import {
@@ -344,6 +345,9 @@ export default function ProfilePage() {
       !stored.preferredLocale && normalizedLocale
         ? { ...stored, preferredLocale: normalizedLocale }
         : stored;
+    if (!stored.preferredLocale && normalizedLocale) {
+      storeLocalePreference(normalizedLocale);
+    }
     setPreferences(hydrated);
     setInitialPreferences(hydrated);
     setPreferencesLoaded(true);
@@ -1077,6 +1081,7 @@ export default function ProfilePage() {
           />
         </label>
         <span id={PREFERENCES_LOCALE_HINT_ID} className="form-hint">
+          Current locale: {normalizeLocale(currentLocale, "") || "Not detected"}.
           Used to format dates, times, and placeholder values across the app.
         </span>
         <datalist id="preferences-locale-options">

--- a/apps/web/src/lib/LocaleContext.test.tsx
+++ b/apps/web/src/lib/LocaleContext.test.tsx
@@ -49,7 +49,9 @@ describe('LocaleProvider', () => {
     );
 
     const localeDisplay = await screen.findByTestId('locale-value');
-    expect(localeDisplay).toHaveTextContent('en-AU');
+    await waitFor(() => {
+      expect(localeDisplay).toHaveTextContent('en-AU');
+    });
   });
 
   it('uses the accept-language header when provided', async () => {
@@ -63,7 +65,9 @@ describe('LocaleProvider', () => {
     );
 
     const localeDisplay = await screen.findByTestId('locale-value');
-    expect(localeDisplay).toHaveTextContent('en-AU');
+    await waitFor(() => {
+      expect(localeDisplay).toHaveTextContent('en-AU');
+    });
   });
 
   it('prefers a stored locale before falling back', async () => {


### PR DESCRIPTION
## Summary
- derive the initial locale preference from the Accept-Language header and stored hints
- ensure the locale preference is persisted when appropriate and keep tests resilient to async updates
- surface the detected locale in the profile preferences form and hydrate empty settings with it

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68db5cc7f9208323903ba9138d24c987