### PR TITLE
Hide live update fallback on finished matches

### DIFF
--- a/apps/web/src/app/matches/[mid]/live-summary.test.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.test.tsx
@@ -50,6 +50,29 @@ describe("LiveSummary", () => {
     expect(screen.getByText("Live updates unavailable.")).toBeInTheDocument();
   });
 
+  it("hides fallback messaging for completed matches", () => {
+    useMatchStreamMock.mockReturnValue({
+      event: null,
+      connected: false,
+      fallback: true,
+    });
+
+    render(
+      <LiveSummary
+        mid="match-3"
+        sport="padel"
+        status="Final"
+        statusCode="final"
+        initialSummary={{}}
+        initialEvents={[]}
+      />
+    );
+
+    expect(
+      screen.queryByText("Live updates unavailable.")
+    ).not.toBeInTheDocument();
+  });
+
   it("omits fallback messaging when live updates are active", () => {
     useMatchStreamMock.mockReturnValue({
       event: null,

--- a/apps/web/src/app/matches/[mid]/live-summary.tsx
+++ b/apps/web/src/app/matches/[mid]/live-summary.tsx
@@ -522,7 +522,7 @@ export default function LiveSummary({
       {latestEvent ? (
         <p className="match-meta">Latest update: {latestEvent}</p>
       ) : null}
-      {fallback && !connected ? (
+      {fallback && !connected && !finished ? (
         <p className="match-meta">Live updates unavailable.</p>
       ) : null}
     </section>


### PR DESCRIPTION
## Summary
- stop showing the live update fallback message when a match is already finished
- add a regression test to ensure completed matches suppress the fallback banner

## Testing
- pnpm exec vitest run live-summary

------
https://chatgpt.com/codex/tasks/task_e_68df52d0d0548323b87315cb7067e92f