### PR TITLE
Remove misleading leaderboard back navigation

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1335,15 +1335,6 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       <p className="sr-only" aria-live="polite">
         {statusMessage}
       </p>
-      <div style={{ marginBottom: "1rem", fontSize: "0.9rem" }}>
-        <Link
-          href={ensureTrailingSlash("/matches")}
-          style={{ textDecoration: "underline" }}
-        >
-          ← Back to matches
-        </Link>
-      </div>
-
       <header
         style={{
           display: "flex",


### PR DESCRIPTION
## Summary
- remove the hard-coded "Back to matches" link from the leaderboard header so the page no longer advertises an incorrect navigation target

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df6112708c832387e984ffb37d1a54