### PR TITLE
Update master leaderboard copy description

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -288,7 +288,7 @@ describe("Leaderboard", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "The master rating averages each player's normalized rating across every sport they've played, letting you compare multi-sport performance on a shared 0–1000 scale.",
+        "Master leaderboard ranks players across all sports based on combined performance.",
       ),
     ).toBeInTheDocument();
   });

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1448,9 +1448,8 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               color: "var(--color-text-muted)",
             }}
           >
-            The master rating averages each player's normalized rating across every sport
-            they've played, letting you compare multi-sport performance on a shared 0–1000
-            scale.
+            Master leaderboard ranks players across all sports based on combined
+            performance.
           </p>
         </section>
       ) : null}


### PR DESCRIPTION
## Summary
- update the master leaderboard information callout to the new copy
- align the leaderboard test expectation with the updated messaging

## Testing
- pnpm test -- --runTestsByPath src/app/leaderboard/leaderboard.test.tsx *(fails: unrelated suite regressions already present in profile and record padel tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df5f42fd2083239a55126cba78b425