### PR TITLE
Improve player comments timestamp formatting

### DIFF
--- a/apps/web/src/app/players/[id]/comments-client.test.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { SWRConfig } from "swr";
 
@@ -158,12 +165,12 @@ describe("PlayerComments", () => {
     const expectedTimestamp = formatDateTime(
       "2024-01-01T12:00:00Z",
       "en-GB",
-      "compact",
+      "default",
       "UTC",
     );
-    expect(
-      screen.getByText((text) => text.includes(expectedTimestamp))
-    ).toBeInTheDocument();
+    const commentItem = screen.getByRole("listitem");
+    expect(within(commentItem).getByText("alice")).toBeInTheDocument();
+    expect(within(commentItem).getByText(expectedTimestamp)).toBeInTheDocument();
     expect(notificationMocks.invalidateNotificationsCache).toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/players/[id]/comments-client.tsx
+++ b/apps/web/src/app/players/[id]/comments-client.tsx
@@ -235,24 +235,30 @@ export default function PlayerComments({ playerId }: { playerId: string }) {
             const createdAtLabel = formatDateTime(
               c.createdAt,
               locale,
-              "compact",
+              "default",
               timeZone,
             );
+            const createdAtDate = new Date(c.createdAt);
+            const createdAtDateTime = Number.isNaN(createdAtDate.getTime())
+              ? undefined
+              : createdAtDate.toISOString();
+            const canDelete =
+              session.loggedIn && (session.admin || session.userId === c.userId);
             return (
-              <li key={c.id} className="mb-2">
-                <div>{c.content}</div>
-                <div className="text-sm text-gray-700">
-                  {c.username} · {createdAtLabel}
-                  {session.loggedIn &&
-                    (session.admin || session.userId === c.userId) && (
-                      <button
-                        onClick={() => remove(c.id, c.userId)}
-                        className="ml-2 text-red-600"
-                      >
-                        Delete
-                      </button>
-                    )}
-                </div>
+              <li key={c.id} className="mb-4">
+                <header className="flex flex-wrap items-baseline gap-x-2 text-sm text-gray-700">
+                  <span className="font-medium text-gray-900">{c.username}</span>
+                  <time dateTime={createdAtDateTime}>{createdAtLabel}</time>
+                  {canDelete && (
+                    <button
+                      onClick={() => remove(c.id, c.userId)}
+                      className="ml-2 text-red-600"
+                    >
+                      Delete
+                    </button>
+                  )}
+                </header>
+                <p className="mt-1 whitespace-pre-line break-words">{c.content}</p>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- display each player comment with a header that shows the author and a locale-aware timestamp before the content
- use the standard date/time preset and semantic markup so the timestamp follows the viewer’s locale and timezone
- update the player comments tests to match the new presentation

## Testing
- pnpm test -- --run src/app/players/[id]/comments-client.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68df516608408323ac30625aa2f4198d