### PR TITLE
Improve ClubSelect clear button accessibility

### DIFF
--- a/apps/web/src/components/ClubSelect.tsx
+++ b/apps/web/src/components/ClubSelect.tsx
@@ -172,6 +172,12 @@ export default function ClubSelect({
     onChange("");
   }, [disabled, onChange]);
 
+  const clearButtonAriaLabel = useMemo(
+    () =>
+      ariaLabel ? `Clear ${ariaLabel} selection` : "Clear club selection",
+    [ariaLabel]
+  );
+
   return (
     <div className={className} style={{ display: "grid", gap: "0.5rem" }}>
       <div style={{ display: "flex", gap: "0.5rem" }}>
@@ -195,6 +201,8 @@ export default function ClubSelect({
           type="button"
           onClick={clearSelection}
           disabled={disabled || (!value && !searchTerm)}
+          aria-label={clearButtonAriaLabel}
+          aria-describedby={ariaDescribedBy}
         >
           Clear
         </button>


### PR DESCRIPTION
## Summary
- derive a contextualized aria-label for the ClubSelect clear button so screen readers announce the action
- connect the clear button to existing status descriptions via aria-describedby

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db72e853a883239b903929cf821044