### PR TITLE
Improve leaderboard accessibility and theme tokens

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -20,6 +20,58 @@
   --color-nav-bg: #0a1f44;
   --color-nav-text: #ffffff;
   --leaderboard-table-header-bg: var(--color-surface);
+  --color-surface-elevated: #ffffff;
+  --color-text-muted: #3f4f67;
+  --color-border-subtle: #c5cfdd;
+  --color-border-strong: #0f203f;
+  --color-button-primary-bg: #0a1f44;
+  --color-button-primary-border: #071327;
+  --color-button-primary-text: #ffffff;
+  --color-button-disabled-bg: #d8dee9;
+  --color-button-disabled-border: #b4bed0;
+  --color-button-disabled-text: #2f3b55;
+  --color-button-strong-bg: var(--color-button-primary-bg);
+  --color-button-strong-border: var(--color-button-primary-border);
+  --color-button-strong-text: var(--color-button-primary-text);
+  --color-feedback-error-border: #f3c5c5;
+  --color-feedback-error-bg: #fff5f5;
+  --color-feedback-error-text: #8a1c1c;
+  --color-text-danger-strong: #b91c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --color-bg: #0b1120;
+    --color-surface: #111c2f;
+    --color-text: #e2e8f0;
+    --color-success: #34d399;
+    --color-warning: #fbbf24;
+    --color-accent-red: #f87171;
+    --color-accent-red-hover: #dc2626;
+    --color-heading: #fca5a5;
+    --color-accent-blue: #60a5fa;
+    --color-nav-bg: #0f172a;
+    --color-nav-text: #f8fafc;
+    --leaderboard-table-header-bg: var(--color-surface-elevated);
+    --color-surface-elevated: #16213f;
+    --color-text-muted: #cbd5f5;
+    --color-border-subtle: #334155;
+    --color-border-strong: #475569;
+    --color-button-primary-bg: #2563eb;
+    --color-button-primary-border: #1d4ed8;
+    --color-button-primary-text: #f8fafc;
+    --color-button-disabled-bg: #1f2937;
+    --color-button-disabled-border: #334155;
+    --color-button-disabled-text: #cbd5f5;
+    --color-button-strong-bg: var(--color-button-primary-bg);
+    --color-button-strong-border: var(--color-button-primary-border);
+    --color-button-strong-text: var(--color-button-primary-text);
+    --color-feedback-error-border: #7f1d1d;
+    --color-feedback-error-bg: #3f1d1d;
+    --color-feedback-error-text: #fecaca;
+    --color-text-danger-strong: #f87171;
+  }
 }
 
 *,
@@ -1514,9 +1566,9 @@ textarea {
 }
 
 .leaderboard-tab--active {
-  border-color: #222;
-  background: #222;
-  color: #fff;
+  border-color: var(--color-button-primary-border);
+  background: var(--color-button-primary-bg);
+  color: var(--color-button-primary-text);
   font-weight: 600;
 }
 

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -627,6 +627,10 @@ describe("Leaderboard", () => {
 
     const table = await screen.findByRole("table");
     expect(table).toHaveAttribute("id", "leaderboard-results");
+    expect(table).toHaveAttribute("aria-labelledby", "leaderboard-results-caption");
+    expect(table).toHaveAccessibleName(
+      "Padel leaderboard results. Global results with no region filters. Columns display rank, player, rating, wins, losses, matches, and win percentage.",
+    );
     expect(table).toHaveClass("leaderboard-table");
     expect(table.parentElement).toHaveClass("leaderboard-table-wrapper");
 

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -70,6 +70,7 @@ const formatSportLabel = (sportId: string) =>
     .join(" ");
 
 const RESULTS_TABLE_ID = "leaderboard-results";
+const RESULTS_TABLE_CAPTION_ID = `${RESULTS_TABLE_ID}-caption`;
 const LEADERBOARD_TIMEOUT_MS = 15000;
 const PAGE_SIZE = 50;
 
@@ -114,8 +115,8 @@ const EmptyState = ({ icon, title, description, cta }: EmptyStateContent) => (
       marginTop: "2rem",
       padding: "2rem 1.5rem",
       borderRadius: "12px",
-      border: "1px solid #e0e0e0",
-      background: "#fafafa",
+      border: "1px solid var(--color-border-subtle)",
+      background: "var(--color-surface-elevated)",
       textAlign: "center",
     }}
   >
@@ -123,7 +124,13 @@ const EmptyState = ({ icon, title, description, cta }: EmptyStateContent) => (
       {icon}
     </div>
     <h2 style={{ margin: "0 0 0.5rem", fontSize: "1.25rem" }}>{title}</h2>
-    <p style={{ margin: "0 0 1.25rem", color: "#555", fontSize: "0.95rem" }}>
+    <p
+      style={{
+        margin: "0 0 1.25rem",
+        color: "var(--color-text-muted)",
+        fontSize: "0.95rem",
+      }}
+    >
       {description}
     </p>
     {cta ? (
@@ -135,9 +142,9 @@ const EmptyState = ({ icon, title, description, cta }: EmptyStateContent) => (
           justifyContent: "center",
           padding: "0.5rem 1.25rem",
           borderRadius: "999px",
-          border: "1px solid #222",
-          background: "#222",
-          color: "#fff",
+          border: "1px solid var(--color-button-strong-border)",
+          background: "var(--color-button-strong-bg)",
+          color: "var(--color-button-strong-text)",
           fontWeight: 600,
           textDecoration: "none",
         }}
@@ -667,6 +674,54 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     const region = parts.length > 0 ? parts.join(" · ") : "Global";
     return sport === ALL_SPORTS ? `All sports combined · ${region}` : region;
   }, [sport, appliedCountry, appliedClubId]);
+
+  const regionFiltersCaption = useMemo(() => {
+    if (sport === MASTER_SPORT) {
+      return "Global master leaderboard coverage.";
+    }
+    const filters: string[] = [];
+    if (appliedCountry) {
+      filters.push(`country ${appliedCountry}`);
+    }
+    if (appliedClubId) {
+      const clubName = clubNameById.get(appliedClubId);
+      filters.push(
+        clubName ? `club ${clubName} (${appliedClubId})` : `club ${appliedClubId}`,
+      );
+    }
+    if (filters.length === 0) {
+      return "Global results with no region filters.";
+    }
+    if (filters.length === 1) {
+      return `Filtered by ${filters[0]}.`;
+    }
+    const lastFilter = filters[filters.length - 1];
+    const initialFilters = filters.slice(0, -1).join(", ");
+    return `Filtered by ${initialFilters} and ${lastFilter}.`;
+  }, [appliedClubId, appliedCountry, clubNameById, sport]);
+
+  const tableCaption = useMemo(() => {
+    const base =
+      sport === ALL_SPORTS
+        ? "Leaderboard results across all sports."
+        : sport === MASTER_SPORT
+          ? "Master leaderboard results."
+          : `${sportDisplayName} leaderboard results.`;
+    return `${base} ${regionFiltersCaption}`;
+  }, [regionFiltersCaption, sport, sportDisplayName]);
+
+  const columnDescription = useMemo(
+    () =>
+      sport === ALL_SPORTS
+        ? "Columns display rank, player, sport, rating, wins, losses, matches, and win percentage."
+        : "Columns display rank, player, rating, wins, losses, matches, and win percentage.",
+    [sport],
+  );
+
+  const captionText = useMemo(
+    () => `${tableCaption} ${columnDescription}`,
+    [columnDescription, tableCaption],
+  );
 
   const normalizedDraftCountry = normalizeCountry(draftCountry);
   const normalizedDraftClubId = normalizeClubId(draftClubId);
@@ -1222,7 +1277,11 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           <h1 className="heading" style={{ marginBottom: "0.25rem" }}>
             {`${sportDisplayName} Leaderboard`}
           </h1>
-          <p style={{ fontSize: "0.85rem", color: "#555" }}>{regionDescription}</p>
+          <p
+            style={{ fontSize: "0.85rem", color: "var(--color-text-muted)" }}
+          >
+            {regionDescription}
+          </p>
         </div>
         <section
           aria-label="Leaderboard controls"
@@ -1306,7 +1365,12 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               value={draftCountry}
               onChange={(next) => setDraftCountry(normalizeCountry(next))}
               placeholder="Select a country"
-              style={{ padding: "0.35rem", border: "1px solid #ccc", borderRadius: "4px" }}
+              style={{
+                padding: "0.35rem",
+                border: "1px solid var(--color-border-subtle)",
+                borderRadius: "4px",
+                background: "var(--color-surface)",
+              }}
               aria-invalid={filterErrors.country ? true : undefined}
               aria-describedby={countryErrorId}
             />
@@ -1317,7 +1381,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                 style={{
                   marginTop: "0.35rem",
                   fontSize: "0.8rem",
-                  color: "#b91c1c",
+                  color: "var(--color-text-danger-strong)",
                 }}
               >
                 {filterErrors.country}
@@ -1346,7 +1410,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                 style={{
                   marginTop: "0.35rem",
                   fontSize: "0.8rem",
-                  color: "#b91c1c",
+                  color: "var(--color-text-danger-strong)",
                 }}
               >
                 {filterErrors.clubId}
@@ -1360,9 +1424,15 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               style={{
                 padding: "0.4rem 0.9rem",
                 borderRadius: "4px",
-                border: "1px solid #222",
-                background: canApply ? "#222" : "#ccc",
-                color: "#fff",
+                border: canApply
+                  ? "1px solid var(--color-button-primary-border)"
+                  : "1px solid var(--color-button-disabled-border)",
+                background: canApply
+                  ? "var(--color-button-primary-bg)"
+                  : "var(--color-button-disabled-bg)",
+                color: canApply
+                  ? "var(--color-button-primary-text)"
+                  : "var(--color-button-disabled-text)",
                 cursor: canApply ? "pointer" : "not-allowed",
                 opacity: canApply ? 1 : 0.7,
               }}
@@ -1377,8 +1447,9 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               style={{
                 padding: "0.4rem 0.9rem",
                 borderRadius: "4px",
-                border: "1px solid #ccc",
+                border: "1px solid var(--color-border-subtle)",
                 background: "transparent",
+                color: "var(--color-text)",
                 cursor: canClear ? "pointer" : "not-allowed",
                 opacity: canClear ? 1 : 0.7,
               }}
@@ -1397,7 +1468,9 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             gap: "0.5rem",
           }}
         >
-          <p style={{ fontSize: "0.8rem", color: "#777", margin: 0 }}>
+          <p
+            style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", margin: 0 }}
+          >
             Regional filters apply to individual sport leaderboards.
           </p>
           {hasAppliedFilters && (
@@ -1408,8 +1481,9 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                 style={{
                   padding: "0.4rem 0.9rem",
                   borderRadius: "4px",
-                  border: "1px solid #ccc",
+                  border: "1px solid var(--color-border-subtle)",
                   background: "transparent",
+                  color: "var(--color-text)",
                   cursor: "pointer",
                 }}
               >
@@ -1422,11 +1496,22 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
 
       {loading ? (
         <div className="leaderboard-table-wrapper">
-          <table id={RESULTS_TABLE_ID} className="leaderboard-table" style={tableStyle}>
+          <table
+            id={RESULTS_TABLE_ID}
+            className="leaderboard-table"
+            style={tableStyle}
+            aria-labelledby={RESULTS_TABLE_CAPTION_ID}
+          >
+            <caption id={RESULTS_TABLE_CAPTION_ID} className="sr-only">
+              {captionText}
+            </caption>
             <TableHeader />
             <tbody>
               {Array.from({ length: 5 }).map((_, i) => (
-                <tr key={`skeleton-${i}`} style={{ borderTop: "1px solid #ccc" }}>
+                <tr
+                  key={`skeleton-${i}`}
+                  style={{ borderTop: "1px solid var(--color-border-subtle)" }}
+                >
                   <td style={cellStyle}>
                     <div className="skeleton" style={{ width: "12px", height: "1em" }} />
                   </td>
@@ -1466,9 +1551,9 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               marginTop: "1.5rem",
               padding: "1rem",
               borderRadius: "8px",
-              border: "1px solid #f3c5c5",
-              background: "#fff5f5",
-              color: "#8a1c1c",
+              border: "1px solid var(--color-feedback-error-border)",
+              background: "var(--color-feedback-error-bg)",
+              color: "var(--color-feedback-error-text)",
             }}
           >
             {error}
@@ -1478,7 +1563,15 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         )
       ) : (
         <div className="leaderboard-table-wrapper">
-          <table id={RESULTS_TABLE_ID} className="leaderboard-table" style={tableStyle}>
+          <table
+            id={RESULTS_TABLE_ID}
+            className="leaderboard-table"
+            style={tableStyle}
+            aria-labelledby={RESULTS_TABLE_CAPTION_ID}
+          >
+            <caption id={RESULTS_TABLE_CAPTION_ID} className="sr-only">
+              {captionText}
+            </caption>
             <TableHeader />
             <tbody>
               {leaders.map((row) => {
@@ -1489,7 +1582,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                 return (
                   <tr
                     key={`${row.rank}-${row.playerId}-${row.sport ?? ""}`}
-                    style={{ borderTop: "1px solid #ccc" }}
+                    style={{ borderTop: "1px solid var(--color-border-subtle)" }}
                   >
                     <td style={cellStyle}>{row.rank}</td>
                     <td style={cellStyle}>{row.playerName}</td>
@@ -1518,7 +1611,11 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       {isLoadingMore ? (
         <p
           aria-live="polite"
-          style={{ marginTop: "0.75rem", fontSize: "0.85rem", color: "#555" }}
+          style={{
+            marginTop: "0.75rem",
+            fontSize: "0.85rem",
+            color: "var(--color-text-muted)",
+          }}
         >
           Loading more results…
         </p>

--- a/apps/web/src/components/PlayerName.tsx
+++ b/apps/web/src/components/PlayerName.tsx
@@ -17,12 +17,10 @@ export default function PlayerName({ player }: { player: PlayerInfo }) {
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={photoUrl}
-          alt=""
+          alt={`${player.name} avatar`}
           width={24}
           height={24}
           className="player-name__avatar"
-          aria-hidden="true"
-          role="presentation"
         />
       )}
       {player.name}


### PR DESCRIPTION
## Summary
- add descriptive alt text for player avatars so screen readers announce the images
- annotate leaderboard tables with captions and column descriptions and update the related test
- replace inline leaderboard colors with reusable theme tokens and expand the palette for light/dark modes

## Testing
- npx vitest run src/app/leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db7ab5389c832394a0b0497285c0b8