### PR TITLE
Adjust record page caching

### DIFF
--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -8,14 +8,16 @@ import {
   getRecordSportMetaBySlug,
 } from "../../lib/recording";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 type Sport = { id: string; name: string };
 
 export default async function RecordPage() {
   let sports: Sport[] = [];
   try {
-    const res = await apiFetch("/v0/sports", { cache: "no-store" });
+    const res = await apiFetch("/v0/sports", {
+      next: { revalidate: 60 },
+    });
     if (res.ok) {
       sports = (await res.json()) as Sport[];
     }


### PR DESCRIPTION
## Summary
- configure the record page to use ISR instead of force dynamic rendering
- cache the sports list fetch for reuse across requests while retaining empty/error fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdad4b71083238397ea378fcdec15