### PR TITLE
Seed profile defaults and document time zone detection

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -532,6 +532,14 @@ export default function LoginPage() {
             {showSignup ? "Hide sign up form" : "Create an account"}
           </button>
         </div>
+        <p
+          className="auth-signup__description"
+          style={{ margin: "0.5rem 0 0", color: "#4b5563", fontSize: "0.95rem" }}
+        >
+          We’ll automatically match your browser’s language and time zone for new
+          accounts. You can fine-tune both defaults anytime from your profile
+          settings.
+        </p>
         {showSignup && (
           <form
             id={signupFormId}

--- a/docs/locale-and-time-zone-defaults.md
+++ b/docs/locale-and-time-zone-defaults.md
@@ -1,0 +1,42 @@
+# Locale and Time Zone Defaults
+
+The web client automatically derives sensible defaults for each visitor's locale
+and preferred time zone so that dates, numbers, and notifications feel familiar
+right away.
+
+## Locale resolution
+
+Locale detection takes the following sources into account (listed in priority
+order):
+
+1. A saved preference from the user settings store (if the user has updated
+   their profile preferences previously).
+2. The `Accept-Language` request header provided by the browser.
+3. A neutral English fallback (`en-GB`) that guarantees consistent formatting
+   when nothing else is available.
+
+Whenever a locale preference is chosen for the first time it is persisted to
+`localStorage` and mirrored into a cookie so that both the client and server can
+render subsequent requests using the same language.
+
+## Time zone resolution
+
+Time zone selection follows a similar layered approach:
+
+1. A saved preference from the user settings store.
+2. The current time zone reported by the `LocaleProvider` (populated from the
+   cookie or the browser's `Intl.DateTimeFormat().resolvedOptions()` result).
+3. A best-effort detection using `detectTimeZone()` with the resolved locale,
+   falling back to `UTC` when no other information is available.
+
+When the profile page hydrates user preferences it seeds the `preferredTimeZone`
+field using the detected value and persists it via `storeTimeZonePreference`.
+This keeps the user's chosen time zone consistent across reloads and devices.
+
+## Why it matters
+
+Seeding locale and time zone preferences provides a better onboarding
+experience—new players see match times in their local zone immediately and can
+fine-tune preferences later if needed. The login and profile pages now explain
+this behaviour so users know where the defaults come from and how to change
+them.


### PR DESCRIPTION
## Summary
- hydrate profile preferences with a prefilled preferred time zone sourced from the user context or detectTimeZone fallback, persisting the value and rendering sorted country options
- extend the profile page tests to cover locale/time zone defaults, persistent success messaging, and club loading feedback
- add onboarding copy about automatic locale/time zone defaults and document the detection flow for contributors

## Testing
- pnpm vitest run --changed

------
https://chatgpt.com/codex/tasks/task_e_68db756e78388323a737b783acc120dd