### PR TITLE
Handle restricted profile fields for non-admin users

### DIFF
--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -403,6 +403,29 @@ describe("ProfilePage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides player customization when access is denied", async () => {
+    const forbidden = Object.assign(new Error("HTTP 403: forbidden"), {
+      status: 403,
+    });
+    apiMocks.fetchMyPlayer.mockRejectedValueOnce(forbidden);
+
+    await act(async () => {
+      renderWithProviders(<ProfilePage />);
+    });
+
+    const restrictionMessage = await screen.findByText(
+      /player profile is managed by an administrator/i,
+    );
+    expect(restrictionMessage).toBeInTheDocument();
+    expect(screen.queryByLabelText("Country")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create my player profile/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/social links are managed by an administrator/i)
+    ).toBeInTheDocument();
+  });
+
   it("creates a player record on demand", async () => {
     const notFound = Object.assign(new Error("HTTP 404: player not found"), {
       status: 404,


### PR DESCRIPTION
## Summary
- hide player profile inputs when the API responds with a 403 and show a clear administrator-managed message instead
- surface ISO country codes in both the profile country selector and the default leaderboard country preferences
- add regression coverage for the restricted-access scenario on the profile page

## Testing
- pnpm --dir apps/web exec vitest run profile/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db64c815e483239b7062427f640d41