### PR TITLE
Improve form hint contrast on record pages

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -322,7 +322,7 @@ img {
 
 .form-hint {
   font-size: 0.8rem;
-  color: rgba(10, 31, 68, 0.7);
+  color: var(--color-text-muted);
 }
 
 input,


### PR DESCRIPTION
## Summary
- use the theme's muted text color for hint text to increase readability on record forms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df322697fc8323a3f1dfe9ad247b63