### PR TITLE
Allow usernames to retain casing

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -107,7 +107,8 @@ async def create_player(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(require_admin),
 ):
-    normalized_name = body.name.strip().lower()
+    name = body.name.strip()
+    normalized_name = name.lower()
     exists = (
         await session.execute(
             select(Player).where(func.lower(Player.name) == normalized_name)
@@ -118,7 +119,7 @@ async def create_player(
     pid = uuid.uuid4().hex
     p = Player(
         id=pid,
-        name=normalized_name,
+        name=name,
         club_id=body.club_id,
         photo_url=body.photo_url,
         bio=body.bio,

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from slowapi.errors import RateLimitExceeded
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -57,7 +57,7 @@ def test_get_and_update_me():
 
         me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         assert me.status_code == 200
-        assert me.json()["username"] == "alice"
+        assert me.json()["username"] == "Alice"
         assert me.json()["photo_url"] is None
 
         resp = client.put(
@@ -82,7 +82,7 @@ def test_get_and_update_me():
             "/auth/me", headers={"Authorization": f"Bearer {new_token}"}
         )
         assert me2.status_code == 200
-        assert me2.json()["username"] == "alice2"
+        assert me2.json()["username"] == "Alice2"
         assert me2.json()["photo_url"] is None
 
 
@@ -124,7 +124,7 @@ def test_update_me_allows_claiming_current_player_name():
             async with db.AsyncSessionLocal() as session:
                 user = (
                     await session.execute(
-                        select(User).where(User.username == "claimee")
+                        select(User).where(func.lower(User.username) == "claimee")
                     )
                 ).scalar_one()
                 player = (
@@ -156,7 +156,7 @@ def test_update_me_allows_claiming_current_player_name():
             async with db.AsyncSessionLocal() as session:
                 user = (
                     await session.execute(
-                        select(User).where(User.username == "claimed")
+                        select(User).where(func.lower(User.username) == "claimed")
                     )
                 ).scalar_one()
                 player = (
@@ -200,7 +200,7 @@ def test_upload_my_photo():
             async with db.AsyncSessionLocal() as session:
                 user = (
                     await session.execute(
-                        select(User).where(User.username == "picuser")
+                        select(User).where(func.lower(User.username) == "picuser")
                     )
                 ).scalar_one()
                 player = (
@@ -248,7 +248,7 @@ def test_delete_my_photo():
             async with db.AsyncSessionLocal() as session:
                 user = (
                     await session.execute(
-                        select(User).where(User.username == "erasepic")
+                        select(User).where(func.lower(User.username) == "erasepic")
                     )
                 ).scalar_one()
                 player = (
@@ -276,7 +276,7 @@ def test_me_missing_user():
             async with db.AsyncSessionLocal() as session:
                 user = (
                     await session.execute(
-                        select(User).where(User.username == "ghost")
+                        select(User).where(func.lower(User.username) == "ghost")
                     )
                 ).scalar_one()
                 await session.delete(user)

--- a/backend/tests/test_players.py
+++ b/backend/tests/test_players.py
@@ -643,7 +643,7 @@ def test_players_by_ids_omits_deleted() -> None:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data == [{"id": active_id, "name": "active", "photo_url": None}]
+        assert data == [{"id": active_id, "name": "Active", "photo_url": None}]
 
 def test_upload_player_photo_prefixed_url() -> None:
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- preserve the user-provided casing when signing up or updating usernames while keeping uniqueness validation case-insensitive
- ensure admin-created players store their display name casing and adjust match creation lookups to remain case-insensitive
- refresh authentication tests to cover the new casing behavior

## Testing
- pytest backend/tests/test_auth.py
- pytest backend/tests/test_auth_me.py

------
https://chatgpt.com/codex/tasks/task_e_68de010e6a208323a0362fb57781a9cb