### PR TITLE
Fix Next.js build and address type regressions

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -16,7 +16,8 @@
         "react": "18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "18.3.1",
-        "swr": "^2.3.6"
+        "swr": "^2.3.6",
+        "use-intl": "^4.3.9"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.3.1",
-    "swr": "^2.3.6"
+    "swr": "^2.3.6",
+    "use-intl": "^4.3.9"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -97,7 +97,7 @@ function resolveRulesetLabel(match: MatchWithOptionalRuleset): string | undefine
   return undefined;
 }
 
-const sportIcons = {
+const sportIcons: Record<string, { glyph: string; labelKey: string }> = {
   padel: {
     glyph: '\uD83C\uDFBE',
     labelKey: 'icons.padel',
@@ -130,7 +130,7 @@ const sportIcons = {
     glyph: '🥏',
     labelKey: 'icons.disc_golf',
   },
-} as const satisfies Record<string, { glyph: string; labelKey: string }>;
+} as const;
 
 interface Props {
   sports: Sport[];
@@ -188,29 +188,26 @@ function mergeMatchPageWithPrevious(
 }
 
 function resolveNextOffset(
-  currentNextOffset: number | null | undefined,
+  currentNextOffset: number | null,
   matchPageNextOffset: number | null | undefined,
   hasAdditionalMatches: boolean,
-): number | null | undefined {
+): number | null {
+  const normalizedCurrent = currentNextOffset ?? null;
+  const normalizedNext = matchPageNextOffset ?? null;
+
   if (!hasAdditionalMatches) {
-    return matchPageNextOffset;
+    return normalizedNext;
   }
 
-  if (matchPageNextOffset === null || matchPageNextOffset === undefined) {
-    return currentNextOffset ?? null;
+  if (normalizedNext === null) {
+    return normalizedCurrent;
   }
 
-  if (currentNextOffset === null || currentNextOffset === undefined) {
-    return matchPageNextOffset;
+  if (normalizedCurrent === null) {
+    return normalizedNext;
   }
 
-  if (typeof currentNextOffset === 'number') {
-    return typeof matchPageNextOffset === 'number'
-      ? Math.max(currentNextOffset, matchPageNextOffset)
-      : currentNextOffset;
-  }
-
-  return currentNextOffset ?? null;
+  return Math.max(normalizedCurrent, normalizedNext);
 }
 
 export default function HomePageClient({

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,7 +6,8 @@ import ToastProvider from '../components/ToastProvider';
 import SessionBanner from '../components/SessionBanner';
 import LocalizedMessagesProvider from '../components/LocalizedMessagesProvider';
 import { cookies } from 'next/headers';
-import { createTranslator } from 'next-intl/server';
+import { createTranslator } from 'use-intl';
+import type enMessages from '../messages/en-GB.json';
 import { LocaleProvider } from '../lib/LocaleContext';
 import { resolveServerLocale } from '../lib/server-locale';
 import { loadLocaleMessages } from '../i18n/messages';
@@ -29,9 +30,9 @@ export default async function RootLayout({
     locale: resolvedLocale,
     messages,
   } = await loadLocaleMessages(locale);
-  const translator = createTranslator({
+  const translator = createTranslator<typeof enMessages>({
     locale: resolvedLocale,
-    messages,
+    messages: messages as typeof enMessages,
   });
 
   return (

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -127,11 +127,12 @@ function isPushSupported(): boolean {
   );
 }
 
-function base64ToUint8Array(value: string): Uint8Array {
+function base64ToUint8Array(value: string): Uint8Array<ArrayBuffer> {
   const padding = "=".repeat((4 - (value.length % 4)) % 4);
   const normalized = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
   const raw = typeof window === "undefined" ? Buffer.from(normalized, "base64") : atob(normalized);
-  const output = new Uint8Array(raw.length ?? 0);
+  const buffer = new ArrayBuffer(raw.length ?? 0);
+  const output = new Uint8Array(buffer);
   if (typeof raw === "string") {
     for (let i = 0; i < raw.length; i += 1) {
       output[i] = raw.charCodeAt(i);

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -200,7 +200,7 @@ function normalizeGameSeries(
     if (reached === null || reached === "invalid") {
       return false;
     }
-    if (!Number.isFinite(reached) || reached <= 0) {
+    if (typeof reached !== "number" || !Number.isFinite(reached) || reached <= 0) {
       return false;
     }
     if (winnerWins !== option) {

--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import {
   markNotificationRead,
+  type NotificationListResponse,
   type NotificationRecord,
 } from "../lib/api";
 import { useNotifications } from "../lib/useNotifications";
@@ -109,7 +110,7 @@ export default function NotificationBell() {
       setMarking((current) => new Set(current).add(id));
       try {
         await markNotificationRead(id);
-        await mutate((pages) => {
+        await mutate((pages: NotificationListResponse[] | undefined) => {
           if (!pages) return pages;
           let updated = false;
           const nextPages = pages.map((page, pageIndex) => {

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -4,7 +4,9 @@ import { NEUTRAL_FALLBACK_LOCALE } from '../lib/i18n';
 
 export default getRequestConfig(async ({ locale }) => {
   try {
-    const { locale: supportedLocale, messages } = await loadLocaleMessages(locale);
+    const { locale: supportedLocale, messages } = await loadLocaleMessages(
+      locale ?? NEUTRAL_FALLBACK_LOCALE,
+    );
     return { locale: supportedLocale, messages };
   } catch (error) {
     console.error('Failed to load locale messages', locale, error);

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -233,9 +233,12 @@ function getLocaleTimeZoneInfo(
 
   try {
     const locale = new Intl.Locale(trimmed);
+    const { timeZones: localeTimeZones } = locale as Intl.Locale & {
+      timeZones?: readonly string[];
+    };
     const timeZones = Array.from(
       new Set(
-        (locale.timeZones ?? [])
+        (localeTimeZones ?? [])
           .map((zone) => normalizeTimeZoneInternal(zone, ''))
           .filter((zone): zone is string => Boolean(zone)),
       ),

--- a/apps/web/src/lib/useApiSWR.ts
+++ b/apps/web/src/lib/useApiSWR.ts
@@ -1,7 +1,7 @@
 import useSWR, {
   mutate,
   type Key,
-  type MutateOptions,
+  type MutatorOptions,
   type SWRConfiguration,
   type SWRResponse,
 } from 'swr';
@@ -132,7 +132,7 @@ export function useApiSWR<T>(
 
 export async function invalidateApiResource(
   matcher: Matcher,
-  options?: Partial<MutateOptions<unknown, ApiError>>,
+  options?: Partial<MutatorOptions<unknown, ApiError>>,
 ) {
   await mutate(
     (key: Key) => {
@@ -146,6 +146,6 @@ export async function invalidateApiResource(
   );
 }
 
-export function invalidateMatchesCache(options?: Partial<MutateOptions<unknown, ApiError>>) {
+export function invalidateMatchesCache(options?: Partial<MutatorOptions<unknown, ApiError>>) {
   return invalidateApiResource((key) => key.includes('/v0/matches'), options);
 }

--- a/apps/web/src/lib/useNotifications.ts
+++ b/apps/web/src/lib/useNotifications.ts
@@ -1,8 +1,7 @@
 import { useCallback, useMemo } from "react";
 import useSWRInfinite, {
-  type BareFetcher,
-  type KeyedMutator,
   type SWRInfiniteKeyLoader,
+  type SWRInfiniteKeyedMutator,
 } from "swr/infinite";
 import { mutate as swrMutate } from "swr";
 import {
@@ -25,7 +24,7 @@ function buildPageKey(limit: number, offset: number): string {
   return `${NOTIFICATION_CACHE_KEY_PREFIX}|${limit}|${offset}`;
 }
 
-const fetchNotificationPage: BareFetcher<NotificationListResponse> = async (
+const fetchNotificationPage: (key: string) => Promise<NotificationListResponse> = async (
   key: string,
 ) => {
   const [, limitValue, offsetValue] = key.split("|");
@@ -44,7 +43,7 @@ export function useNotifications(
   isValidating: boolean;
   hasMore: boolean;
   loadMore: () => Promise<NotificationPages | undefined>;
-  mutate: KeyedMutator<NotificationPages>;
+  mutate: SWRInfiniteKeyedMutator<NotificationPages>;
   refresh: () => Promise<NotificationPages | undefined>;
 } {
   const pageSize = options?.pageSize ?? DEFAULT_PAGE_SIZE;


### PR DESCRIPTION
## Summary
- replace the server layout translator to rely on use-intl and add the dependency so Next.js can build again
- tighten match pagination, notification, and push helpers to satisfy stricter runtime and TypeScript checks
- harden locale and API utilities for newer library typings and optional request data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba4a15f348323ad132f0cfa033064