### PR TITLE
Optimize rating match count loop

### DIFF
--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -157,9 +157,12 @@ async def update_ratings(
         ).scalars().all()
 
         match_counts = {pid: 0 for pid in ids}
+        tracked_ids = set(match_counts)
         for player_ids in rows:
-            for pid in ids:
-                if pid in player_ids:
+            if not player_ids:
+                continue
+            for pid in player_ids:
+                if pid in tracked_ids:
                     match_counts[pid] += 1
 
         k_map: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- avoid repeatedly scanning all tracked players for every match participant row when computing match counts in the rating service
- skip empty participant lists while counting and reuse a set for membership checks to cut unnecessary work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcca8b61a88323882def2fe506ccf4