### PR TITLE
Add realtime username availability check

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1313,6 +1313,20 @@ textarea {
   font-size: 0.9rem;
 }
 
+.auth-form__hint {
+  font-size: 0.85rem;
+  color: rgba(10, 31, 68, 0.75);
+  margin-top: 0.5rem;
+}
+
+.auth-form__hint--success {
+  color: var(--color-success);
+}
+
+.auth-form__hint--error {
+  color: var(--color-accent-red);
+}
+
 .connection-indicator {
   display: inline-flex;
   align-items: center;

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -485,6 +485,12 @@ class TokenOut(BaseModel):
     csrf_token: str
 
 
+class UsernameAvailabilityResponse(BaseModel):
+    """Response payload for username availability checks."""
+
+    available: bool
+
+
 class UserOut(BaseModel):
     """Public user information."""
     id: str


### PR DESCRIPTION
## Summary
- add a username availability endpoint on the auth API and cover it with tests
- surface realtime username availability feedback on the signup form, including inline messaging styles and test coverage

## Testing
- pnpm test -- --runInBand *(fails: existing suite has unrelated failing tests)*
- pytest backend/tests/test_auth.py::test_username_availability_endpoint_reports_taken_usernames


------
https://chatgpt.com/codex/tasks/task_e_68df5bdfddb48323ad2c4d491230063f