### PR TITLE
Add aria label to player search input

### DIFF
--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -395,6 +395,7 @@ export default function PlayersPage() {
               id="player-search"
               type="search"
               className="input"
+              aria-label="Search players"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search players"


### PR DESCRIPTION
## Summary
- add an aria-label to the player search field to ensure assistive technologies announce its purpose

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db67aec4a48323ba39e4b335c35af4