### PR TITLE
Ensure withNoStore enforces no-store caching

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -821,13 +821,18 @@ export type StageStandings = {
 function withNoStore(
   init?: ApiRequestInit
 ): ApiRequestInit | undefined {
+  const headers = new Headers(init?.headers ?? {});
+  headers.set("Cache-Control", "no-store");
+
   if (!init) {
-    return { cache: "no-store" };
+    return { cache: "no-store", headers };
   }
-  if (init.cache) {
-    return init;
+
+  if (init.cache === "no-store") {
+    return { ...init, headers };
   }
-  return { ...init, cache: "no-store" };
+
+  return { ...init, cache: "no-store", headers };
 }
 
 export async function listTournaments(


### PR DESCRIPTION
## Summary
- always set `cache: "no-store"` when using `withNoStore`
- ensure the Cache-Control header is added so fetches bypass caches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe4178a988323b49c3efd5de8cd24