### PR TITLE
Improve date formatting for day-first locales

### DIFF
--- a/apps/web/src/app/admin/matches/page.test.tsx
+++ b/apps/web/src/app/admin/matches/page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+import AdminMatchesPage from './page';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('../../../lib/api', () => ({
+  apiFetch: (...args: Parameters<typeof apiFetchMock>) => apiFetchMock(...args),
+  isAdmin: () => true,
+  withAbsolutePhotoUrl: (value: unknown) => value,
+}));
+
+vi.mock('../../../lib/LocaleContext', () => ({
+  useLocale: () => 'en-AU',
+  useTimeZone: () => 'Australia/Melbourne',
+}));
+
+vi.mock('../../../lib/participants', () => ({
+  resolveParticipantGroups: () => [],
+}));
+
+vi.mock('../../../lib/loginRedirect', () => ({
+  rememberLoginRedirect: vi.fn(),
+}));
+
+vi.mock('../../../components/MatchParticipants', () => ({
+  __esModule: true,
+  default: ({ sides }: { sides: unknown }) => (
+    <div data-testid="participants">{JSON.stringify(sides)}</div>
+  ),
+}));
+
+describe('AdminMatchesPage', () => {
+  afterEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it('renders dates using day-first ordering for Australian locales', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: 'm1',
+            sport: 'padel',
+            stageId: null,
+            bestOf: 3,
+            playedAt: '2024-02-03T00:00:00Z',
+            location: 'Centre Court',
+            isFriendly: false,
+          },
+        ],
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          participants: [],
+          summary: null,
+        }),
+      } as unknown as Response);
+
+    render(<AdminMatchesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/3\/2\/24/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -3,7 +3,12 @@ import { cookies } from "next/headers";
 import { apiFetch, type ApiError } from "../../lib/api";
 import Pager from "./pager";
 import MatchParticipants from "../../components/MatchParticipants";
-import { formatDate, formatDateTime, resolveTimeZone } from "../../lib/i18n";
+import {
+  formatDate,
+  formatDateTime,
+  getPreferredDateOptions,
+  resolveTimeZone,
+} from "../../lib/i18n";
 import { hasTimeComponent } from "../../lib/datetime";
 import { ensureTrailingSlash } from "../../lib/routes";
 import { resolveServerLocale } from "../../lib/server-locale";
@@ -128,6 +133,7 @@ export default async function MatchesPage(
   const cookieStore = cookies();
   const { locale, preferredTimeZone } = resolveServerLocale({ cookieStore });
   const timeZone = resolveTimeZone(preferredTimeZone, locale);
+  const preferredDateOptions = getPreferredDateOptions(locale);
 
   try {
     const { rows, hasMore, nextOffset, totalCount } = await getMatches(
@@ -166,7 +172,7 @@ export default async function MatchesPage(
                   : formatDate(
                       m.playedAt,
                       locale,
-                      { dateStyle: 'medium' },
+                      preferredDateOptions,
                       timeZone,
                     );
               const metadataText = formatMatchMetadata([

--- a/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
@@ -23,9 +23,12 @@ vi.mock("../../../components/charts/MatchHeatmap", () => ({
   ),
 }));
 
+const useLocaleMock = vi.fn(() => "en-AU");
+const useTimeZoneMock = vi.fn(() => "Australia/Melbourne");
+
 vi.mock("../../../lib/LocaleContext", () => ({
-  useLocale: () => "en-US",
-  useTimeZone: () => "UTC",
+  useLocale: () => useLocaleMock(),
+  useTimeZone: () => useTimeZoneMock(),
 }));
 
 import PlayerCharts from "./PlayerCharts";
@@ -70,10 +73,12 @@ describe("PlayerCharts", () => {
     const winRate = readJson<Array<{ date: string; winRate: number }>>("win-rate");
     expect(winRate).toHaveLength(2);
     expect(winRate[0].date).toBe("Match 1");
+    expect(winRate[1].date).toBe("1/1/24");
 
     const ranking = readJson<Array<{ date: string; rank: number }>>("ranking-history");
     expect(ranking).toHaveLength(2);
     expect(ranking[0].date).toBe("Match 1");
+    expect(ranking[1].date).toBe("1/1/24");
 
     const heatmap = readJson<Array<{ x: number; y: number; v: number }>>("heatmap");
     expect(heatmap).toHaveLength(1);

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -10,7 +10,7 @@ import PlayerDetailErrorBoundary, {
 import PlayerName, { PlayerInfo } from "../../../components/PlayerName";
 import MatchParticipants from "../../../components/MatchParticipants";
 import PhotoUpload from "./PhotoUpload";
-import { formatDate, resolveTimeZone } from "../../../lib/i18n";
+import { formatDate, getPreferredDateOptions, resolveTimeZone } from "../../../lib/i18n";
 import { resolveServerLocale } from "../../../lib/server-locale";
 import {
   formatMatchRecord,
@@ -463,6 +463,7 @@ export default async function PlayerPage({
   const cookieStore = cookies();
   const { locale, preferredTimeZone } = resolveServerLocale({ cookieStore });
   const timeZone = resolveTimeZone(preferredTimeZone, locale);
+  const preferredDateOptions = getPreferredDateOptions(locale);
   let player: Player;
   try {
     player = await getPlayer(params.id);
@@ -548,7 +549,12 @@ export default async function PlayerPage({
           .flatMap(([, pl]) => pl);
         const winner = winnerFromSummary(m.summary);
         const result = winner ? (winner === mySide ? "Win" : "Loss") : "—";
-        const date = formatDate(m.playedAt, locale, undefined, timeZone);
+        const date = formatDate(
+          m.playedAt,
+          locale,
+          preferredDateOptions,
+          timeZone,
+        );
         return { id: m.id, opponents, date, result };
       })
       .filter(Boolean) as {
@@ -682,7 +688,12 @@ export default async function PlayerPage({
                             {result ? ` · ${result}` : ""}
                             {m.summary || result ? " · " : ""}
                             {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-                            {formatDate(m.playedAt, locale, undefined, timeZone)}
+                            {formatDate(
+                              m.playedAt,
+                              locale,
+                              preferredDateOptions,
+                              timeZone,
+                            )}
                             {" · "}
                             {m.location ?? "—"}
                           </div>
@@ -771,7 +782,13 @@ export default async function PlayerPage({
                       />
                     </Link>
                     <div className="text-sm text-gray-700">
-                      {formatDate(m.playedAt, locale, undefined, timeZone)} ·{' '}
+                      {formatDate(
+                        m.playedAt,
+                        locale,
+                        preferredDateOptions,
+                        timeZone,
+                      )}{' '}
+                      ·{' '}
                       {m.location ?? "—"}
                     </div>
                   </li>


### PR DESCRIPTION
## Summary
- treat browser-detected UTC/GMT time zones as fallbacks and reuse locale defaults when present
- add getPreferredDateOptions to prefer short date styles for day-first locales and apply it across server formatting
- expand coverage so i18n, home, admin matches, and player charts assert Australian date ordering

## Testing
- pnpm test --run src/lib/i18n.test.ts
- pnpm test --run src/app/players/[id]/PlayerCharts.test.tsx
- pnpm test --run src/app/__tests__/home.page.test.tsx
- pnpm test --run src/app/admin/matches/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db6d88d0a483238706b654585c9f1e