### PR TITLE
Adjust signup messaging and redirect to profile

### DIFF
--- a/apps/web/src/app/__tests__/login.page.test.tsx
+++ b/apps/web/src/app/__tests__/login.page.test.tsx
@@ -119,7 +119,7 @@ describe('LoginPage signup feedback', () => {
       access_token: 'token',
       refresh_token: 'refresh',
     });
-    expect(pushMock).toHaveBeenCalledWith('/');
+    expect(pushMock).toHaveBeenCalledWith('/profile');
 
     const toast = await screen.findByTestId('toast');
     expect(toast).toHaveTextContent(/Account created successfully!/i);

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -416,8 +416,8 @@ export default function LoginPage() {
         setConfirmPass("");
         setUsername("");
         setPassword("");
-        const redirectTarget = consumeLoginRedirect();
-        router.push(redirectTarget ?? "/");
+        consumeLoginRedirect();
+        router.push("/profile");
       } else {
         const messages = await extractSignupErrors(res);
         setSignupErrors(messages);
@@ -533,9 +533,8 @@ export default function LoginPage() {
           className="auth-signup__description"
           style={{ margin: "0.5rem 0 0", color: "#4b5563", fontSize: "0.95rem" }}
         >
-          We’ll automatically match your browser’s language and time zone for new
-          accounts. You can fine-tune both defaults anytime from your profile
-          settings.
+          After creating your account, we’ll take you to your profile so you can
+          customize preferences like language and time zone.
         </p>
         {showSignup && (
           <form


### PR DESCRIPTION
## Summary
- remove the misleading auto language/time zone promise from the signup description
- redirect new signups to the profile page so they can update language and time zone preferences

## Testing
- npm test -- login.page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df5bb1712c8323a93c29722c9576d4