### PR TITLE
Explain master leaderboard purpose

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -254,6 +254,34 @@ describe("Leaderboard", () => {
     );
   });
 
+  it("explains how the master leaderboard works", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<Leaderboard sport="master" />);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/leaderboards/master?limit=50&offset=0"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "What is the Master leaderboard?",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The master rating averages each player's normalized rating across every sport they've played, letting you compare multi-sport performance on a shared 0–1000 scale.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("passes region filters to each sport when viewing the combined board", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1382,6 +1382,39 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         </section>
       </header>
 
+      {sport === MASTER_SPORT ? (
+        <section
+          aria-label="Master leaderboard information"
+          style={{
+            marginTop: "1rem",
+            padding: "0.75rem 1rem",
+            borderRadius: "8px",
+            border: "1px solid var(--color-border-subtle)",
+            background: "var(--color-surface-elevated)",
+          }}
+        >
+          <h2
+            style={{
+              margin: "0 0 0.35rem",
+              fontSize: "0.95rem",
+            }}
+          >
+            What is the Master leaderboard?
+          </h2>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "0.85rem",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            The master rating averages each player's normalized rating across every sport
+            they've played, letting you compare multi-sport performance on a shared 0–1000
+            scale.
+          </p>
+        </section>
+      ) : null}
+
       {supportsFilters ? (
         <form
           onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- add an informational callout explaining how the master leaderboard rating is calculated
- cover the new explanation with a dedicated UI test

## Testing
- pnpm exec vitest run --reporter=basic --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68df4807fbc483238b021da109ed072b