### PR TITLE
Add next-intl i18n support to web app

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,9 +1,20 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
+
+const supportedLocales = ['en-GB', 'es-ES'];
+const defaultLocale = supportedLocales[0];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   // Generate routes with a trailing slash so static hosts can resolve nested
   // paths like `/players/` without relying on custom rewrites.
   trailingSlash: true,
+  i18n: {
+    locales: supportedLocales,
+    defaultLocale,
+  },
   async redirects() {
     return [
       {
@@ -24,4 +35,4 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -12,6 +12,7 @@
         "chart.js": "^4.5.0",
         "chartjs-chart-matrix": "^1.3.0",
         "next": "14.2.5",
+        "next-intl": "^4.3.9",
         "react": "18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "18.3.1",
@@ -587,6 +588,66 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1220,6 +1281,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
@@ -2809,7 +2876,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -4443,6 +4509,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -5326,6 +5404,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "14.2.5",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
@@ -5372,6 +5459,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.9.tgz",
+      "integrity": "sha512-4oSROHlgy8a5Qr2vH69wxo9F6K0uc6nZM2GNzqSe6ET79DEzOmBeSijCRzD5txcI4i+XTGytu4cxFsDXLKEDpQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.9"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -7011,7 +7125,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7118,6 +7232,20 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.9.tgz",
+      "integrity": "sha512-bZu+h13HIgOvsoGleQtUe4E6gM49CRm+AH36KnJVB/qb1+Beo7jr7HNrR8YWH8oaOkQfGNm6vh0HTepxng8UTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "chart.js": "^4.5.0",
     "chartjs-chart-matrix": "^1.3.0",
     "next": "14.2.5",
+    "next-intl": "^4.3.9",
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.3.1",

--- a/apps/web/src/app/__tests__/home.page.test.tsx
+++ b/apps/web/src/app/__tests__/home.page.test.tsx
@@ -6,6 +6,8 @@ import * as apiModule from '../../lib/api';
 import * as matchesModule from '../../lib/matches';
 import { SWRConfig } from 'swr';
 import { useLocale, useTimeZone } from '../../lib/LocaleContext';
+import { NextIntlClientProvider } from 'next-intl';
+import enMessages from '../../messages/en-GB.json';
 
 vi.mock('../../lib/LocaleContext', () => ({
   useLocale: vi.fn(() => 'en-GB'),
@@ -45,9 +47,11 @@ afterEach(() => {
 describe('HomePageClient error messages', () => {
   function renderComponent(props = defaultProps) {
     return render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <HomePageClient {...props} />
-      </SWRConfig>,
+      <NextIntlClientProvider locale="en-GB" messages={enMessages}>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <HomePageClient {...props} />
+        </SWRConfig>
+      </NextIntlClientProvider>,
     );
   }
 

--- a/apps/web/src/app/__tests__/matches.page.test.tsx
+++ b/apps/web/src/app/__tests__/matches.page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MatchesPage from '../matches/page';
 import { apiFetch, type ApiError } from '../../lib/api';
+import enMessages from '../../messages/en-GB.json';
 
 vi.mock('../../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../../lib/api')>(
@@ -26,6 +27,32 @@ const cookiesMock = vi.hoisted(() => vi.fn(() => ({ get: vi.fn(() => undefined) 
 vi.mock('next/headers', () => ({
   headers: vi.fn(() => new Headers()),
   cookies: cookiesMock,
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(async (namespaceOrOptions?: unknown) => {
+    const namespace =
+      typeof namespaceOrOptions === 'string'
+        ? namespaceOrOptions
+        : typeof namespaceOrOptions === 'object' && namespaceOrOptions && 'namespace' in namespaceOrOptions
+          ? (namespaceOrOptions as { namespace?: string }).namespace ?? ''
+          : '';
+    return (key: string, values?: Record<string, unknown>) => {
+      const fullKey = [namespace, key].filter(Boolean).join('.');
+      const template = fullKey
+        .split('.')
+        .reduce<unknown>((acc, segment) => (acc as Record<string, unknown>)?.[segment], enMessages);
+      if (typeof template !== 'string') {
+        throw new Error(`Missing translation for ${fullKey}`);
+      }
+      return template.replace(/\{(\w+)\}/g, (_, token) => {
+        if (values && token in values) {
+          return String(values[token]);
+        }
+        return `{${token}}`;
+      });
+    };
+  }),
 }));
 
 const mockedApiFetch = vi.mocked(apiFetch);

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -7,6 +7,7 @@ import { currentUsername, isAdmin, logout } from '../lib/api';
 import { ensureTrailingSlash } from '../lib/routes';
 import { rememberLoginRedirect } from '../lib/loginRedirect';
 import NotificationBell from '../components/NotificationBell';
+import { useTranslations } from 'next-intl';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -14,6 +15,8 @@ export default function Header() {
   const [admin, setAdmin] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
+  const commonT = useTranslations('Common');
+  const headerT = useTranslations('Header');
 
   const normalizedPathname = useMemo(
     () => ensureTrailingSlash(pathname ?? '/'),
@@ -56,7 +59,7 @@ export default function Header() {
     <header className="nav">
       <button
         className="hamburger"
-        aria-label="Toggle navigation"
+        aria-label={commonT('nav.toggle')}
         aria-expanded={open}
         aria-controls="nav-menu"
         onClick={() => setOpen((prev) => !prev)}
@@ -72,7 +75,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/')}
               onClick={() => setOpen(false)}
             >
-              Home
+              {headerT('links.home')}
             </Link>
           </li>
           <li>
@@ -82,7 +85,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/players')}
               onClick={() => setOpen(false)}
             >
-              Players
+              {headerT('links.players')}
             </Link>
           </li>
           <li>
@@ -92,7 +95,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/matches')}
               onClick={() => setOpen(false)}
             >
-              Matches
+              {headerT('links.matches')}
             </Link>
           </li>
           <li>
@@ -102,7 +105,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/record')}
               onClick={() => setOpen(false)}
             >
-              Record
+              {headerT('links.record')}
             </Link>
           </li>
           <li>
@@ -112,7 +115,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/tournaments')}
               onClick={() => setOpen(false)}
             >
-              Tournaments
+              {headerT('links.tournaments')}
             </Link>
           </li>
           <li>
@@ -122,7 +125,7 @@ export default function Header() {
               aria-current={linkAriaCurrent('/leaderboard')}
               onClick={() => setOpen(false)}
             >
-              Leaderboards
+              {headerT('links.leaderboards')}
             </Link>
           </li>
           {admin && (
@@ -134,7 +137,7 @@ export default function Header() {
                   aria-current={linkAriaCurrent('/admin/matches')}
                   onClick={() => setOpen(false)}
                 >
-                  Admin Matches
+                  {headerT('links.adminMatches')}
                 </Link>
               </li>
               <li>
@@ -144,7 +147,7 @@ export default function Header() {
                   aria-current={linkAriaCurrent('/admin/badges')}
                   onClick={() => setOpen(false)}
                 >
-                  Admin Badges
+                  {headerT('links.adminBadges')}
                 </Link>
               </li>
             </>
@@ -158,15 +161,17 @@ export default function Header() {
                   aria-current={linkAriaCurrent('/profile')}
                   onClick={() => setOpen(false)}
                 >
-                  Profile
+                  {headerT('links.profile')}
                 </Link>
               </li>
               <li>
                 <NotificationBell />
               </li>
-              <li className="user-status">Logged in as {user}</li>
+              <li className="user-status">
+                {commonT('nav.loggedInAs', { username: user })}
+              </li>
               <li>
-                <button onClick={handleLogout}>Logout</button>
+                <button onClick={handleLogout}>{headerT('actions.logout')}</button>
               </li>
             </>
           ) : (
@@ -180,7 +185,7 @@ export default function Header() {
                   setOpen(false);
                 }}
               >
-                Login
+                {headerT('links.login')}
               </Link>
             </li>
           )}

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -18,6 +18,7 @@ import {
   canonicalizeSportId,
   createSportDisplayNameLookup,
 } from '../lib/sports';
+import { useTranslations } from 'next-intl';
 
 interface Sport {
   id: string;
@@ -96,40 +97,40 @@ function resolveRulesetLabel(match: MatchWithOptionalRuleset): string | undefine
   return undefined;
 }
 
-const sportIcons: Record<string, { glyph: string; label: string }> = {
+const sportIcons = {
   padel: {
     glyph: '\uD83C\uDFBE',
-    label: 'Padel tennis ball icon',
+    labelKey: 'icons.padel',
   },
   padel_americano: {
     glyph: '🧮',
-    label: 'Padel Americano abacus icon',
+    labelKey: 'icons.padel_americano',
   },
   bowling: {
     glyph: '🎳',
-    label: 'Bowling ball and pins icon',
+    labelKey: 'icons.bowling',
   },
   tennis: {
     glyph: '🎾',
-    label: 'Tennis racket and ball icon',
+    labelKey: 'icons.tennis',
   },
   pickleball: {
     glyph: '🥒',
-    label: 'Pickleball cucumber icon',
+    labelKey: 'icons.pickleball',
   },
   badminton: {
     glyph: '🏸',
-    label: 'Badminton shuttlecock icon',
+    labelKey: 'icons.badminton',
   },
   table_tennis: {
     glyph: '🏓',
-    label: 'Table tennis paddles icon',
+    labelKey: 'icons.table_tennis',
   },
   disc_golf: {
     glyph: '🥏',
-    label: 'Disc golf flying disc icon',
+    labelKey: 'icons.disc_golf',
   },
-};
+} as const satisfies Record<string, { glyph: string; labelKey: string }>;
 
 interface Props {
   sports: Sport[];
@@ -234,6 +235,8 @@ export default function HomePageClient({
   const timeZone = useTimeZone();
   const activeLocale =
     localeFromContext || initialLocale || NEUTRAL_FALLBACK_LOCALE;
+  const commonT = useTranslations('Common');
+  const homeT = useTranslations('Home');
   const formatMatchDate = useMemo(
     () => (value: Date | string | number | null | undefined) =>
       formatDateTime(value, activeLocale, 'compact', timeZone),
@@ -437,20 +440,20 @@ export default function HomePageClient({
   return (
     <main className="container">
       <section className="card">
-        <h1 className="heading">cross-sport-tracker</h1>
-        <p>Ongoing self-hosted project</p>
+        <h1 className="heading">{commonT('appName')}</h1>
+        <p>{commonT('appTagline')}</p>
       </section>
 
       <section className="section">
-        <h2 className="heading">Sports</h2>
+        <h2 className="heading">{homeT('sportsHeading')}</h2>
         {sportsStatusVisible ? (
           <p className="sr-only" role="status" aria-live="polite">
-            Updating sports…
+            {commonT('status.updatingSports')}
           </p>
         ) : null}
         {sportsLoading && sports.length === 0 ? (
           <div role="status" aria-live="polite">
-            <p className="sr-only">Loading sports…</p>
+            <p className="sr-only">{commonT('status.loadingSports')}</p>
             <ul className="sport-list">
               {Array.from({ length: 3 }).map((_, i) => (
                 <li key={`sport-skeleton-${i}`} className="sport-item">
@@ -462,17 +465,17 @@ export default function HomePageClient({
         ) : sports.length === 0 ? (
           sportError ? (
             <p role="alert">
-              Unable to load sports. Check connection.{' '}
+              {homeT('sportsError')}{' '}
               <button
                 type="button"
                 onClick={retrySports}
                 className="link-button"
               >
-                Retry
+                {commonT('actions.retry')}
               </button>
             </p>
           ) : (
-            <p>No sports found.</p>
+            <p>{homeT('noSports')}</p>
           )
         ) : (
           <ul className="sport-list" role="list">
@@ -485,7 +488,11 @@ export default function HomePageClient({
                 <li key={s.id} className="sport-item">
                   <Link href={href} className="sport-link">
                     {icon ? (
-                      <span className="sport-icon" role="img" aria-label={icon.label}>
+                      <span
+                        className="sport-icon"
+                        role="img"
+                        aria-label={homeT(icon.labelKey)}
+                      >
                         {icon.glyph}
                       </span>
                     ) : null}
@@ -499,15 +506,15 @@ export default function HomePageClient({
       </section>
 
       <section className="section">
-        <h2 className="heading">Recent Matches</h2>
+        <h2 className="heading">{homeT('matchesHeading')}</h2>
         {matchesStatusVisible ? (
           <p className="sr-only" role="status" aria-live="polite">
-            Updating matches…
+            {commonT('status.updatingMatches')}
           </p>
         ) : null}
         {matchesLoading && matches.length === 0 ? (
           <div role="status" aria-live="polite">
-            <p className="sr-only">Loading recent matches…</p>
+            <p className="sr-only">{commonT('status.loadingRecentMatches')}</p>
             <ul className="match-list">
               {Array.from({ length: 3 }).map((_, i) => (
                 <li key={`match-skeleton-${i}`} className="card match-item">
@@ -523,17 +530,17 @@ export default function HomePageClient({
         ) : matches.length === 0 ? (
           matchError ? (
             <p role="alert">
-              Unable to load matches. Check connection.{' '}
+              {homeT('matchesError')}{' '}
               <button
                 type="button"
                 onClick={retryMatches}
                 className="link-button"
               >
-                Retry
+                {commonT('actions.retry')}
               </button>
             </p>
           ) : (
-            <p>No matches recorded yet.</p>
+            <p>{homeT('noMatches')}</p>
           )
         ) : (
           <ul className="match-list" role="list">
@@ -543,7 +550,7 @@ export default function HomePageClient({
               const metadataText = formatMatchMetadata([
                 getSportName(matchWithRuleset.sport),
                 matchWithRuleset.bestOf != null
-                  ? `Best of ${matchWithRuleset.bestOf}`
+                  ? commonT('match.bestOf', { count: matchWithRuleset.bestOf })
                   : null,
                 rulesetLabel,
                 formatMatchDate(matchWithRuleset.playedAt),
@@ -559,7 +566,7 @@ export default function HomePageClient({
                   <div className="match-meta">{metadataText || '—'}</div>
                   <div>
                     <Link href={ensureTrailingSlash(`/matches/${m.id}`)}>
-                      Match details
+                      {commonT('match.details')}
                     </Link>
                   </div>
                 </li>
@@ -579,22 +586,24 @@ export default function HomePageClient({
                   className="button"
                   disabled={loadingMore}
                 >
-                  {loadingMore ? 'Loading…' : 'Load more matches'}
+                  {loadingMore
+                    ? commonT('status.loading')
+                    : commonT('actions.loadMoreMatches')}
                 </button>
                 {loadingMore ? (
                   <p className="sr-only" aria-live="polite">
-                    Loading more matches…
+                    {commonT('status.loadingMoreMatches')}
                   </p>
                 ) : null}
                 {paginationError ? (
                   <p role="alert" className="error-text">
-                    Unable to load more matches. Please try again.
+                    {commonT('errors.loadMoreMatches')}
                   </p>
                 ) : null}
               </>
             ) : (
               <Link href="/matches" className="view-all-link">
-                View all matches
+                {commonT('actions.viewAllMatches')}
               </Link>
             )}
           </div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,16 +4,19 @@ import Header from './header';
 import ChunkErrorReload from '../components/ChunkErrorReload';
 import ToastProvider from '../components/ToastProvider';
 import SessionBanner from '../components/SessionBanner';
+import LocalizedMessagesProvider from '../components/LocalizedMessagesProvider';
 import { cookies } from 'next/headers';
+import { createTranslator } from 'next-intl/server';
 import { LocaleProvider } from '../lib/LocaleContext';
 import { resolveServerLocale } from '../lib/server-locale';
+import { loadLocaleMessages } from '../i18n/messages';
 
 export const metadata = {
   title: 'cross-sport-tracker',
   description: 'Ongoing self-hosted project',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -22,26 +25,39 @@ export default function RootLayout({
   const { locale, acceptLanguage, preferredTimeZone } = resolveServerLocale({
     cookieStore,
   });
+  const {
+    locale: resolvedLocale,
+    messages,
+  } = await loadLocaleMessages(locale);
+  const translator = createTranslator({
+    locale: resolvedLocale,
+    messages,
+  });
 
   return (
-    <html lang={locale}>
+    <html lang={resolvedLocale}>
       <body>
         <a className="skip-link" href="#main-content">
-          Skip to main content
+          {translator('Common.nav.skipToContent')}
         </a>
         <LocaleProvider
           locale={locale}
           acceptLanguage={acceptLanguage}
           timeZone={preferredTimeZone}
         >
-          <ToastProvider>
-            <ChunkErrorReload />
-            <Header />
-            <SessionBanner />
-            <div id="main-content" tabIndex={-1} className="skip-target">
-              {children}
-            </div>
-          </ToastProvider>
+          <LocalizedMessagesProvider
+            initialLocale={resolvedLocale}
+            initialMessages={messages}
+          >
+            <ToastProvider>
+              <ChunkErrorReload />
+              <Header />
+              <SessionBanner />
+              <div id="main-content" tabIndex={-1} className="skip-target">
+                {children}
+              </div>
+            </ToastProvider>
+          </LocalizedMessagesProvider>
         </LocaleProvider>
       </body>
     </html>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 
-export default function NotFound() {
+export default async function NotFound() {
+  const t = await getTranslations('NotFound');
   return (
     <main className="container">
       <section className="card">
-        <h1 className="heading">Page not found</h1>
+        <h1 className="heading">{t('title')}</h1>
         <p>
-          <Link href="/">Return home</Link>
+          <Link href="/">{t('returnHome')}</Link>
         </p>
       </section>
     </main>

--- a/apps/web/src/components/LocalizedMessagesProvider.tsx
+++ b/apps/web/src/components/LocalizedMessagesProvider.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  NextIntlClientProvider,
+  type AbstractIntlMessages,
+} from 'next-intl';
+import { useLocale, useTimeZone } from '../lib/LocaleContext';
+import {
+  loadLocaleMessages,
+  resolveSupportedLocale,
+} from '../i18n/messages';
+import { NEUTRAL_FALLBACK_LOCALE, normalizeLocale } from '../lib/i18n';
+
+interface Props {
+  initialLocale: string;
+  initialMessages: AbstractIntlMessages;
+  children: React.ReactNode;
+}
+
+export default function LocalizedMessagesProvider({
+  initialLocale,
+  initialMessages,
+  children,
+}: Props) {
+  const contextLocale = useLocale();
+  const timeZone = useTimeZone();
+  const initialSupported = useMemo(
+    () => resolveSupportedLocale(initialLocale),
+    [initialLocale],
+  );
+  const messagesCacheRef = useRef<Record<string, AbstractIntlMessages>>({
+    [initialSupported]: initialMessages,
+  });
+  const [activeLocale, setActiveLocale] = useState(initialSupported);
+  const [messages, setMessages] = useState(initialMessages);
+
+  useEffect(() => {
+    const normalizedContextLocale = normalizeLocale(
+      contextLocale,
+      NEUTRAL_FALLBACK_LOCALE,
+    );
+    const supportedLocale = resolveSupportedLocale(normalizedContextLocale);
+
+    if (messagesCacheRef.current[supportedLocale]) {
+      setActiveLocale(supportedLocale);
+      setMessages(messagesCacheRef.current[supportedLocale]);
+      return;
+    }
+
+    let cancelled = false;
+
+    void loadLocaleMessages(supportedLocale)
+      .then(({ locale: loadedLocale, messages: loadedMessages }) => {
+        if (cancelled) return;
+        messagesCacheRef.current[loadedLocale] = loadedMessages;
+        setActiveLocale(loadedLocale);
+        setMessages(loadedMessages);
+      })
+      .catch(async () => {
+        if (cancelled) return;
+        try {
+          const { locale: fallbackLocale, messages: fallbackMessages } =
+            await loadLocaleMessages(NEUTRAL_FALLBACK_LOCALE);
+          messagesCacheRef.current[fallbackLocale] = fallbackMessages;
+          setActiveLocale(fallbackLocale);
+          setMessages(fallbackMessages);
+        } catch (fallbackError) {
+          console.error('Failed to load fallback locale messages', fallbackError);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [contextLocale]);
+
+  return (
+    <NextIntlClientProvider
+      locale={activeLocale}
+      timeZone={timeZone}
+      messages={messages}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -1,0 +1,39 @@
+import type { AbstractIntlMessages } from 'next-intl';
+import { NEUTRAL_FALLBACK_LOCALE, normalizeLocale } from '../lib/i18n';
+
+export const SUPPORTED_LOCALES = ['en-GB', 'es-ES'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export function resolveSupportedLocale(locale: string): SupportedLocale {
+  const normalized = normalizeLocale(locale, NEUTRAL_FALLBACK_LOCALE);
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(normalized)) {
+    return normalized as SupportedLocale;
+  }
+
+  const normalizedLower = normalized.toLowerCase();
+  const matching = SUPPORTED_LOCALES.find(
+    (candidate) => candidate.toLowerCase() === normalizedLower,
+  );
+
+  return matching ?? SUPPORTED_LOCALES[0];
+}
+
+async function importMessages(locale: SupportedLocale): Promise<AbstractIntlMessages> {
+  switch (locale) {
+    case 'es-ES':
+      return (await import('../messages/es-ES.json')).default;
+    case 'en-GB':
+    default:
+      return (await import('../messages/en-GB.json')).default;
+  }
+}
+
+export async function loadLocaleMessages(locale: string): Promise<{
+  locale: SupportedLocale;
+  messages: AbstractIntlMessages;
+}> {
+  const supportedLocale = resolveSupportedLocale(locale);
+  const messages = await importMessages(supportedLocale);
+
+  return { locale: supportedLocale, messages };
+}

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -1,0 +1,16 @@
+import { getRequestConfig } from 'next-intl/server';
+import { loadLocaleMessages } from './messages';
+import { NEUTRAL_FALLBACK_LOCALE } from '../lib/i18n';
+
+export default getRequestConfig(async ({ locale }) => {
+  try {
+    const { locale: supportedLocale, messages } = await loadLocaleMessages(locale);
+    return { locale: supportedLocale, messages };
+  } catch (error) {
+    console.error('Failed to load locale messages', locale, error);
+    const { locale: fallbackLocale, messages } = await loadLocaleMessages(
+      NEUTRAL_FALLBACK_LOCALE,
+    );
+    return { locale: fallbackLocale, messages };
+  }
+});

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -1,0 +1,90 @@
+{
+  "Common": {
+    "appName": "cross-sport-tracker",
+    "appTagline": "Ongoing self-hosted project",
+    "actions": {
+      "retry": "Retry",
+      "login": "Login",
+      "logout": "Logout",
+      "loadMoreMatches": "Load more matches",
+      "viewAllMatches": "View all matches",
+      "moreInfo": "More info"
+    },
+    "status": {
+      "loading": "Loading…",
+      "loadingMoreMatches": "Loading more matches…",
+      "updatingSports": "Updating sports…",
+      "loadingSports": "Loading sports…",
+      "updatingMatches": "Updating matches…",
+      "loadingRecentMatches": "Loading recent matches…"
+    },
+    "errors": {
+      "loadMoreMatches": "Unable to load more matches. Please try again."
+    },
+    "nav": {
+      "skipToContent": "Skip to main content",
+      "toggle": "Toggle navigation",
+      "loggedInAs": "Logged in as {username}"
+    },
+    "match": {
+      "friendly": "Friendly",
+      "bestOf": "Best of {count}",
+      "details": "Match details"
+    }
+  },
+  "Home": {
+    "sportsHeading": "Sports",
+    "matchesHeading": "Recent Matches",
+    "sportsError": "Unable to load sports. Check connection.",
+    "noSports": "No sports found.",
+    "matchesError": "Unable to load matches. Check connection.",
+    "noMatches": "No matches recorded yet.",
+    "icons": {
+      "padel": "Padel tennis ball icon",
+      "padel_americano": "Padel Americano abacus icon",
+      "bowling": "Bowling ball and pins icon",
+      "tennis": "Tennis racket and ball icon",
+      "pickleball": "Pickleball cucumber icon",
+      "badminton": "Badminton shuttlecock icon",
+      "table_tennis": "Table tennis paddles icon",
+      "disc_golf": "Disc golf flying disc icon"
+    }
+  },
+  "Matches": {
+    "title": "Matches",
+    "emptyInitial": "No matches yet.",
+    "emptyPage": "No matches on this page.",
+    "errors": {
+      "load": "Failed to load matches. Try again later.",
+      "forbidden": "You do not have permission to view these matches.",
+      "notFound": "We couldn't find that match.",
+      "sessionExpired": "Your session expired. Please refresh and try again."
+    },
+    "summary": {
+      "sets": "Sets",
+      "games": "Games",
+      "points": "Points"
+    }
+  },
+  "Header": {
+    "links": {
+      "home": "Home",
+      "players": "Players",
+      "matches": "Matches",
+      "record": "Record",
+      "tournaments": "Tournaments",
+      "leaderboards": "Leaderboards",
+      "adminMatches": "Admin Matches",
+      "adminBadges": "Admin Badges",
+      "profile": "Profile",
+      "login": "Login"
+    },
+    "actions": {
+      "logout": "Logout"
+    }
+  },
+  "NotFound": {
+    "title": "Page not found",
+    "returnHome": "Return home"
+  }
+}

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -1,0 +1,90 @@
+{
+  "Common": {
+    "appName": "cross-sport-tracker",
+    "appTagline": "Proyecto autoalojado en curso",
+    "actions": {
+      "retry": "Reintentar",
+      "login": "Iniciar sesión",
+      "logout": "Cerrar sesión",
+      "loadMoreMatches": "Cargar más partidos",
+      "viewAllMatches": "Ver todos los partidos",
+      "moreInfo": "Más información"
+    },
+    "status": {
+      "loading": "Cargando…",
+      "loadingMoreMatches": "Cargando más partidos…",
+      "updatingSports": "Actualizando deportes…",
+      "loadingSports": "Cargando deportes…",
+      "updatingMatches": "Actualizando partidos…",
+      "loadingRecentMatches": "Cargando partidos recientes…"
+    },
+    "errors": {
+      "loadMoreMatches": "No se pueden cargar más partidos. Inténtalo de nuevo."
+    },
+    "nav": {
+      "skipToContent": "Saltar al contenido principal",
+      "toggle": "Mostrar u ocultar la navegación",
+      "loggedInAs": "Sesión iniciada como {username}"
+    },
+    "match": {
+      "friendly": "Amistoso",
+      "bestOf": "Mejor de {count}",
+      "details": "Detalles del partido"
+    }
+  },
+  "Home": {
+    "sportsHeading": "Deportes",
+    "matchesHeading": "Partidos recientes",
+    "sportsError": "No se pueden cargar los deportes. Comprueba la conexión.",
+    "noSports": "No se encontraron deportes.",
+    "matchesError": "No se pueden cargar los partidos. Comprueba la conexión.",
+    "noMatches": "Todavía no hay partidos registrados.",
+    "icons": {
+      "padel": "Icono de pelota de pádel",
+      "padel_americano": "Icono de ábaco de Pádel Americano",
+      "bowling": "Icono de bola y bolos",
+      "tennis": "Icono de raqueta y pelota de tenis",
+      "pickleball": "Icono de pepino de pickleball",
+      "badminton": "Icono de volante de bádminton",
+      "table_tennis": "Icono de palas de tenis de mesa",
+      "disc_golf": "Icono de disco volador de disc golf"
+    }
+  },
+  "Matches": {
+    "title": "Partidos",
+    "emptyInitial": "Todavía no hay partidos.",
+    "emptyPage": "No hay partidos en esta página.",
+    "errors": {
+      "load": "Error al cargar los partidos. Inténtalo de nuevo más tarde.",
+      "forbidden": "No tienes permiso para ver estos partidos.",
+      "notFound": "No pudimos encontrar ese partido.",
+      "sessionExpired": "Tu sesión ha expirado. Actualiza la página e inténtalo de nuevo."
+    },
+    "summary": {
+      "sets": "Sets",
+      "games": "Juegos",
+      "points": "Puntos"
+    }
+  },
+  "Header": {
+    "links": {
+      "home": "Inicio",
+      "players": "Jugadores",
+      "matches": "Partidos",
+      "record": "Registro",
+      "tournaments": "Torneos",
+      "leaderboards": "Clasificaciones",
+      "adminMatches": "Partidos de administrador",
+      "adminBadges": "Insignias de administrador",
+      "profile": "Perfil",
+      "login": "Iniciar sesión"
+    },
+    "actions": {
+      "logout": "Cerrar sesión"
+    }
+  },
+  "NotFound": {
+    "title": "Página no encontrada",
+    "returnHome": "Volver al inicio"
+  }
+}

--- a/docs/qa/internationalization.md
+++ b/docs/qa/internationalization.md
@@ -1,0 +1,8 @@
+# Internationalization smoke test
+
+Use these manual checks after deploying to verify the locale wiring is functioning:
+
+1. Load the home page in a clean browser session. Confirm that copy renders in English and that the skip link, navigation, home hero, and matches list use localized strings.
+2. In the same session, open the browser console and set the preferred locale via `localStorage.setItem('cst:locale', 'es-ES')`, then refresh. Validate that navigation links, home sections, and the matches index use Spanish translations and that formatted dates adopt the Spanish locale.
+3. With the console still open, set an unsupported locale such as `localStorage.setItem('cst:locale', 'fr-CA')` and refresh. Verify that the UI falls back to English strings without errors and that dates continue to render in a supported locale.
+4. Navigate to the `/matches` page under both English and Spanish preferences. Ensure that list headings, metadata (Friendly, Best of, etc.), empty-state copy, and error prompts are localized appropriately.


### PR DESCRIPTION
## Summary
- configure Next.js to load `next-intl` with English and Spanish locales and add runtime message loading
- localize the layout, header navigation, home page, matches index, and not-found view with shared translation catalogs
- update tests and documentation to cover the new internationalization behavior and provide manual QA guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db961dcab88323957235e77498ebbe