### PR TITLE
Fix bowling match recording scoring and ratings

### DIFF
--- a/backend/tests/test_matches.py
+++ b/backend/tests/test_matches.py
@@ -418,6 +418,83 @@ async def test_create_match_with_details(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_bowling_match_details_compute_score_and_ratings(tmp_path):
+  from app import db
+  from app.models import (
+    GlickoRating,
+    Match,
+    MatchParticipant,
+    Player,
+    PlayerMetric,
+    Rating,
+    ScoreEvent,
+    Sport,
+    User,
+  )
+  from app.schemas import MatchCreate, Participant
+  from app.routers.matches import create_match
+  from sqlalchemy import select
+
+  db.engine = None
+  db.AsyncSessionLocal = None
+  engine = db.get_engine()
+  async with engine.begin() as conn:
+    await conn.run_sync(
+      db.Base.metadata.create_all,
+      tables=[
+        Sport.__table__,
+        Player.__table__,
+        Match.__table__,
+        MatchParticipant.__table__,
+        Rating.__table__,
+        GlickoRating.__table__,
+        PlayerMetric.__table__,
+        ScoreEvent.__table__,
+      ],
+    )
+
+  async with db.AsyncSessionLocal() as session:
+    session.add_all([
+      Sport(id="bowling", name="Bowling"),
+      Player(id="pa", name="Alice"),
+      Player(id="pb", name="Bob"),
+    ])
+    await session.commit()
+
+    body = MatchCreate(
+      sport="bowling",
+      participants=[
+        Participant(side="A", playerIds=["pa"]),
+        Participant(side="B", playerIds=["pb"]),
+      ],
+      details={
+        "players": [
+          {"id": "pa", "side": "A", "total": 215, "frameScores": [10, 20]},
+          {"id": "pb", "side": "B", "total": 198, "frameScores": [9, 19]},
+        ]
+      },
+    )
+
+    admin = User(id="admin", username="admin", password_hash="", is_admin=True)
+    resp = await create_match(body, session, user=admin)
+
+    m = await session.get(Match, resp.id)
+    assert m.details is not None
+    assert m.details.get("score") == {"A": 215, "B": 198}
+    players = m.details.get("players") or []
+    assert all(isinstance(p, dict) and "scores" in p for p in players)
+
+    ratings = (await session.execute(select(Rating))).scalars().all()
+    rating_map = {r.player_id: r.value for r in ratings}
+    assert rating_map.get("pa", 0) > rating_map.get("pb", 0)
+
+    score_events = (
+      await session.execute(select(ScoreEvent).where(ScoreEvent.match_id == resp.id))
+    ).scalars().all()
+    assert score_events, "rating events should be recorded for bowling matches"
+
+
+@pytest.mark.anyio
 async def test_create_match_by_name_with_sets(tmp_path):
   from app import db
   from app.models import Match, MatchParticipant, Player, Sport, User


### PR DESCRIPTION
## Summary
- derive bowling match totals from player details so recorded matches carry score data
- allow non-set sports such as bowling to update ratings and player metrics using final totals
- add regression test that verifies bowling matches recorded by admins generate scores and ratings

## Testing
- pytest tests/test_matches.py::test_bowling_match_details_compute_score_and_ratings

------
https://chatgpt.com/codex/tasks/task_e_68de7fcc4954832381aee4e6ae8d2ae8