### PR TITLE
Implement tournament detail API helpers and dynamic schedule table

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -842,6 +842,17 @@ export async function listTournaments(
   return res.json();
 }
 
+export async function getTournament(
+  tournamentId: string,
+  init?: ApiRequestInit
+): Promise<TournamentSummary> {
+  const res = await apiFetch(
+    `/v0/tournaments/${tournamentId}`,
+    withNoStore(init)
+  );
+  return res.json();
+}
+
 export async function createTournament(
   payload: TournamentCreatePayload
 ): Promise<TournamentSummary> {
@@ -866,6 +877,17 @@ export async function createStage(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
+  return res.json();
+}
+
+export async function listTournamentStages(
+  tournamentId: string,
+  init?: ApiRequestInit
+): Promise<StageSummary[]> {
+  const res = await apiFetch(
+    `/v0/tournaments/${tournamentId}/stages`,
+    withNoStore(init)
+  );
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- add API helpers to retrieve tournament details and stage lists with no-store caching
- update the tournament detail page to use the helpers and keep error handling consistent
- render stage schedules with dynamic side columns and expand tests to cover the new API calls

## Testing
- pnpm vitest run src/app/__tests__/tournaments.page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df580fb28c83239a272f7ed742dc41