### PR TITLE
Improve player metadata presentation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -590,6 +590,52 @@ textarea {
   gap: 0.75rem;
 }
 
+.player-detail__view-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.25rem 0 1rem;
+}
+
+.player-detail__view-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  text-decoration: none;
+  font-weight: 600;
+  color: inherit;
+  background: transparent;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.player-detail__view-link:hover,
+.player-detail__view-link:focus-visible {
+  background: rgba(26, 115, 232, 0.12);
+  color: var(--color-accent-blue);
+}
+
+.player-detail__view-link:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 3px;
+}
+
+.player-detail__view-link.is-active {
+  background: rgba(26, 115, 232, 0.18);
+  color: var(--color-accent-blue);
+}
+
+@media (min-width: 768px) {
+  .player-detail__view-nav {
+    gap: 1rem;
+    margin-top: 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+}
+
 .player-list {
   list-style: none;
   padding-left: 0;

--- a/apps/web/src/app/players/[id]/page.null-playedAt.test.tsx
+++ b/apps/web/src/app/players/[id]/page.null-playedAt.test.tsx
@@ -133,6 +133,12 @@ describe("PlayerPage matches without playedAt", () => {
         return makeResponse([]);
       }
 
+      if (path === "/v0/sports") {
+        return makeResponse([
+          { id: "tennis", name: "Tennis" },
+        ]);
+      }
+
       throw new Error(`Unexpected apiFetch call: ${path}`);
     });
 

--- a/apps/web/src/app/players/[id]/page.sections.test.tsx
+++ b/apps/web/src/app/players/[id]/page.sections.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshMock = vi.fn();
+const { notFoundMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<typeof import("next/navigation")>(
+    "next/navigation"
+  );
+  return {
+    ...actual,
+    useRouter: () => ({
+      refresh: refreshMock,
+    }),
+    notFound: notFoundMock,
+  };
+});
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get: (key: string) =>
+      key.toLowerCase() === "accept-language" ? "en-GB" : null,
+  }),
+  cookies: () => ({ get: () => undefined }),
+}));
+
+vi.mock("./PlayerCharts", () => ({
+  default: () => <div data-testid="player-charts" />,
+}));
+
+vi.mock("./comments-client", () => ({
+  default: () => <div data-testid="player-comments" />,
+}));
+
+vi.mock("./PhotoUpload", () => ({
+  default: () => <div data-testid="photo-upload" />,
+}));
+
+vi.mock("../../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../lib/api")>(
+    "../../../lib/api"
+  );
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+    fetchClubs: vi.fn(),
+  };
+});
+
+import PlayerPage from "./page";
+import { apiFetch, fetchClubs } from "../../../lib/api";
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedFetchClubs = vi.mocked(fetchClubs);
+
+const makeResponse = <T,>(
+  data: T,
+  init: { status?: number } = {}
+): Response => {
+  const status = init.status ?? 200;
+  const ok = status >= 200 && status < 300;
+  return {
+    ok,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+    clone() {
+      return makeResponse(data, init);
+    },
+  } as unknown as Response;
+};
+
+describe("PlayerPage optional sections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshMock.mockReset();
+    notFoundMock.mockReset();
+  });
+
+  it("renders headings when data is available", async () => {
+    mockedFetchClubs.mockResolvedValue([]);
+
+    mockedApiFetch.mockImplementation(async (path) => {
+      switch (path) {
+        case "/v0/players/player-rich":
+          return makeResponse({
+            id: "player-rich",
+            name: "Riley Ace",
+            badges: [{ id: "badge-1", name: "Club MVP" }],
+            social_links: [],
+          });
+        case "/v0/matches?playerId=player-rich":
+          return makeResponse([
+            {
+              id: "match-1",
+              sport: "padel",
+              bestOf: 3,
+              playedAt: "2024-01-05T10:00:00Z",
+              location: "Court A",
+              isFriendly: false,
+              stageId: null,
+            },
+          ]);
+        case "/v0/matches/match-1":
+          return makeResponse({
+            participants: [
+              { side: "A", playerIds: ["player-rich"] },
+              { side: "B", playerIds: ["opponent-1"] },
+            ],
+            summary: { sets: { A: 2, B: 1 } },
+          });
+        case "/v0/matches?playerId=player-rich&upcoming=true":
+          return makeResponse([
+            {
+              id: "match-upcoming",
+              sport: "padel",
+              bestOf: null,
+              playedAt: "2099-01-01T12:00:00Z",
+              location: "Centre Court",
+              isFriendly: true,
+              stageId: null,
+            },
+          ]);
+        case "/v0/matches/match-upcoming":
+          return makeResponse({
+            participants: [
+              { side: "A", playerIds: ["player-rich", "teammate-1"] },
+              { side: "B", playerIds: ["opponent-2", "opponent-3"] },
+            ],
+            summary: null,
+          });
+        case "/v0/players/player-rich/stats":
+          return makeResponse({
+            playerId: "player-rich",
+            matchSummary: { wins: 5, losses: 2 },
+            withRecords: [],
+          });
+        case "/v0/sports":
+          return makeResponse([
+            { id: "padel", name: "Padel" },
+          ]);
+        default:
+          if (path.startsWith("/v0/players/by-ids")) {
+            const idsParam = path.split("ids=")[1] ?? "";
+            const ids = idsParam.split(",");
+            const directory: Record<string, { id: string; name: string }> = {
+              "player-rich": { id: "player-rich", name: "Riley Ace" },
+              "opponent-1": { id: "opponent-1", name: "Jordan Foe" },
+              "opponent-2": { id: "opponent-2", name: "Sky Rival" },
+              "opponent-3": { id: "opponent-3", name: "Lane Foe" },
+              "teammate-1": { id: "teammate-1", name: "Alex Ally" },
+            };
+            return makeResponse(
+              ids
+                .filter((id) => id in directory)
+                .map((id) => directory[id])
+            );
+          }
+          throw new Error(`Unexpected apiFetch call: ${path}`);
+      }
+    });
+
+    const view = await PlayerPage({
+      params: { id: "player-rich" },
+      searchParams: {},
+    });
+
+    render(view);
+
+    expect(
+      screen.getByRole("navigation", { name: "Player timeline navigation" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Matches" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Recent Opponents" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Upcoming Matches" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Badges" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("Padel"))
+    ).toBeInTheDocument();
+  });
+
+  it("hides optional headings when data is absent", async () => {
+    mockedFetchClubs.mockResolvedValue([]);
+
+    mockedApiFetch.mockImplementation(async (path) => {
+      switch (path) {
+        case "/v0/players/player-empty":
+          return makeResponse({
+            id: "player-empty",
+            name: "Jamie Blank",
+            badges: [],
+            social_links: [],
+          });
+        case "/v0/matches?playerId=player-empty":
+          return makeResponse([]);
+        case "/v0/matches?playerId=player-empty&upcoming=true":
+          return makeResponse([]);
+        case "/v0/players/player-empty/stats":
+          return makeResponse(null, { status: 204 });
+        case "/v0/sports":
+          return makeResponse([
+            { id: "padel", name: "Padel" },
+          ]);
+        default:
+          if (path.startsWith("/v0/players/by-ids")) {
+            return makeResponse([]);
+          }
+          throw new Error(`Unexpected apiFetch call: ${path}`);
+      }
+    });
+
+    const view = await PlayerPage({
+      params: { id: "player-empty" },
+      searchParams: {},
+    });
+
+    const { unmount } = render(view);
+
+    expect(
+      screen.queryByRole("heading", { name: "Matches" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No matches found.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Recent Opponents" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No recent opponents found.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Upcoming Matches" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No upcoming matches.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Badges" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No badges.")
+    ).toBeInTheDocument();
+
+    unmount();
+
+    const summaryView = await PlayerPage({
+      params: { id: "player-empty" },
+      searchParams: { view: "summary" },
+    });
+
+    render(summaryView);
+
+    expect(
+      screen.queryByRole("heading", { name: "Season Summary" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText("No matches found.").length
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/app/players/__tests__/player.page.test.tsx
+++ b/apps/web/src/app/players/__tests__/player.page.test.tsx
@@ -154,6 +154,11 @@ describe('PlayerPage server component', () => {
       if (path === '/v0/players/player-1/stats') {
         return makeResponse(null, { status: 204 });
       }
+      if (path === '/v0/sports') {
+        return makeResponse([
+          { id: 'tennis', name: 'Tennis' },
+        ]);
+      }
       throw new Error(`Unexpected apiFetch call: ${path}`);
     });
 
@@ -175,6 +180,9 @@ describe('PlayerPage server component', () => {
     mockedApiFetch.mockImplementation(async (path) => {
       if (path === '/v0/players/missing') {
         throw makeError(404, 'HTTP 404: Player not found');
+      }
+      if (path === '/v0/sports') {
+        return makeResponse([]);
       }
       throw new Error(`Unexpected apiFetch call: ${path}`);
     });

--- a/apps/web/src/lib/sports.ts
+++ b/apps/web/src/lib/sports.ts
@@ -1,0 +1,72 @@
+import { apiFetch } from "./api";
+import {
+  getRecordSportDisplayName,
+  getRecordSportMetaById,
+} from "./recording";
+
+export type Sport = { id: string; name: string };
+
+export async function fetchSportsCatalog(): Promise<Sport[]> {
+  try {
+    const response = (await apiFetch(`/v0/sports`, {
+      cache: "no-store",
+    } as RequestInit)) as Response;
+    if (!response.ok) {
+      return [];
+    }
+    const data = (await response.json()) as Sport[];
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data.filter(
+      (sport): sport is Sport =>
+        Boolean(sport) && typeof sport.id === "string" && typeof sport.name === "string"
+    );
+  } catch (error) {
+    console.warn("Unable to load sports catalog", error);
+    return [];
+  }
+}
+
+function titleizeFallback(id: string): string {
+  const normalized = id.replace(/[_-]+/g, " ");
+  return normalized.replace(/\b([a-z])/gi, (match) => match.toUpperCase());
+}
+
+export function createSportDisplayNameLookup(sports: Sport[]): (
+  sportId: string | null | undefined,
+) => string {
+  const map = new Map<string, string>();
+  sports.forEach((sport) => {
+    if (!sport || typeof sport.id !== "string") {
+      return;
+    }
+    const id = sport.id.trim();
+    if (!id) {
+      return;
+    }
+    const name = typeof sport.name === "string" && sport.name.trim();
+    if (name) {
+      map.set(id, name);
+    }
+  });
+
+  return (sportId) => {
+    if (!sportId) {
+      return "—";
+    }
+    const normalized = sportId.trim();
+    if (!normalized) {
+      return "—";
+    }
+    const direct = map.get(normalized);
+    if (direct) {
+      return direct;
+    }
+    const meta = getRecordSportMetaById(normalized);
+    if (meta) {
+      return getRecordSportDisplayName(meta);
+    }
+    return titleizeFallback(normalized);
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared sports catalog helper and use friendlier sport names in the player timeline and matches list
- guard optional player sections, refresh the timeline/summary nav styles, and format comment timestamps with locale-aware utilities
- extend coverage with new player detail section tests and updated matches/comments specs

## Testing
- npx vitest run src/app/matches/page.test.tsx src/app/players/[id]/comments-client.test.tsx src/app/players/[id]/page.sections.test.tsx src/app/players/[id]/page.null-playedAt.test.tsx src/app/players/__tests__/player.page.test.tsx --reporter=basic


------
https://chatgpt.com/codex/tasks/task_e_68db72e521648323b318a4f7cc0e4604