### PR TITLE
Ensure server translations respect preferred locale

### DIFF
--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -1,8 +1,10 @@
 import { getRequestConfig } from 'next-intl/server';
 import { loadLocaleMessages } from './messages';
 import { NEUTRAL_FALLBACK_LOCALE } from '../lib/i18n';
+import { resolveServerLocale } from '../lib/server-locale';
 
-export default getRequestConfig(async ({ locale }) => {
+export default getRequestConfig(async () => {
+  const { locale } = resolveServerLocale();
   try {
     const { locale: supportedLocale, messages } = await loadLocaleMessages(locale);
     return { locale: supportedLocale, messages };


### PR DESCRIPTION
## Summary
- resolve the active locale from cookies and headers when configuring next-intl requests
- continue to fall back to the neutral locale if loading the preferred locale fails

## Testing
- pnpm test *(fails: dependency resolution issues in vitest for next-intl packages)*

------
https://chatgpt.com/codex/tasks/task_e_68dba327c8008323baa13062f7ad1d53