### PR TITLE
Refine racket summary columns for non-game sports

### DIFF
--- a/apps/web/src/lib/match-summary.ts
+++ b/apps/web/src/lib/match-summary.ts
@@ -125,6 +125,10 @@ export const RACKET_SPORTS = new Set([
   "table_tennis",
 ]);
 
+export const RACKET_SPORTS_WITHOUT_GAME_TOTALS = new Set([
+  "padel",
+]);
+
 export function isRacketSport(sport?: string | null): boolean {
   const normalized = normalizeSportId(sport);
   if (!normalized) return false;


### PR DESCRIPTION
## Summary
- hide the games column for padel in match detail summaries and live scoreboards
- rename racket totals headers to clarify they represent wins and add a tooltip about game availability
- expand match detail tests to cover padel game column behaviour and tooltip rendering

## Testing
- pnpm vitest run src/app/matches/[mid]/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df6503a5a48323a641379442ec7ca9