### PR TITLE
Add tournament editing UI and permissions messaging

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -760,6 +760,12 @@ export type TournamentSummary = TournamentCreatePayload & {
   createdByUserId?: string | null;
 };
 
+export type TournamentUpdatePayload = {
+  name?: string | null;
+  sport?: string | null;
+  clubId?: string | null;
+};
+
 export type StageCreatePayload = {
   type: string;
   config?: Record<string, unknown> | null;
@@ -860,6 +866,22 @@ export async function createTournament(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+  });
+  return res.json();
+}
+
+export async function updateTournament(
+  tournamentId: string,
+  payload: TournamentUpdatePayload
+): Promise<TournamentSummary> {
+  const entries = Object.entries(payload).filter(
+    (entry): entry is [string, string | null] => entry[1] !== undefined
+  );
+  const body = Object.fromEntries(entries);
+  const res = await apiFetch(`/v0/tournaments/${tournamentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
   });
   return res.json();
 }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -792,6 +792,14 @@ class TournamentOut(BaseModel):
     createdByUserId: Optional[str] = None
 
 
+class TournamentUpdate(BaseModel):
+    """Schema for updating a tournament."""
+
+    name: Optional[str] = None
+    sport: Optional[str] = None
+    clubId: Optional[str] = None
+
+
 class StageCreate(BaseModel):
     """Schema for creating a tournament stage."""
 


### PR DESCRIPTION
## Summary
- add a PATCH endpoint, schema, and backend tests so tournaments can be renamed with appropriate permission checks
- expose an `updateTournament` client helper and add an inline edit experience plus clearer permission messaging on the tournaments page
- expand frontend tests to cover tournament editing flows and permission documentation

## Testing
- pnpm test -- --runInBand *(fails: existing suite has known failing cases outside tournament scope)*
- pytest backend/tests/test_tournaments.py

------
https://chatgpt.com/codex/tasks/task_e_68df62a269a883238eaba3489729003d