### PR TITLE
Enforce pickleball overtime game point requirement

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.test.ts
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.test.ts
@@ -55,4 +55,16 @@ describe("normalizeGameSeries – pickleball overtime", () => {
       ),
     ).toThrowError(/won by at least 2 points/);
   });
+
+  it("rejects overtime when the loser never reached game point", () => {
+    expect(() =>
+      normalizeGameSeries(
+        [
+          { a: "15", b: "3" },
+          { a: "11", b: "8" },
+        ],
+        pickleballConfig,
+      ),
+    ).toThrowError(/require both teams to reach at least 10 points/);
+  });
 });

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -155,6 +155,22 @@ export function normalizeGameSeries(
     const losingPoints = Math.min(valueA, valueB);
 
     if (
+      exceedsMax &&
+      allowsScoresBeyondMax &&
+      typeof maxPoints === "number"
+    ) {
+      const minPointsForOvertime = maxPoints - 1;
+      if (
+        winningPoints < minPointsForOvertime ||
+        losingPoints < minPointsForOvertime
+      ) {
+        throw new Error(
+          `Game ${i + 1} scores above ${maxPoints} require both teams to reach at least ${minPointsForOvertime} points first.`,
+        );
+      }
+    }
+
+    if (
       typeof config.requiredWinningMargin === "number" &&
       winningPoints - losingPoints < config.requiredWinningMargin
     ) {


### PR DESCRIPTION
## Summary
- prevent pickleball overtime scores from being accepted unless both teams have reached game point
- add a regression test covering invalid overtime inputs

## Testing
- pnpm --dir apps/web test RecordSportForm

------
https://chatgpt.com/codex/tasks/task_e_68df5da47fb08323906c2a6913eb8271