### PR TITLE
Fix padel record form validation messaging

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -226,6 +226,12 @@ describe("RecordPadelPage", () => {
     const playerB1 = await screen.findByRole("combobox", { name: "Player B 1" });
     const saveButton = screen.getByRole("button", { name: /save/i });
 
+    const playerHints = await screen.findAllByText(/Add players to both sides\./i);
+    expect(playerHints).toHaveLength(2);
+    expect(
+      screen.queryByText(/Add at least one player to side B\./i),
+    ).not.toBeInTheDocument();
+
     fireEvent.change(playerA1, {
       target: { value: "p1" },
     });

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -60,6 +60,7 @@ export default function RecordPadelPage() {
     b2: "",
   });
   const [saving, setSaving] = useState(false);
+  const [showSummaryValidation, setShowSummaryValidation] = useState(false);
   const locale = useLocale();
   const [success, setSuccess] = useState(false);
   const saveSummaryId = useId();
@@ -172,10 +173,14 @@ export default function RecordPadelPage() {
   const buttonOpacity = canSave ? 1 : 0.75;
   const sideASummaryMessage = hasSideAPlayers
     ? `Side A: ${sideAPlayerNames.join(", ")}`
-    : "Add at least one player to side A.";
+    : showSummaryValidation
+      ? "Add at least one player to side A."
+      : "Add players to both sides.";
   const sideBSummaryMessage = hasSideBPlayers
     ? `Side B: ${sideBPlayerNames.join(", ")}`
-    : "Add at least one player to side B.";
+    : showSummaryValidation
+      ? "Add at least one player to side B."
+      : "Add players to both sides.";
   const duplicatePlayersMessage = duplicatePlayerNames.length
     ? `Players cannot appear on both sides: ${duplicatePlayerNames.join(", ")}.`
     : null;
@@ -273,6 +278,7 @@ export default function RecordPadelPage() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    setShowSummaryValidation(true);
     if (saving || !canSave) {
       return;
     }
@@ -660,14 +666,22 @@ export default function RecordPadelPage() {
         </p>
         <div id={saveSummaryId} aria-live="polite">
           <p
-            className={hasSideAPlayers ? "form-hint" : "error"}
-            role={hasSideAPlayers ? undefined : "alert"}
+            className={
+              !hasSideAPlayers && showSummaryValidation ? "error" : "form-hint"
+            }
+            role={
+              !hasSideAPlayers && showSummaryValidation ? "alert" : undefined
+            }
           >
             {sideASummaryMessage}
           </p>
           <p
-            className={hasSideBPlayers ? "form-hint" : "error"}
-            role={hasSideBPlayers ? undefined : "alert"}
+            className={
+              !hasSideBPlayers && showSummaryValidation ? "error" : "form-hint"
+            }
+            role={
+              !hasSideBPlayers && showSummaryValidation ? "alert" : undefined
+            }
           >
             {sideBSummaryMessage}
           </p>
@@ -677,8 +691,12 @@ export default function RecordPadelPage() {
             </p>
           )}
           <p
-            className={setStatus.message ? "error" : "form-hint"}
-            role={setStatus.message ? "alert" : undefined}
+            className={
+              setStatus.message && showSummaryValidation ? "error" : "form-hint"
+            }
+            role={
+              setStatus.message && showSummaryValidation ? "alert" : undefined
+            }
           >
             {completedSetsMessage}
           </p>
@@ -687,7 +705,6 @@ export default function RecordPadelPage() {
           type="submit"
           aria-disabled={!canSave ? "true" : "false"}
           aria-describedby={`padel-save-hint ${saveSummaryId}`}
-          disabled={!canSave}
           data-saving={saving}
           style={{
             opacity: buttonOpacity,


### PR DESCRIPTION
## Summary
- defer displaying padel record form validation errors until the user tries to submit
- show instructional hints before submission and gate summary alerts behind submit attempts
- update the padel recording test to reflect the new hint messaging

## Testing
- pnpm vitest run src/app/record/padel/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db5f596dd88323af798937676de712