### PR TITLE
Localize leaderboard empty state CTAs

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -174,6 +174,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const searchParamsString = searchParams?.toString() ?? "";
   const lastSyncedUrlRef = useRef<string | null>(null);
   const homeT = useTranslations("Home");
+  const leaderboardT = useTranslations("Leaderboard");
 
   const initialCountry = normalizeCountry(country);
   const initialClubId = normalizeClubId(clubId);
@@ -811,24 +812,30 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         const firstSport = SPORTS[0];
         cta = {
           href: withRegion(`/leaderboard?sport=${firstSport}`),
-          label: `View ${getSportDisplayName(firstSport)} leaderboard`,
+          label: leaderboardT("emptyState.viewSportLeaderboard", {
+            sport: getSportDisplayName(firstSport),
+          }),
         };
       } else if (sport === ALL_SPORTS) {
         cta = {
           href: ensureTrailingSlash("/record"),
-          label: "Record a match",
+          label: leaderboardT("emptyState.recordMatch"),
         };
       } else if (SPORTS.includes(sport as (typeof SPORTS)[number])) {
         const normalizedSportId = sport.replace(/-/g, "_");
         if (isSportIdImplementedForRecording(normalizedSportId)) {
           cta = {
             href: recordPathForSport(normalizedSportId),
-            label: `Record a ${sportDisplayName} match`,
+            label: leaderboardT("emptyState.recordSportMatch", {
+              sport: sportDisplayName,
+            }),
           };
         } else {
           cta = {
             href: "/record",
-            label: `Record a ${sportDisplayName} match`,
+            label: leaderboardT("emptyState.recordSportMatch", {
+              sport: sportDisplayName,
+            }),
           };
         }
       }
@@ -851,30 +858,43 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       const firstSport = SPORTS[0];
       cta = {
         href: withRegion(`/leaderboard?sport=${firstSport}`),
-        label: `View ${getSportDisplayName(firstSport)} leaderboard`,
+        label: leaderboardT("emptyState.viewSportLeaderboard", {
+          sport: getSportDisplayName(firstSport),
+        }),
       };
     } else if (sport === ALL_SPORTS) {
       cta = {
         href: ensureTrailingSlash("/record"),
-        label: "Record a match",
+        label: leaderboardT("emptyState.recordMatch"),
       };
     } else if (SPORTS.includes(sport as (typeof SPORTS)[number])) {
       const normalizedSportId = sport.replace(/-/g, "_");
       if (isSportIdImplementedForRecording(normalizedSportId)) {
         cta = {
           href: recordPathForSport(normalizedSportId),
-          label: `Record a ${sportDisplayName} match`,
+          label: leaderboardT("emptyState.recordSportMatch", {
+            sport: sportDisplayName,
+          }),
         };
       } else {
         cta = {
           href: "/record",
-          label: `Record a ${sportDisplayName} match`,
+          label: leaderboardT("emptyState.recordSportMatch", {
+            sport: sportDisplayName,
+          }),
         };
       }
     }
 
     return { icon, iconLabel, title, description, cta };
-  }, [getSportIconLabel, hasAppliedFilters, sport, sportDisplayName, withRegion]);
+  }, [
+    getSportIconLabel,
+    hasAppliedFilters,
+    leaderboardT,
+    sport,
+    sportDisplayName,
+    withRegion,
+  ]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/apps/web/src/messages/en-AU.json
+++ b/apps/web/src/messages/en-AU.json
@@ -50,6 +50,13 @@
       "disc_golf": "Disc golf flying disc icon"
     }
   },
+  "Leaderboard": {
+    "emptyState": {
+      "viewSportLeaderboard": "View {sport} leaderboard",
+      "recordMatch": "Record a match",
+      "recordSportMatch": "Record a {sport} match"
+    }
+  },
   "Matches": {
     "title": "Matches",
     "emptyInitial": "No matches yet.",

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -50,6 +50,13 @@
       "disc_golf": "Disc golf flying disc icon"
     }
   },
+  "Leaderboard": {
+    "emptyState": {
+      "viewSportLeaderboard": "View {sport} leaderboard",
+      "recordMatch": "Record a match",
+      "recordSportMatch": "Record a {sport} match"
+    }
+  },
   "Matches": {
     "title": "Matches",
     "emptyInitial": "No matches yet.",

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -50,6 +50,13 @@
       "disc_golf": "Icono de disco volador de disc golf"
     }
   },
+  "Leaderboard": {
+    "emptyState": {
+      "viewSportLeaderboard": "Ver la clasificación de {sport}",
+      "recordMatch": "Registrar un partido",
+      "recordSportMatch": "Registrar un partido de {sport}"
+    }
+  },
   "Matches": {
     "title": "Partidos",
     "emptyInitial": "Todavía no hay partidos.",


### PR DESCRIPTION
## Summary
- localize leaderboard empty state call-to-action labels through next-intl
- add locale strings that clarify sport-specific recording destinations

## Testing
- pnpm --filter @cst/web lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df615ef50083239ccc3219a0180693