### PR TITLE
Add en-AU locale to Next.js config

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,7 +2,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
-const supportedLocales = ['en-GB', 'es-ES'];
+const supportedLocales = ['en-GB', 'en-AU', 'es-ES'];
 const defaultLocale = supportedLocales[0];
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
## Summary
- include the new en-AU locale in the Next.js internationalization configuration so SSR and routing treat it as supported

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df50a92c688323a6e9dfe2c12e7faf