### PR TITLE
Restore dynamic rendering for record page

### DIFF
--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -8,7 +8,7 @@ import {
   getRecordSportMetaBySlug,
 } from "../../lib/recording";
 
-export const revalidate = 60;
+export const dynamic = "force-dynamic";
 
 type Sport = { id: string; name: string };
 


### PR DESCRIPTION
## Summary
- restore force-dynamic rendering for the record page so it can safely read cookies while fetching sports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe412e8f8832383f8febc4b21874d