### PR TITLE
Add share/export controls to match detail page

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,6 +11,7 @@
         "@zxcvbn-ts/core": "^3.0.4",
         "chart.js": "^4.5.0",
         "chartjs-chart-matrix": "^1.3.0",
+        "jspdf": "^2.5.1",
         "next": "14.2.5",
         "next-intl": "^4.3.9",
         "react": "18.3.1",
@@ -73,7 +74,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
       "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1498,6 +1498,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
@@ -2431,6 +2438,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2474,6 +2493,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2495,6 +2524,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/busboy": {
@@ -2597,6 +2638,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -2737,6 +2798,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2750,6 +2823,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -2998,6 +3081,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3898,6 +3988,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4375,6 +4471,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5079,6 +5189,24 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -5853,6 +5981,13 @@
         "node": "*"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6024,6 +6159,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -6103,6 +6248,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6181,6 +6333,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -6559,6 +6721,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -6832,6 +7004,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
@@ -6851,6 +7033,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -7256,6 +7448,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "chartjs-chart-matrix": "^1.3.0",
     "next": "14.2.5",
     "next-intl": "^4.3.9",
+    "jspdf": "^2.5.1",
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.3.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       next:
         specifier: 14.2.5
         version: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-intl:
+        specifier: ^4.3.9
+        version: 4.3.9(next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -32,6 +35,9 @@ importers:
       swr:
         specifier: ^2.3.6
         version: 2.3.6(react@18.3.1)
+      use-intl:
+        specifier: ^4.3.9
+        version: 4.3.9(react@18.3.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.8.0
@@ -255,6 +261,24 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -472,6 +496,9 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1378,6 +1405,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1636,6 +1666,20 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  next-intl@4.3.9:
+    resolution: {integrity: sha512-4oSROHlgy8a5Qr2vH69wxo9F6K0uc6nZM2GNzqSe6ET79DEzOmBeSijCRzD5txcI4i+XTGytu4cxFsDXLKEDpQ==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   next@14.2.5:
     resolution: {integrity: sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==}
@@ -2153,6 +2197,11 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-intl@4.3.9:
+    resolution: {integrity: sha512-bZu+h13HIgOvsoGleQtUe4E6gM49CRm+AH36KnJVB/qb1+Beo7jr7HNrR8YWH8oaOkQfGNm6vh0HTepxng8UTg==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-sync-external-store@1.5.0:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
@@ -2421,6 +2470,36 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2564,6 +2643,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@schummar/icu-type-parser@1.21.5': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -3695,6 +3776,13 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -3965,6 +4053,18 @@ snapshots:
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
+
+  next-intl@4.3.9(next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.2):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      use-intl: 4.3.9(react@18.3.1)
+    optionalDependencies:
+      typescript: 5.9.2
 
   next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -4582,6 +4682,13 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-intl@4.3.9(react@18.3.1):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@schummar/icu-type-parser': 1.21.5
+      intl-messageformat: 10.7.16
+      react: 18.3.1
 
   use-sync-external-store@1.5.0(react@18.3.1):
     dependencies:

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1120,6 +1120,74 @@ textarea {
   font-size: 0.9rem;
 }
 
+.match-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-detail-header__top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.match-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.share-match {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.share-match__trigger {
+  white-space: nowrap;
+}
+
+.share-match__menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  min-width: 180px;
+  border: 1px solid rgba(10, 31, 68, 0.2);
+  border-radius: 6px;
+  background-color: var(--color-surface);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.15);
+  padding: 0.25rem 0;
+  z-index: 5;
+}
+
+.share-match__menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.share-match__menu-item:hover,
+.share-match__menu-item:focus {
+  background-color: rgba(26, 115, 232, 0.08);
+  outline: none;
+}
+
+.share-match__feedback {
+  min-height: 1em;
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
 .match-detail-layout {
   margin-top: 24px;
   display: grid;

--- a/apps/web/src/app/matches/[mid]/ShareMatchButton.tsx
+++ b/apps/web/src/app/matches/[mid]/ShareMatchButton.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type ShareParticipant = {
+  label: string;
+  players: string[];
+};
+
+type ShareSummaryColumn = {
+  key: string;
+  label: string;
+};
+
+type ShareSummaryRow = {
+  label: string;
+  values: Record<string, number | null>;
+};
+
+type ShareMatchButtonProps = {
+  matchId: string;
+  matchTitle: string;
+  sharePath: string;
+  participants: ShareParticipant[];
+  summaryColumns: ShareSummaryColumn[];
+  summaryRows: ShareSummaryRow[];
+  meta: string[];
+  status?: string | null;
+  playedAt?: string | null;
+  location?: string | null;
+};
+
+function escapeCsvValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const stringValue = String(value);
+  if (/[",\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export default function ShareMatchButton({
+  matchId,
+  matchTitle,
+  sharePath,
+  participants,
+  summaryColumns,
+  summaryRows,
+  meta,
+  status,
+  playedAt,
+  location,
+}: ShareMatchButtonProps) {
+  const [shareUrl, setShareUrl] = useState<string>(sharePath);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    setShareUrl(window.location.href);
+  }, [sharePath]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current) return;
+      if (event.target instanceof Node && !containerRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!feedback) return undefined;
+    const timeout = window.setTimeout(() => {
+      setFeedback(null);
+    }, 4000);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [feedback]);
+
+  const matchMetaLines = useMemo(() => {
+    const lines: string[] = [];
+    if (status) lines.push(`Status: ${status}`);
+    if (playedAt) lines.push(`Date & time: ${playedAt}`);
+    if (location) lines.push(`Location: ${location}`);
+    meta.forEach((entry) => {
+      if (!lines.includes(entry)) {
+        lines.push(entry);
+      }
+    });
+    return lines;
+  }, [status, playedAt, location, meta]);
+
+  const handleCopyLink = useCallback(async () => {
+    const url = shareUrl || sharePath;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = url;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      setFeedback("Match link copied to clipboard");
+    } catch (error) {
+      console.error("Unable to copy match link", error);
+      setFeedback("Unable to copy match link. Try copying the URL manually.");
+    } finally {
+      setMenuOpen(false);
+    }
+  }, [shareUrl, sharePath]);
+
+  const buildCsvContent = useCallback(() => {
+    const lines: string[] = [];
+    lines.push(`Match,${escapeCsvValue(matchTitle)}`);
+    matchMetaLines.forEach((line) => {
+      const [label, ...rest] = line.split(": ");
+      if (label && rest.length) {
+        lines.push(`${escapeCsvValue(label)},${escapeCsvValue(rest.join(": "))}`);
+      } else {
+        lines.push(`Detail,${escapeCsvValue(line)}`);
+      }
+    });
+
+    if (participants.length) {
+      lines.push("");
+      lines.push(["Side", "Players"].map(escapeCsvValue).join(","));
+      participants.forEach((participant) => {
+        lines.push(
+          [
+            escapeCsvValue(participant.label),
+            escapeCsvValue(participant.players.join(" / ")),
+          ].join(",")
+        );
+      });
+    }
+
+    if (summaryColumns.length && summaryRows.length) {
+      lines.push("");
+      lines.push(
+        ["Side", ...summaryColumns.map((column) => column.label)].map(escapeCsvValue).join(",")
+      );
+      summaryRows.forEach((row) => {
+        const rowValues = summaryColumns.map((column) =>
+          escapeCsvValue(row.values[column.key] ?? "")
+        );
+        lines.push([escapeCsvValue(row.label), ...rowValues].join(","));
+      });
+    }
+
+    return `${lines.join("\n")}\n`;
+  }, [matchTitle, matchMetaLines, participants, summaryColumns, summaryRows]);
+
+  const handleDownloadCsv = useCallback(() => {
+    try {
+      const csvContent = buildCsvContent();
+      const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `match-${matchId}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setFeedback("CSV exported successfully");
+    } catch (error) {
+      console.error("Unable to export match CSV", error);
+      setFeedback("Unable to export CSV. Please try again.");
+    } finally {
+      setMenuOpen(false);
+    }
+  }, [buildCsvContent, matchId]);
+
+  const handleDownloadPdf = useCallback(async () => {
+    try {
+      const { jsPDF } = await import("jspdf");
+      const doc = new jsPDF();
+      let cursorY = 14;
+      const lineHeight = 6;
+      const maxWidth = 190;
+
+      const ensureSpace = (extra: number) => {
+        if (cursorY + extra > 285) {
+          doc.addPage();
+          cursorY = 14;
+        }
+      };
+
+      const writeLines = (text: string, indent = 0) => {
+        const availableWidth = maxWidth - indent;
+        const lines = doc.splitTextToSize(text, availableWidth);
+        lines.forEach((line) => {
+          ensureSpace(lineHeight);
+          doc.text(line, 10 + indent, cursorY);
+          cursorY += lineHeight;
+        });
+      };
+
+      doc.setFontSize(16);
+      writeLines(matchTitle);
+      cursorY += 2;
+
+      doc.setFontSize(12);
+      matchMetaLines.forEach((line) => writeLines(line));
+      if (matchMetaLines.length) {
+        cursorY += 4;
+      }
+
+      if (participants.length) {
+        doc.setFontSize(14);
+        writeLines("Participants");
+        doc.setFontSize(12);
+        participants.forEach((participant) => {
+          writeLines(`${participant.label}: ${participant.players.join(" & ")}`, 4);
+        });
+        cursorY += 2;
+      }
+
+      if (summaryColumns.length && summaryRows.length) {
+        doc.setFontSize(14);
+        writeLines("Results");
+        doc.setFontSize(12);
+        summaryRows.forEach((row) => {
+          const parts = summaryColumns.map((column) => {
+            const value = row.values[column.key];
+            return `${column.label}: ${value ?? "—"}`;
+          });
+          writeLines(`${row.label} – ${parts.join(", ")}`, 4);
+        });
+      }
+
+      doc.save(`match-${matchId}.pdf`);
+      setFeedback("PDF exported successfully");
+    } catch (error) {
+      console.error("Unable to export match PDF", error);
+      setFeedback("Unable to export PDF. Please try again.");
+    } finally {
+      setMenuOpen(false);
+    }
+  }, [matchId, matchMetaLines, matchTitle, participants, summaryColumns, summaryRows]);
+
+  return (
+    <div className="share-match" ref={containerRef}>
+      <button
+        type="button"
+        className="button-secondary share-match__trigger"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={() => setMenuOpen((open) => !open)}
+      >
+        Share match
+      </button>
+      {menuOpen ? (
+        <div className="share-match__menu" role="menu">
+          <button
+            type="button"
+            className="share-match__menu-item"
+            role="menuitem"
+            onClick={handleCopyLink}
+          >
+            Copy link
+          </button>
+          <button
+            type="button"
+            className="share-match__menu-item"
+            role="menuitem"
+            onClick={handleDownloadPdf}
+          >
+            Export PDF
+          </button>
+          <button
+            type="button"
+            className="share-match__menu-item"
+            role="menuitem"
+            onClick={handleDownloadCsv}
+          >
+            Export CSV
+          </button>
+        </div>
+      ) : null}
+      <p className="share-match__feedback" role="status" aria-live="polite">
+        {feedback}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/matches/[mid]/page.tsx
+++ b/apps/web/src/app/matches/[mid]/page.tsx
@@ -6,6 +6,7 @@ import { apiFetch, withAbsolutePhotoUrl } from "../../../lib/api";
 import LiveSummary from "./live-summary";
 import MatchParticipants from "../../../components/MatchParticipants";
 import { PlayerInfo } from "../../../components/PlayerName";
+import ShareMatchButton from "./ShareMatchButton";
 import { formatDate, formatDateTime, resolveTimeZone } from "../../../lib/i18n";
 import { hasTimeComponent } from "../../../lib/datetime";
 import { ensureTrailingSlash, recordPathForSport } from "../../../lib/routes";
@@ -795,6 +796,42 @@ export default async function MatchDetailPage({
 
   const hasSummaryTable = summaryColumns.length > 0 && summaryRows.length > 0;
 
+  const shareParticipants = participantsWithSides.map((participant) => ({
+    label: participant.label,
+    players: participant.players.map((player) => player.name),
+  }));
+
+  const shareSummaryColumns = summaryColumns.map((column) => ({
+    key: column.key,
+    label: column.label,
+  }));
+
+  const shareSummaryRows = summaryRows.map((row) => {
+    const values: Record<string, number | null> = {};
+    summaryColumns.forEach((column) => {
+      values[column.key] = column.values.get(row.sideKey) ?? null;
+    });
+    return {
+      label: row.label,
+      values,
+    };
+  });
+
+  const matchTitle = participantsWithSides.length
+    ? participantsWithSides
+        .map((participant) => {
+          const playerNames = participant.players
+            .map((player) => player.name)
+            .filter((name) => name && name.trim().length > 0)
+            .join(" & ");
+          return playerNames || participant.label;
+        })
+        .join(" vs ")
+    : "Match";
+
+  const shareMeta = [...headerMetaParts];
+  const sharePath = `/matches/${encodeURIComponent(params.mid)}`;
+
   return (
     <main className="container">
       <div className="text-sm">
@@ -822,18 +859,34 @@ export default async function MatchDetailPage({
         </div>
       ) : null}
 
-      <header className="section">
-        <h1 className="heading">
-          {participantGroups.length ? (
-            <MatchParticipants
-              as="span"
-              sides={participantGroups}
-              separatorSymbol="/"
+      <header className="section match-detail-header">
+        <div className="match-detail-header__top">
+          <h1 className="heading">
+            {participantGroups.length ? (
+              <MatchParticipants
+                as="span"
+                sides={participantGroups}
+                separatorSymbol="/"
+              />
+            ) : (
+              "A vs B"
+            )}
+          </h1>
+          <div className="match-detail-actions">
+            <ShareMatchButton
+              matchId={params.mid}
+              matchTitle={matchTitle}
+              sharePath={sharePath}
+              participants={shareParticipants}
+              summaryColumns={shareSummaryColumns}
+              summaryRows={shareSummaryRows}
+              meta={shareMeta}
+              status={statusText}
+              playedAt={playedAtLabel}
+              location={locationLabel}
             />
-          ) : (
-            "A vs B"
-          )}
-        </h1>
+          </div>
+        </div>
         <p className="match-meta">{headerMetaParts.join(" · ")}</p>
       </header>
       <div className="match-detail-layout">


### PR DESCRIPTION
## Summary
- add a Share match client component with copy link, PDF, and CSV export actions
- surface match summary data from the detail page so the share menu has player and scoring context
- style the match header to host the new actions and add jspdf for PDF generation

## Testing
- npm test *(fails: pre-existing vitest suites for leaderboard overflow and profile password validation)*

------
https://chatgpt.com/codex/tasks/task_e_68df66a48ca0832399a215446727f7fa