### PR TITLE
Allow pickleball overtime scoring in match recorder

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.test.ts
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeGameSeries,
+  type GameSeriesConfig,
+} from "./RecordSportForm";
+
+describe("normalizeGameSeries – pickleball overtime", () => {
+  const pickleballConfig: GameSeriesConfig = {
+    maxGames: 3,
+    gamesNeededOptions: [2],
+    invalidSeriesMessage: "Pickleball matches finish when a side wins two games.",
+    maxPointsPerGame: 11,
+    allowScoresBeyondMax: true,
+    requiredWinningMargin: 2,
+  };
+
+  it("allows games that extend beyond 11 when the winner leads by two", () => {
+    const result = normalizeGameSeries(
+      [
+        { a: "12", b: "10" },
+        { a: "8", b: "11" },
+        { a: "15", b: "13" },
+      ],
+      pickleballConfig,
+    );
+
+    expect(result.sets).toEqual([
+      [12, 10],
+      [8, 11],
+      [15, 13],
+    ]);
+  });
+
+  it("rejects scores beyond 11 that are not won by two", () => {
+    expect(() =>
+      normalizeGameSeries(
+        [
+          { a: "12", b: "11" },
+          { a: "11", b: "8" },
+        ],
+        pickleballConfig,
+      ),
+    ).toThrowError(/won by at least 2 points/);
+  });
+
+  it("rejects regulation games that are not won by two", () => {
+    expect(() =>
+      normalizeGameSeries(
+        [
+          { a: "11", b: "10" },
+          { a: "11", b: "8" },
+        ],
+        pickleballConfig,
+      ),
+    ).toThrowError(/won by at least 2 points/);
+  });
+});

--- a/apps/web/src/lib/sportCopy.ts
+++ b/apps/web/src/lib/sportCopy.ts
@@ -82,9 +82,9 @@ const SPORT_COPY: Record<string, Record<string, SportCopy>> = {
       playersHint:
         'Choose the lineup for each side. Leave the second slot empty for singles games.',
       scoringHint:
-        'Pickleball matches are best of three games. Enter the points for each game below (for example 11-6, 8-11, 11-9) and the app will calculate the 2-1 result.',
+        'Pickleball matches are best of three games. Enter the points for each game below—games are played to 11 and must be won by two (deciders often go to 15). For example 11-6, 12-10, 15-13.',
       confirmationMessage: 'Save this pickleball match?',
-      gameScorePlaceholder: 'Points to 11 for this game (e.g. 11)',
+      gameScorePlaceholder: 'Points to 11 for this game (win by 2, e.g. 11)',
     },
     'en-au': {
       matchDetailsHint:


### PR DESCRIPTION
## Summary
- allow pickleball game validation to accept scores beyond 11 when the winner leads by two
- enforce the win-by-two requirement for pickleball games and update the inline copy to explain extended games
- add unit tests covering overtime and invalid pickleball game results

## Testing
- npm run test -- RecordSportForm

------
https://chatgpt.com/codex/tasks/task_e_68df59dec57c8323a87664a1a76de357