### PR TITLE
Normalize admin reset username lookup

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -496,9 +496,10 @@ async def admin_reset_password(
   if body.user_id:
     user = await session.get(User, body.user_id)
   else:
+    normalized_username = body.username.lower() if body.username is not None else None
     user = (
         await session.execute(
-            select(User).where(func.lower(User.username) == body.username)
+            select(User).where(func.lower(User.username) == normalized_username)
         )
     ).scalar_one_or_none()
   if not user:


### PR DESCRIPTION
## Summary
- normalize admin password reset lookups by lowercasing the provided username before querying

## Testing
- pytest backend/tests/test_auth.py::test_admin_reset_password_generates_temporary_password -q

------
https://chatgpt.com/codex/tasks/task_e_68de0574c9788323bf1db976c80fd1a7