### PR TITLE
Fix ApiRequestInit usage in frontend fetch utilities

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -536,7 +536,7 @@ export interface ClubSummary {
 }
 
 export async function fetchClubs(
-  init?: RequestInit
+  init?: ApiRequestInit
 ): Promise<ClubSummary[]> {
   const res = await apiFetch("/v0/clubs", init);
   return res.json();
@@ -818,8 +818,8 @@ export type StageStandings = {
   standings: StageStanding[];
 };
 
-function withNoStore<T extends ApiRequestInit | undefined>(
-  init?: T
+function withNoStore(
+  init?: ApiRequestInit
 ): ApiRequestInit | undefined {
   if (!init) {
     return { cache: "no-store" };
@@ -831,7 +831,7 @@ function withNoStore<T extends ApiRequestInit | undefined>(
 }
 
 export async function listTournaments(
-  init?: RequestInit
+  init?: ApiRequestInit
 ): Promise<TournamentSummary[]> {
   const res = await apiFetch("/v0/tournaments", withNoStore(init));
   return res.json();
@@ -883,7 +883,7 @@ export async function scheduleAmericanoStage(
 export async function fetchStageStandings(
   tournamentId: string,
   stageId: string,
-  init?: RequestInit
+  init?: ApiRequestInit
 ): Promise<StageStandings> {
   const res = await apiFetch(
     `/v0/tournaments/${tournamentId}/stages/${stageId}/standings`,
@@ -895,7 +895,7 @@ export async function fetchStageStandings(
 export async function listStageMatches(
   tournamentId: string,
   stageId: string,
-  init?: RequestInit
+  init?: ApiRequestInit
 ): Promise<StageScheduleMatch[]> {
   const res = await apiFetch(
     `/v0/tournaments/${tournamentId}/stages/${stageId}/matches`,

--- a/apps/web/src/lib/useApiSWR.ts
+++ b/apps/web/src/lib/useApiSWR.ts
@@ -5,7 +5,7 @@ import useSWR, {
   type SWRConfiguration,
   type SWRResponse,
 } from 'swr';
-import { apiFetch, type ApiError } from './api';
+import { apiFetch, type ApiError, type ApiRequestInit } from './api';
 
 const API_CACHE_KEY_PREFIX = 'api:';
 const DEFAULT_DEDUPING_INTERVAL = 60_000;
@@ -55,7 +55,7 @@ function stableStringify(value: unknown): string {
     .join(',')}}`;
 }
 
-function normalizeInit(init?: RequestInit): Record<string, unknown> | undefined {
+function normalizeInit(init?: ApiRequestInit): Record<string, unknown> | undefined {
   if (!init) return undefined;
   const { method, cache, credentials, mode, redirect, referrer, referrerPolicy, next } = init;
   const headers = headersToObject(init.headers);
@@ -73,7 +73,7 @@ function normalizeInit(init?: RequestInit): Record<string, unknown> | undefined 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
-export function getApiCacheKey(path: string, init?: RequestInit): string {
+export function getApiCacheKey(path: string, init?: ApiRequestInit): string {
   const normalizedInit = normalizeInit(init);
   if (!normalizedInit) {
     return `${API_CACHE_KEY_PREFIX}${path}`;
@@ -92,7 +92,7 @@ async function defaultParse<T>(response: Response): Promise<T> {
 type Matcher = string | RegExp | ((key: string) => boolean);
 
 type UseApiSWRConfig<T> = {
-  init?: RequestInit;
+  init?: ApiRequestInit;
   parse?: (response: Response) => Promise<T>;
   swr?: SWRConfiguration<T, ApiError>;
 };


### PR DESCRIPTION
## Summary
- update club and tournament fetch helpers to accept ApiRequestInit
- simplify the no-store helper to work with ApiRequestInit objects
- adjust the shared SWR wrapper to normalize ApiRequestInit consistently

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe0721d308323ae14688ad2f62a2e