### PR TITLE
Fix optimistic comments total calculation

### DIFF
--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -138,10 +138,11 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
             const filteredItems = base.items.filter(
               (existing) => existing.id !== newComment.id,
             );
+            const isExistingComment = filteredItems.length !== base.items.length;
             return {
               ...base,
               items: [newComment, ...filteredItems],
-              total: filteredItems.length + 1,
+              total: base.total + (isExistingComment ? 0 : 1),
             };
           },
           { populateCache: true, revalidate: false },


### PR DESCRIPTION
## Summary
- adjust the optimistic cache update for player comments to reuse the existing total count
- ensure the total is incremented only when the added comment is new to the cached list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6a6b0dd08323b57f1b98d43aba26