### PR TITLE
Add timeout error feedback to players and leaderboard

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -488,6 +488,7 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     await screen.findByText("We couldn't load the leaderboard right now.");
+    expect(screen.getByRole("button", { name: /retry/i })).toBeVisible();
   });
 
   it("normalizes a trailing slash when syncing filters", async () => {

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -181,6 +181,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const [leaders, setLeaders] = useState<Leader[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
   type CachedLeaderboard = {
     leaders: Leader[];
     total: number;
@@ -1035,6 +1036,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     appliedClubId,
     buildUrl,
     preferencesApplied,
+    reloadToken,
     getCachedLeaders,
     storeCachedLeaders,
     combineLeaders,
@@ -1042,6 +1044,12 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     parseLeaderboardResponse,
     refreshLeadersFromCache,
   ]);
+
+  const handleRetryLoad = useCallback(() => {
+    setReloadToken((prev) => prev + 1);
+    setError(null);
+    setLoading(true);
+  }, []);
 
   const loadMore = useCallback(async () => {
     if (loading || isLoadingMore || !hasMore) {
@@ -1605,6 +1613,8 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         error ? (
           <div
             role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
             style={{
               marginTop: "1.5rem",
               padding: "1rem",
@@ -1612,9 +1622,28 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               border: "1px solid var(--color-feedback-error-border)",
               background: "var(--color-feedback-error-bg)",
               color: "var(--color-feedback-error-text)",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.75rem",
+              alignItems: "flex-start",
             }}
           >
-            {error}
+            <p style={{ margin: 0 }}>{error}</p>
+            <button
+              type="button"
+              onClick={handleRetryLoad}
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "6px",
+                border: "1px solid var(--color-button-outline-border)",
+                background: "var(--color-button-outline-bg)",
+                color: "var(--color-button-outline-text)",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Retry
+            </button>
           </div>
         ) : (
           <EmptyState {...emptyStateContent} />

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -43,6 +43,8 @@ const PLAYERS_SERVER_ERROR_MESSAGE =
   "Failed to load players due to a server error. Please try again later.";
 const PLAYERS_NETWORK_ERROR_MESSAGE =
   "Failed to load players because we couldn't reach the network. Check your connection and retry.";
+const PLAYERS_TIMEOUT_ERROR_MESSAGE =
+  "Unable to load players. Please try again later.";
 const PLAYERS_FORBIDDEN_MESSAGE =
   "You do not have permission to view hidden players.";
 
@@ -162,9 +164,7 @@ export default function PlayersPage() {
       if (!message) {
         const abortError = err as DOMException;
         if (abortError?.name === "AbortError") {
-          message = didTimeout
-            ? "Loading players took too long. Please check your connection and try again."
-            : null;
+          message = didTimeout ? PLAYERS_TIMEOUT_ERROR_MESSAGE : null;
         }
       }
 
@@ -365,7 +365,12 @@ export default function PlayersPage() {
           <PlayerListSkeleton />
         </div>
       ) : playersLoadError && !loading && players.length === 0 ? (
-        <div className="player-list__error" role="alert">
+        <div
+          className="player-list__error"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
           <p>{playersLoadError}</p>
           <nav
             aria-label="Player loading recovery options"


### PR DESCRIPTION
## Summary
- show a timeout-specific message in the players list and ensure the alert is announced via aria-live
- add a retry control and aria-live feedback when leaderboard loads fail so the UI recovers after a timeout

## Testing
- pnpm test players/page.test.tsx leaderboard/leaderboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df47f943708323ac89af72ebc8f78e