### PR TITLE
Hide empty player detail sections

### DIFF
--- a/apps/web/src/app/players/[id]/PlayerCharts.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.tsx
@@ -62,20 +62,38 @@ export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) 
     return { x, y, v };
   });
 
+  const hasMatches = winRateData.length > 0;
+  const hasRankingHistory = rankingData.length > 0;
+  const hasHeatmapEntries = heatmapData.length > 0;
+
   const xLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const yLabels = Array.from({ length: 24 }, (_, i) => `${i}:00`);
 
   return (
-    <section className="mt-8">
-      <h2 className="heading">Performance</h2>
-      <WinRateChart data={winRateData} />
-      <div className="mt-8">
-        <h3 className="heading">Ranking History</h3>
-        <RankingHistoryChart data={rankingData} />
+    <section className="mt-8 space-y-8">
+      <div>
+        <h2 className="heading">Performance</h2>
+        {hasMatches ? (
+          <WinRateChart data={winRateData} />
+        ) : (
+          <p className="text-sm text-gray-600">No matches found.</p>
+        )}
       </div>
-      <div className="mt-8">
+      <div>
+        <h3 className="heading">Ranking History</h3>
+        {hasRankingHistory ? (
+          <RankingHistoryChart data={rankingData} />
+        ) : (
+          <p className="text-sm text-gray-600">No ranking history.</p>
+        )}
+      </div>
+      <div>
         <h3 className="heading">Activity Heatmap</h3>
-        <MatchHeatmap data={heatmapData} xLabels={xLabels} yLabels={yLabels} />
+        {hasHeatmapEntries ? (
+          <MatchHeatmap data={heatmapData} xLabels={xLabels} yLabels={yLabels} />
+        ) : (
+          <p className="text-sm text-gray-600">No activity recorded.</p>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -714,22 +714,24 @@ export default async function PlayerPage({
               </section>
             )}
 
-            <h2 className="heading mt-4">Recent Opponents</h2>
             {recentOpponents.length ? (
-              <ul>
-                {recentOpponents.map((o) => (
-                  <li key={o.id} className="mb-2">
-                    <div>
-                      <MatchParticipants as="span" sides={[o.opponents]} />
-                    </div>
-                    <div className="text-sm text-gray-700">
-                      {o.date} · {o.result}
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              <>
+                <h2 className="heading mt-4">Recent Opponents</h2>
+                <ul>
+                  {recentOpponents.map((o) => (
+                    <li key={o.id} className="mb-2">
+                      <div>
+                        <MatchParticipants as="span" sides={[o.opponents]} />
+                      </div>
+                      <div className="text-sm text-gray-700">
+                        {o.date} · {o.result}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </>
             ) : (
-              <p>No recent opponents found.</p>
+              <p className="mt-4 text-sm text-gray-600">No recent opponents found.</p>
             )}
 
             {teammateRecords.length ? (
@@ -743,7 +745,9 @@ export default async function PlayerPage({
                   ))}
                 </ul>
               </>
-            ) : null}
+            ) : (
+              <p className="mt-4 text-sm text-gray-600">No teammate records.</p>
+            )}
 
             <PlayerCharts matches={matches} />
 
@@ -754,36 +758,40 @@ export default async function PlayerPage({
             </Link>
           </section>
         <aside className="md:w-1/3 md:pl-4 mt-8 md:mt-0">
-          <h2 className="heading">Upcoming Matches</h2>
           {upcoming.length ? (
-            <ul>
-              {upcoming.map((m) => (
-                <li key={m.id} className="mb-2">
-                  <Link href={`/matches/${m.id}`}>
-                    <MatchParticipants
-                      as="span"
-                      sides={Object.values(m.players)}
-                    />
-                  </Link>
-                  <div className="text-sm text-gray-700">
-                    {formatDate(m.playedAt, locale, undefined, timeZone)} ·{' '}
-                    {m.location ?? "—"}
-                  </div>
-                </li>
-              ))}
-            </ul>
+            <>
+              <h2 className="heading">Upcoming Matches</h2>
+              <ul>
+                {upcoming.map((m) => (
+                  <li key={m.id} className="mb-2">
+                    <Link href={`/matches/${m.id}`}>
+                      <MatchParticipants
+                        as="span"
+                        sides={Object.values(m.players)}
+                      />
+                    </Link>
+                    <div className="text-sm text-gray-700">
+                      {formatDate(m.playedAt, locale, undefined, timeZone)} ·{' '}
+                      {m.location ?? "—"}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
           ) : (
-            <p>No upcoming matches.</p>
+            <p className="text-sm text-gray-600">No upcoming matches.</p>
           )}
-          <h2 className="heading mt-4">Badges</h2>
           {player.badges.length ? (
-            <ul>
-              {player.badges.map((b) => (
-                <li key={b.id}>{b.name}</li>
-              ))}
-            </ul>
+            <>
+              <h2 className="heading mt-4">Badges</h2>
+              <ul>
+                {player.badges.map((b) => (
+                  <li key={b.id}>{b.name}</li>
+                ))}
+              </ul>
+            </>
           ) : (
-            <p>No badges.</p>
+            <p className="mt-4 text-sm text-gray-600">No badges.</p>
           )}
         </aside>
       </main>


### PR DESCRIPTION
## Summary
- stop rendering player performance charts when no match data is available and show context messages instead
- gate recent opponents, teammate records, upcoming matches, and badges sections behind real data with descriptive fallbacks

## Testing
- `npm run lint` *(fails: existing @typescript-eslint/no-unused-vars errors in src/app/record/disc-golf/page.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68db6bf271788323bb52e86f8c8c387b