### PR TITLE
Improve heading contrast

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -13,6 +13,7 @@
   /* Accents */
   --color-accent-red: #ba0c2f;
   --color-accent-red-hover: #8e0a23;
+  --color-heading: #8e0a23;
   --color-accent-blue: #1a73e8;
 
   /* Navigation */
@@ -93,7 +94,7 @@ img {
 
 .heading {
   margin-top: 0;
-  color: var(--color-accent-red);
+  color: var(--color-heading);
 }
 
 .form-stack {

--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -64,7 +64,7 @@ export default function RankingsPage() {
           style={{
             fontSize: "1.25rem",
             margin: "0 0 0.75rem",
-            color: "var(--color-accent-red)",
+            color: "var(--color-heading)",
           }}
         >
           Filters
@@ -97,7 +97,7 @@ export default function RankingsPage() {
           style={{
             fontSize: "1.25rem",
             margin: "0 0 0.75rem",
-            color: "var(--color-accent-red)",
+            color: "var(--color-heading)",
           }}
         >
           Results


### PR DESCRIPTION
## Summary
- add a dedicated `--color-heading` token and update the shared `.heading` style so headings meet AA contrast on the default background
- switch the rankings page inline heading styles to the new token for consistency

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68db6f51fc908323b0406a7e86ab698d