### PR TITLE
Add visible label for overflow sport selector

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1814,6 +1814,15 @@ textarea {
 .leaderboard-nav-select {
   position: relative;
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.leaderboard-nav-select__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
 }
 
 .leaderboard-nav-select__control {

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1400,14 +1400,16 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
             </ul>
             {isOverflowing ? (
               <div className="leaderboard-nav-select">
-                <label className="sr-only" htmlFor="leaderboard-sport-more">
+                <label
+                  className="leaderboard-nav-select__label"
+                  htmlFor="leaderboard-sport-more"
+                >
                   More sports
                 </label>
                 <select
                   id="leaderboard-sport-more"
                   value={sport}
                   onChange={handleSportChange}
-                  aria-label="Select a sport"
                   className="leaderboard-nav-select__control"
                 >
                   {navItems.map((item) => (


### PR DESCRIPTION
## Summary
- add a visible "More sports" label to the overflow sport selector so the control is discoverable
- style the overflow selector container to align the label and dropdown with the tab list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6203e9c883239257c65e4a3832b7