### PR TITLE
Add participant validation and anonymous rate limiting

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 class ValidationError(Exception):
     """Raised when submitted set scores are invalid."""
@@ -13,6 +13,7 @@ def validate_set_scores(
     *,
     max_sets: Optional[int] = 5,
     allow_ties: bool = False,
+    max_points_per_side: Optional[int] = 1000,
 ) -> None:
     """Validate a list of set score dictionaries.
 
@@ -51,6 +52,98 @@ def validate_set_scores(
             raise ValidationError(f"Set #{i} scores must be >= 0.")
         if not allow_ties and a == b:
             raise ValidationError(f"Set #{i} cannot be a tie.")
+        if max_points_per_side is not None and (
+            a > max_points_per_side or b > max_points_per_side
+        ):
+            raise ValidationError(
+                f"Set #{i} scores must be <= {max_points_per_side}."
+            )
 
     return None
+
+
+SPORT_RULES: dict[str, dict[str, object]] = {
+    "padel": {"team_sizes": {1, 2}, "min_sides": 2, "max_sides": 2},
+    "padel_americano": {"team_sizes": {2}, "min_sides": 2, "max_sides": 2},
+    "tennis": {"team_sizes": {1, 2}, "min_sides": 2, "max_sides": 2},
+    "pickleball": {"team_sizes": {1, 2}, "min_sides": 2, "max_sides": 2},
+    "bowling": {"team_sizes": {1}, "min_sides": 1},
+    "disc_golf": {"team_sizes": {1}, "min_sides": 1},
+}
+
+
+def _sport_label(sport_id: str) -> str:
+    return sport_id.replace("_", " ").title() or "Sport"
+
+
+def validate_participants_for_sport(
+    sport_id: str, side_players: Dict[str, List[str]]
+) -> None:
+    rules = SPORT_RULES.get(sport_id)
+    if not rules:
+        return
+
+    team_sizes = rules.get("team_sizes")
+    if isinstance(team_sizes, set) and team_sizes:
+        allowed_sizes = sorted(int(size) for size in team_sizes)
+        for side, players in side_players.items():
+            size = len(players)
+            if size not in team_sizes:
+                if len(allowed_sizes) == 1:
+                    raise ValidationError(
+                        f"{_sport_label(sport_id)} matches require exactly {allowed_sizes[0]}"
+                        " player(s) per side."
+                    )
+                formatted = ", ".join(str(v) for v in allowed_sizes)
+                raise ValidationError(
+                    f"{_sport_label(sport_id)} matches must use {formatted} players per side."
+                )
+
+    side_count = len(side_players)
+    min_sides = rules.get("min_sides")
+    max_sides = rules.get("max_sides")
+
+    if isinstance(min_sides, int) and side_count < min_sides:
+        raise ValidationError(
+            f"{_sport_label(sport_id)} matches require at least {min_sides} side(s)."
+        )
+    if isinstance(max_sides, int) and side_count > max_sides:
+        raise ValidationError(
+            f"{_sport_label(sport_id)} matches support at most {max_sides} side(s)."
+        )
+
+
+def validate_score_totals(
+    scores: Sequence[Any],
+    *,
+    min_value: int = 0,
+    max_value: int = 1000,
+) -> List[int]:
+    if not isinstance(scores, Sequence) or isinstance(scores, (str, bytes)):
+        raise ValidationError("Scores must be provided as a sequence of integers.")
+    if len(scores) == 0:
+        raise ValidationError("Scores must include at least one value.")
+
+    normalized: List[int] = []
+    for index, raw in enumerate(scores, start=1):
+        if isinstance(raw, bool):
+            raise ValidationError(
+                f"Score #{index} must be an integer (not a boolean)."
+            )
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            raise ValidationError(f"Score #{index} must be an integer.")
+
+        if value < min_value:
+            raise ValidationError(
+                f"Score #{index} must be greater than or equal to {min_value}."
+            )
+        if max_value is not None and value > max_value:
+            raise ValidationError(
+                f"Score #{index} must be less than or equal to {max_value}."
+            )
+        normalized.append(value)
+
+    return normalized
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -7,6 +7,7 @@ import jwt
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
 
 from app import db
 from app.models import Sport
@@ -66,6 +67,8 @@ def seed_sports():
 
 def test_comment_and_match_notifications_flow():
     app = FastAPI()
+    app.state.limiter = auth.limiter
+    app.add_exception_handler(RateLimitExceeded, auth.rate_limit_handler)
     app.include_router(auth.router)
     app.include_router(players.router)
     app.include_router(matches.router)


### PR DESCRIPTION
## Summary
- enforce participant existence, team size, and score validation on match creation
- rate limit anonymous requests hitting match recording endpoints using shared limiter helpers
- update tests to seed required players and configure test apps with the limiter

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68db5f3d525c832387f4d97dcb2e2cb0