### PR TITLE
Sort player lists alphabetically

### DIFF
--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -79,3 +79,46 @@ describe('PlayersPage error handling', () => {
     consoleErrorSpy.mockRestore();
   });
 });
+
+describe('PlayersPage sorting', () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    mockedIsAdmin.mockReset();
+    mockedIsAdmin.mockReturnValue(false);
+  });
+
+  it('sorts players alphabetically ignoring case', async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      json: async () => ({
+        players: [
+          { id: '2', name: 'benni', hidden: false, photo_url: null },
+          { id: '4', name: 'bridget', hidden: false, photo_url: null },
+          { id: '1', name: 'Addi', hidden: false, photo_url: null },
+          { id: '3', name: 'Amy', hidden: false, photo_url: null },
+        ],
+      }),
+    } as unknown as Response);
+
+    const { container } = render(
+      <ToastProvider>
+        <PlayersPage />
+      </ToastProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('ul.player-list li')).toHaveLength(4);
+    });
+
+    const names = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>(
+        '.player-list__item .player-list__link',
+      ),
+    ).map((link) => link.textContent?.trim());
+
+    expect(names).toEqual(['Addi', 'Amy', 'benni', 'bridget']);
+  });
+});

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -125,15 +125,18 @@ export default function PlayersPage() {
         signal: controller.signal,
       });
       const data = await res.json();
-      const normalized = ((data.players ?? []) as ApiPlayer[]).map(
-        ({ matchSummary, match_summary, hidden: maybeHidden, ...rest }) =>
+      const normalized = ((data.players ?? []) as ApiPlayer[])
+        .map(({ matchSummary, match_summary, hidden: maybeHidden, ...rest }) =>
           withAbsolutePhotoUrl<Player>({
             ...rest,
             hidden: Boolean(maybeHidden),
             matchSummary:
               normalizeMatchSummary(matchSummary ?? match_summary) ?? null,
           })
-      );
+        )
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+        );
       if (loadRequestId.current !== requestId) {
         return;
       }

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -865,7 +865,12 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
         const res = await fetch(`${base}/v0/players`);
         if (res.ok) {
           const data = (await res.json()) as { players: Player[] };
-          setPlayers(data.players || []);
+          const sortedPlayers = (data.players ?? [])
+            .slice()
+            .sort((a, b) =>
+              a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+            );
+          setPlayers(sortedPlayers);
         }
       } catch {
         // ignore errors

--- a/apps/web/src/app/record/disc-golf/page.tsx
+++ b/apps/web/src/app/record/disc-golf/page.tsx
@@ -215,7 +215,10 @@ function DiscGolfForm() {
             .filter((player): player is PlayerOption =>
               Boolean(player?.id && player?.name),
             )
-            .map((player) => ({ id: player.id, name: player.name }));
+            .map((player) => ({ id: player.id, name: player.name }))
+            .sort((a, b) =>
+              a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+            );
           setPlayers(normalized);
         }
       } catch (err) {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -271,7 +271,12 @@ export default function RecordPadelPage() {
       try {
         const res = await apiFetch(`/v0/players`);
         const data = (await res.json()) as { players: Player[] };
-        setPlayers(data.players || []);
+        const sortedPlayers = (data.players ?? [])
+          .slice()
+          .sort((a, b) =>
+            a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+          );
+        setPlayers(sortedPlayers);
       } catch (err: unknown) {
         setGlobalError("Failed to load players");
         const status = (err as { status?: number }).status;

--- a/apps/web/src/app/tournaments/create-tournament-form.tsx
+++ b/apps/web/src/app/tournaments/create-tournament-form.tsx
@@ -112,7 +112,12 @@ export default function CreateTournamentForm({
     try {
       const res = await apiFetch("/v0/players", { cache: "no-store" });
       const data = (await res.json()) as { players: PlayerOption[] };
-      setPlayers(data.players || []);
+      const sortedPlayers = (data.players ?? [])
+        .slice()
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+        );
+      setPlayers(sortedPlayers);
       setPlayersStatus("success");
     } catch (err) {
       console.error("Failed to load players", err);


### PR DESCRIPTION
## Summary
- sort player collections after API fetches to ensure case-insensitive alphabetical ordering across recording and tournament flows
- order the players page results with localeCompare and add a regression test that enforces the new behavior

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68df4faa0f0c8323a629de9c15623ec5