### PR TITLE
feat: add sticky headers for mobile scoreboards

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1082,8 +1082,18 @@ textarea {
   font-size: 1rem;
 }
 
-.scoreboard-wrapper {
+.table-scroll-container {
+  position: relative;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
+}
+
+.scoreboard-wrapper {
+  position: relative;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
 }
 
 .scoreboard-table {
@@ -1098,9 +1108,32 @@ textarea {
   border-bottom: 1px solid rgba(10, 31, 68, 0.08);
 }
 
+.table-header--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.97),
+    rgba(240, 242, 245, 0.94)
+  );
+  backdrop-filter: blur(4px);
+  box-shadow: inset 0 -1px 0 rgba(10, 31, 68, 0.08);
+  background-clip: padding-box;
+}
+
 .scoreboard-table thead th {
   font-weight: 600;
-  background: rgba(10, 31, 68, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.96),
+    rgba(10, 31, 68, 0.08)
+  );
+  box-shadow: inset 0 -1px 0 rgba(10, 31, 68, 0.12);
+  background-clip: padding-box;
 }
 
 .scoreboard-table th:first-child,
@@ -1111,6 +1144,27 @@ textarea {
 .scoreboard-table th:not(:first-child),
 .scoreboard-table td:not(:first-child) {
   text-align: center;
+}
+
+.leaderboard-table {
+  min-width: 360px;
+}
+
+.scoreboard-table .leaderboard-col-rank {
+  width: 56px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.scoreboard-table .leaderboard-col-player {
+  text-align: left;
+  min-width: 160px;
+}
+
+.scoreboard-table .leaderboard-col-rating {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .scoreboard-table tbody tr:nth-child(even) th,

--- a/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
+++ b/apps/web/src/app/matches/[mid]/MatchScoreboard.tsx
@@ -322,21 +322,27 @@ export default function MatchScoreboard({
       hideIfEmpty: Boolean(isFinished),
     });
     if (racket) {
-      return <div className="scoreboard-wrapper">{racket}</div>;
+      return (
+        <div className="scoreboard-wrapper table-scroll-container">{racket}</div>
+      );
     }
   }
 
   if (sportId === "disc_golf") {
     const discGolf = renderDiscGolfSummary(summary);
     if (discGolf) {
-      return <div className="scoreboard-wrapper">{discGolf}</div>;
+      return (
+        <div className="scoreboard-wrapper table-scroll-container">{discGolf}</div>
+      );
     }
   }
 
   if (sportId === "bowling") {
     const bowling = renderBowlingSummary(summary);
     if (bowling) {
-      return <div className="scoreboard-wrapper">{bowling}</div>;
+      return (
+        <div className="scoreboard-wrapper table-scroll-container">{bowling}</div>
+      );
     }
   }
 
@@ -344,8 +350,14 @@ export default function MatchScoreboard({
     hideIfEmpty: Boolean(isFinished),
   });
   if (racketFallback) {
-    return <div className="scoreboard-wrapper">{racketFallback}</div>;
+    return (
+      <div className="scoreboard-wrapper table-scroll-container">{racketFallback}</div>
+    );
   }
 
-  return <div className="scoreboard-wrapper">{renderFallback(summary)}</div>;
+  return (
+    <div className="scoreboard-wrapper table-scroll-container">
+      {renderFallback(summary)}
+    </div>
+  );
 }

--- a/apps/web/src/app/rankings/page.tsx
+++ b/apps/web/src/app/rankings/page.tsx
@@ -103,62 +103,51 @@ export default function RankingsPage() {
           Results
         </h2>
         {loading ? (
-          <table
-            style={{
-              marginTop: "0.5rem",
-              borderCollapse: "collapse",
-              width: "100%",
-            }}
-            aria-busy="true"
-            aria-describedby={resultsHeadingId}
-          >
-            <thead>
-              <tr>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  #
-                </th>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  Player
-                </th>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  Rating
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {Array.from({ length: 5 }).map((_, i) => (
-                <tr key={`skeleton-${i}`}>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>
-                    <div className="skeleton" style={{ width: "12px", height: "1em" }} />
-                  </td>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>
-                    <div className="skeleton" style={{ width: "120px", height: "1em" }} />
-                  </td>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>
-                    <div className="skeleton" style={{ width: "40px", height: "1em" }} />
-                  </td>
+          <div className="table-scroll-container" style={{ marginTop: "0.5rem" }}>
+            <table
+              className="scoreboard-table leaderboard-table"
+              aria-busy="true"
+              aria-describedby={resultsHeadingId}
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-rank"
+                  >
+                    #
+                  </th>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-player"
+                  >
+                    Player
+                  </th>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-rating"
+                  >
+                    Rating
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={`skeleton-${i}`}>
+                    <td className="leaderboard-col-rank">
+                      <div className="skeleton" style={{ width: "12px", height: "1em" }} />
+                    </td>
+                    <td className="leaderboard-col-player">
+                      <div className="skeleton" style={{ width: "120px", height: "1em" }} />
+                    </td>
+                    <td className="leaderboard-col-rating">
+                      <div className="skeleton" style={{ width: "40px", height: "1em" }} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         ) : error ? (
           <div
             role="alert"
@@ -177,55 +166,44 @@ export default function RankingsPage() {
         ) : leaders.length === 0 ? (
           <p>No rankings available for this sport.</p>
         ) : (
-          <table
-            style={{
-              marginTop: "0.5rem",
-              borderCollapse: "collapse",
-              width: "100%",
-            }}
-            aria-describedby={resultsHeadingId}
-          >
-            <thead>
-              <tr>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  #
-                </th>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  Player
-                </th>
-                <th
-                  style={{
-                    border: "1px solid #ccc",
-                    padding: "0.5rem",
-                    textAlign: "left",
-                  }}
-                >
-                  Rating
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {leaders.map((l, i) => (
-                <tr key={l.playerId}>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{i + 1}</td>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{l.playerName}</td>
-                  <td style={{ border: "1px solid #ccc", padding: "0.5rem" }}>{Math.round(l.rating)}</td>
+          <div className="table-scroll-container" style={{ marginTop: "0.5rem" }}>
+            <table
+              className="scoreboard-table leaderboard-table"
+              aria-describedby={resultsHeadingId}
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-rank"
+                  >
+                    #
+                  </th>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-player"
+                  >
+                    Player
+                  </th>
+                  <th
+                    scope="col"
+                    className="table-header--sticky leaderboard-col-rating"
+                  >
+                    Rating
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {leaders.map((l, i) => (
+                  <tr key={l.playerId}>
+                    <td className="leaderboard-col-rank">{i + 1}</td>
+                    <td className="leaderboard-col-player">{l.playerName}</td>
+                    <td className="leaderboard-col-rating">{Math.round(l.rating)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a reusable scroll container and sticky header styling so scoreboard headers stay visible while scrolling
- wrap match scoreboards and the rankings loading/results tables with the responsive container
- align rankings column styles and apply sticky header classes to maintain layout on narrow screens

## Testing
- npm --prefix apps/web run lint *(fails: existing `@typescript-eslint/no-unused-vars` errors in disc-golf tests)*

------
https://chatgpt.com/codex/tasks/task_e_68db6d8bda748323acda78e1c9006c07