### PR TITLE
Add admin club management UI and API endpoint

### DIFF
--- a/apps/web/src/app/__tests__/admin-clubs.page.test.tsx
+++ b/apps/web/src/app/__tests__/admin-clubs.page.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import AdminClubsPage from '../admin/clubs/page';
+import { apiFetch, isAdmin } from '../../lib/api';
+
+vi.mock('../../lib/api', () => ({
+  apiFetch: vi.fn(),
+  isAdmin: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedIsAdmin = vi.mocked(isAdmin);
+
+const jsonResponse = (data: unknown): Response =>
+  ({
+    ok: true,
+    json: async () => data,
+  } as Response);
+
+const emptyResponse = (): Response =>
+  ({
+    ok: true,
+    json: async () => ({}),
+  } as Response);
+
+describe('AdminClubsPage', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedIsAdmin.mockReset();
+    document.cookie = 'cst-login-redirect=; path=/; max-age=0';
+    window.history.replaceState(null, '', '/admin/clubs');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects non-admins to login', async () => {
+    let currentUrl = new URL('http://localhost/admin/clubs');
+    const locationMock = {
+      assign: vi.fn((value: string) => {
+        currentUrl = new URL(value, currentUrl.origin);
+      }),
+      replace: vi.fn(),
+      reload: vi.fn(),
+    } as Partial<Location>;
+    Object.defineProperties(locationMock, {
+      href: {
+        configurable: true,
+        get: () => `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}` || '/',
+        set: (value: string) => {
+          currentUrl = new URL(value, currentUrl.origin);
+        },
+      },
+      pathname: {
+        configurable: true,
+        get: () => currentUrl.pathname,
+      },
+      search: {
+        configurable: true,
+        get: () => currentUrl.search,
+      },
+      hash: {
+        configurable: true,
+        get: () => currentUrl.hash,
+      },
+      origin: {
+        configurable: true,
+        get: () => currentUrl.origin,
+      },
+      protocol: {
+        configurable: true,
+        get: () => currentUrl.protocol,
+      },
+    });
+    vi.stubGlobal('location', locationMock);
+
+    mockedIsAdmin.mockReturnValue(false);
+
+    render(<AdminClubsPage />);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('/login');
+    });
+    expect(document.cookie).toContain('cst-login-redirect=%2Fadmin%2Fclubs');
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('renders clubs returned from the API', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 'club-a', name: 'Club A' },
+        { id: 'club-b', name: 'Club B' },
+      ])
+    );
+
+    render(<AdminClubsPage />);
+
+    expect(await screen.findByText('Club A')).toBeInTheDocument();
+    expect(screen.getByText('club-a')).toBeInTheDocument();
+    expect(screen.getByText('Club B')).toBeInTheDocument();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      '/v0/clubs',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  it('creates a new club', async () => {
+    mockedIsAdmin.mockReturnValue(true);
+    mockedApiFetch
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(emptyResponse())
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { id: 'club-xyz', name: 'Club XYZ' },
+        ])
+      );
+
+    render(<AdminClubsPage />);
+
+    const form = screen.getByRole('form', { name: /create club/i });
+    const idInput = within(form).getByLabelText('Club ID');
+    const nameInput = within(form).getByLabelText('Club name');
+
+    fireEvent.change(idInput, { target: { value: 'club-xyz' } });
+    fireEvent.change(nameInput, { target: { value: 'Club XYZ' } });
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    });
+
+    const postCall = mockedApiFetch.mock.calls[1];
+    expect(postCall[0]).toBe('/v0/clubs');
+    expect(postCall[1]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(postCall[1]?.body as string)).toEqual({
+      id: 'club-xyz',
+      name: 'Club XYZ',
+    });
+    expect(await screen.findByText('Club created.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/clubs/page.tsx
+++ b/apps/web/src/app/admin/clubs/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { apiFetch, isAdmin, type ApiError } from '../../../lib/api';
+import { rememberLoginRedirect } from '../../../lib/loginRedirect';
+
+type ClubRecord = {
+  id: string;
+  name: string;
+};
+
+function normalizeClubs(clubs: ClubRecord[]): ClubRecord[] {
+  return clubs
+    .map((club) => ({ id: club.id.trim(), name: club.name.trim() }))
+    .filter((club) => club.id.length > 0 && club.name.length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+}
+
+function errorMessageFrom(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object') {
+    const { parsedMessage } = err as Partial<ApiError>;
+    if (typeof parsedMessage === 'string' && parsedMessage.trim().length > 0) {
+      return parsedMessage.trim();
+    }
+    const { message } = err as Partial<Error>;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message.trim();
+    }
+  }
+  return fallback;
+}
+
+export default function AdminClubsPage() {
+  const [clubs, setClubs] = useState<ClubRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newClubId, setNewClubId] = useState('');
+  const [newClubName, setNewClubName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const loadClubs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/v0/clubs', { cache: 'no-store' });
+      const data = (await res.json()) as ClubRecord[];
+      setClubs(normalizeClubs(data));
+      setError(null);
+    } catch (err) {
+      setError(errorMessageFrom(err, 'Failed to load clubs.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin()) {
+      rememberLoginRedirect();
+      window.location.href = '/login';
+      return;
+    }
+    void loadClubs();
+  }, [loadClubs]);
+
+  const sortedClubs = useMemo(() => normalizeClubs(clubs), [clubs]);
+
+  const handleCreate = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const id = newClubId.trim();
+      const name = newClubName.trim();
+
+      if (!id || !name) {
+        setError('Club ID and name are required.');
+        setSuccess(null);
+        return;
+      }
+      if (/\s/.test(id)) {
+        setError('Club ID cannot contain whitespace.');
+        setSuccess(null);
+        return;
+      }
+
+      setCreating(true);
+      setError(null);
+      setSuccess(null);
+
+      try {
+        await apiFetch('/v0/clubs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, name }),
+        });
+        setNewClubId('');
+        setNewClubName('');
+        await loadClubs();
+        setSuccess('Club created.');
+      } catch (err) {
+        setError(errorMessageFrom(err, 'Failed to create club.'));
+      } finally {
+        setCreating(false);
+      }
+    },
+    [loadClubs, newClubId, newClubName]
+  );
+
+  return (
+    <main className="container">
+      <h1 className="heading">Admin Clubs</h1>
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="success" role="status">
+          {success}
+        </p>
+      )}
+      {loading && (
+        <div role="status" aria-live="polite" aria-atomic="true">
+          <p>Loading clubs...</p>
+        </div>
+      )}
+
+      <section className="card" style={{ marginBottom: 24 }}>
+        <h2>Create new club</h2>
+        <form
+          aria-label="Create club"
+          onSubmit={handleCreate}
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}
+        >
+          <label htmlFor="new-club-id" style={{ flex: '1 1 160px' }}>
+            Club ID
+            <input
+              id="new-club-id"
+              value={newClubId}
+              onChange={(event) => setNewClubId(event.target.value)}
+              required
+              disabled={creating}
+            />
+          </label>
+          <label htmlFor="new-club-name" style={{ flex: '2 1 240px' }}>
+            Club name
+            <input
+              id="new-club-name"
+              value={newClubName}
+              onChange={(event) => setNewClubName(event.target.value)}
+              required
+              disabled={creating}
+            />
+          </label>
+          <button type="submit" disabled={creating}>
+            {creating ? 'Creating…' : 'Create club'}
+          </button>
+        </form>
+        <p style={{ marginTop: 12, color: '#4b5563' }}>
+          Use a short, unique identifier (letters, numbers, or dashes) for the club ID.
+        </p>
+      </section>
+
+      <section className="card">
+        <h2>Existing clubs</h2>
+        {sortedClubs.length === 0 ? (
+          <p>No clubs have been created yet.</p>
+        ) : (
+          <ul style={{ display: 'grid', gap: 12, padding: 0, listStyle: 'none' }}>
+            {sortedClubs.map((club) => (
+              <li
+                key={club.id}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '12px 16px',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: 8,
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600 }}>{club.name}</div>
+                  <div style={{ fontSize: '0.9rem', color: '#6b7280' }}>{club.id}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -142,6 +142,16 @@ export default function Header() {
               </li>
               <li>
                 <Link
+                  href={ensureTrailingSlash('/admin/clubs')}
+                  className={linkClassName('/admin/clubs')}
+                  aria-current={linkAriaCurrent('/admin/clubs')}
+                  onClick={() => setOpen(false)}
+                >
+                  {headerT('links.adminClubs')}
+                </Link>
+              </li>
+              <li>
+                <Link
                   href={ensureTrailingSlash('/admin/badges')}
                   className={linkClassName('/admin/badges')}
                   aria-current={linkAriaCurrent('/admin/badges')}

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -75,6 +75,7 @@
       "tournaments": "Tournaments",
       "leaderboards": "Leaderboards",
       "adminMatches": "Admin Matches",
+      "adminClubs": "Admin Clubs",
       "adminBadges": "Admin Badges",
       "profile": "Profile",
       "login": "Login"

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -75,6 +75,7 @@
       "tournaments": "Torneos",
       "leaderboards": "Clasificaciones",
       "adminMatches": "Partidos de administrador",
+      "adminClubs": "Clubes de administrador",
       "adminBadges": "Insignias de administrador",
       "profile": "Perfil",
       "login": "Iniciar sesión"

--- a/backend/app/routers/clubs.py
+++ b/backend/app/routers/clubs.py
@@ -1,15 +1,46 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
-from ..models import Club
-from ..schemas import ClubOut
+from ..exceptions import ProblemDetail, http_problem
+from ..models import Club, User
+from ..schemas import ClubCreate, ClubOut
+from .admin import require_admin
 
-router = APIRouter(prefix="/clubs", tags=["clubs"])
+router = APIRouter(
+    prefix="/clubs",
+    tags=["clubs"],
+    responses={404: {"model": ProblemDetail}},
+)
+
+
+def _to_club_out(club: Club) -> ClubOut:
+    return ClubOut(id=club.id, name=club.name)
+
+
+@router.post("", response_model=ClubOut, status_code=status.HTTP_201_CREATED)
+async def create_club(
+    body: ClubCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+) -> ClubOut:
+    club = Club(id=body.id, name=body.name)
+    session.add(club)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        raise http_problem(
+            status_code=409,
+            detail="club already exists",
+            code="club_exists",
+        )
+    return _to_club_out(club)
 
 
 @router.get("", response_model=list[ClubOut])
 async def list_clubs(session: AsyncSession = Depends(get_session)) -> list[ClubOut]:
     rows = (await session.execute(select(Club).order_by(Club.name))).scalars().all()
-    return [ClubOut(id=club.id, name=club.name) for club in rows]
+    return [_to_club_out(club) for club in rows]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -25,6 +25,35 @@ class ClubOut(BaseModel):
     id: str
     name: str
 
+
+class ClubCreate(BaseModel):
+    id: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _validate_id(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("id must be a string")
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("id must not be empty")
+        if any(ch.isspace() for ch in trimmed):
+            raise ValueError("id must not contain whitespace")
+        return trimmed
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("name must be a string")
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("name must not be empty")
+        return trimmed
+
 class BadgeCreate(BaseModel):
     name: str
     icon: Optional[str] = None

--- a/backend/tests/test_clubs.py
+++ b/backend/tests/test_clubs.py
@@ -1,0 +1,184 @@
+import asyncio
+import os
+import sys
+from typing import Iterator, Tuple
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import db
+from app.exceptions import DomainException, ProblemDetail
+from app.models import Club, Player, RefreshToken, User
+from app.routers import auth, clubs
+
+os.environ["ADMIN_SECRET"] = "admintest"
+
+
+app = FastAPI()
+
+
+@app.exception_handler(DomainException)
+async def domain_exception_handler(request, exc):
+    problem = ProblemDetail(
+        type=exc.type,
+        title=exc.title,
+        detail=exc.detail,
+        status=exc.status_code,
+        code=exc.code,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request, exc):
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    problem = ProblemDetail(
+        title=detail,
+        detail=detail,
+        status=exc.status_code,
+        code=getattr(exc, "code", f"http_{exc.status_code}"),
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=problem.model_dump(),
+        media_type="application/problem+json",
+    )
+
+
+app.include_router(auth.router)
+app.include_router(clubs.router)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    async def init_models():
+        if os.path.exists("./test_clubs.db"):
+            os.remove("./test_clubs.db")
+        db.engine = None
+        db.AsyncSessionLocal = None
+        engine = db.get_engine()
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                db.Base.metadata.create_all,
+                tables=[
+                    User.__table__,
+                    RefreshToken.__table__,
+                    Player.__table__,
+                    Club.__table__,
+                ],
+            )
+
+    asyncio.run(init_models())
+    yield
+    if os.path.exists("./test_clubs.db"):
+        os.remove("./test_clubs.db")
+
+
+@pytest.fixture
+def async_client() -> Iterator[Tuple[AsyncClient, asyncio.AbstractEventLoop]]:
+    loop = asyncio.new_event_loop()
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://testserver")
+    loop.run_until_complete(client.__aenter__())
+    try:
+        yield client, loop
+    finally:
+        loop.run_until_complete(client.__aexit__(None, None, None))
+        loop.close()
+
+
+async def create_admin_token(client: AsyncClient) -> str:
+    auth.limiter.reset()
+    response = await client.post(
+        "/auth/signup",
+        json={"username": "club-admin", "password": "Str0ng!Pass!", "is_admin": True},
+        headers={"X-Admin-Secret": "admintest"},
+    )
+    if response.status_code != 200:
+        response = await client.post(
+            "/auth/login", json={"username": "club-admin", "password": "Str0ng!Pass!"}
+        )
+    data = response.json()
+    return data["access_token"]
+
+
+def test_create_club_requires_admin(async_client) -> None:
+    client, loop = async_client
+
+    async def scenario() -> None:
+        response = await client.post("/clubs", json={"id": "club-1", "name": "Club One"})
+        assert response.status_code == 401
+
+        auth.limiter.reset()
+        user_resp = await client.post(
+            "/auth/signup",
+            json={"username": "regular", "password": "Str0ng!Pass!", "is_admin": False},
+            headers={"X-Admin-Secret": "admintest"},
+        )
+        assert user_resp.status_code == 200
+        token = user_resp.json()["access_token"]
+
+        response = await client.post(
+            "/clubs",
+            json={"id": "club-2", "name": "Club Two"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+        payload = response.json()
+        assert payload["code"] == "admin_forbidden"
+
+    loop.run_until_complete(scenario())
+
+
+def test_create_and_list_clubs(async_client) -> None:
+    client, loop = async_client
+
+    async def scenario() -> None:
+        token = await create_admin_token(client)
+
+        create_resp = await client.post(
+            "/clubs",
+            json={"id": "club-alpha", "name": "Club Alpha"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert create_resp.status_code == 201
+        assert create_resp.json() == {"id": "club-alpha", "name": "Club Alpha"}
+
+        list_resp = await client.get("/clubs")
+        assert list_resp.status_code == 200
+        assert list_resp.json() == [{"id": "club-alpha", "name": "Club Alpha"}]
+
+    loop.run_until_complete(scenario())
+
+
+def test_create_club_conflict(async_client) -> None:
+    client, loop = async_client
+
+    async def scenario() -> None:
+        token = await create_admin_token(client)
+
+        first = await client.post(
+            "/clubs",
+            json={"id": "club-beta", "name": "Club Beta"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert first.status_code == 201
+
+        duplicate = await client.post(
+            "/clubs",
+            json={"id": "club-beta", "name": "Club Beta"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert duplicate.status_code == 409
+        payload = duplicate.json()
+        assert payload["code"] == "club_exists"
+
+    loop.run_until_complete(scenario())


### PR DESCRIPTION
## Summary
- add a POST /v0/clubs endpoint for admins with validation and conflict handling
- build an admin page to create clubs and surface the link in the main navigation
- add automated coverage for the new backend route and admin UI interactions

## Testing
- pytest backend/tests/test_clubs.py
- pnpm test admin-clubs

------
https://chatgpt.com/codex/tasks/task_e_68de027b604483238465b9d785ae2155