### PR TITLE
Ensure /v0/sports exposes all supported sports

### DIFF
--- a/backend/app/routers/sports.py
+++ b/backend/app/routers/sports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,8 +10,52 @@ from ..schemas import SportOut
 
 router = APIRouter(prefix="/sports", tags=["sports"])
 
+
+DEFAULT_SPORT_CATALOG: tuple[tuple[str, str], ...] = (
+    ("padel", "Padel"),
+    ("padel_americano", "Padel Americano"),
+    ("bowling", "Bowling"),
+    ("tennis", "Tennis"),
+    ("pickleball", "Pickleball"),
+    ("table_tennis", "Table Tennis"),
+    ("disc_golf", "Disc Golf"),
+)
+
+DEFAULT_SPORT_NAME_LOOKUP = {sport_id: name for sport_id, name in DEFAULT_SPORT_CATALOG}
+
+
+def _fallback_sport_name(sport_id: str, provided_name: str | None) -> str:
+    if provided_name:
+        normalized = provided_name.strip()
+        if normalized:
+            return normalized
+
+    fallback = DEFAULT_SPORT_NAME_LOOKUP.get(sport_id)
+    if fallback:
+        return fallback
+
+    normalized_id = sport_id.replace("_", " ").replace("-", " ").strip()
+    if not normalized_id:
+        return sport_id
+
+    return normalized_id.title()
+
+
 # GET /api/v0/sports
 @router.get("", response_model=list[SportOut])  # or use "/" — both work as the router's root
-async def list_sports(session: AsyncSession = Depends(get_session)):
+async def list_sports(session: AsyncSession = Depends(get_session)) -> list[SportOut]:
     rows = (await session.execute(select(Sport))).scalars().all()
-    return [SportOut(id=s.id, name=s.name) for s in rows]
+
+    catalog: dict[str, str] = {}
+    for sport in rows:
+        catalog[sport.id] = _fallback_sport_name(sport.id, sport.name)
+
+    for sport_id, name in DEFAULT_SPORT_CATALOG:
+        catalog.setdefault(sport_id, name)
+
+    # Return a deterministic ordering for consumers
+    sorted_catalog = sorted(
+        catalog.items(), key=lambda item: (item[1].lower(), item[0])
+    )
+
+    return [SportOut(id=sport_id, name=name) for sport_id, name in sorted_catalog]

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -24,6 +24,7 @@ async def main():
             ("bowling", "Bowling"),
             ("tennis", "Tennis"),
             ("pickleball", "Pickleball"),
+            ("table_tennis", "Table Tennis"),
             ("disc_golf", "Disc Golf"),
         ]:
             if sid not in have:

--- a/backend/tests/test_sports_endpoint.py
+++ b/backend/tests/test_sports_endpoint.py
@@ -1,0 +1,112 @@
+import asyncio
+import os
+import sys
+from collections.abc import Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+
+from backend.app.db import Base, get_session
+from backend.app.models import Sport
+from backend.app.routers import sports
+
+
+@pytest.fixture()
+def sports_client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async_session_maker = sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async def init_schema() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all, tables=[Sport.__table__])
+
+    asyncio.run(init_schema())
+
+    async def override_get_session() -> Iterable[AsyncSession]:
+        async with async_session_maker() as session:
+            yield session
+
+    app = FastAPI()
+    app.include_router(sports.router, prefix="/api/v0")
+    app.dependency_overrides[get_session] = override_get_session
+
+    with TestClient(app) as client:
+        yield client, async_session_maker
+
+    app.dependency_overrides.clear()
+    asyncio.run(engine.dispose())
+
+
+def test_list_sports_includes_configured_defaults(sports_client):
+    client, session_maker = sports_client
+
+    async def seed_partial_catalog() -> None:
+        async with session_maker() as session:
+            session.add_all(
+                [
+                    Sport(id="padel", name="Padel"),
+                    Sport(id="padel_americano", name="Padel Americano"),
+                    Sport(id="bowling", name="Bowling"),
+                ]
+            )
+            await session.commit()
+
+    asyncio.run(seed_partial_catalog())
+
+    response = client.get("/api/v0/sports")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+
+    catalog = {entry["id"]: entry["name"] for entry in payload}
+
+    expected_ids = {
+        "padel",
+        "padel_americano",
+        "bowling",
+        "tennis",
+        "pickleball",
+        "table_tennis",
+        "disc_golf",
+    }
+
+    for sport_id in expected_ids:
+        assert sport_id in catalog, f"Expected sport {sport_id} to be present"
+
+    assert catalog["pickleball"] == "Pickleball"
+    assert catalog["table_tennis"] == "Table Tennis"
+    assert catalog["disc_golf"] == "Disc Golf"
+
+
+def test_list_sports_preserves_custom_entries(sports_client):
+    client, session_maker = sports_client
+
+    async def seed_custom_sport() -> None:
+        async with session_maker() as session:
+            session.add(Sport(id="custom", name="Custom Sport"))
+            await session.commit()
+
+    asyncio.run(seed_custom_sport())
+
+    response = client.get("/api/v0/sports")
+    assert response.status_code == 200
+    payload = response.json()
+    catalog = {entry["id"]: entry["name"] for entry in payload}
+
+    assert catalog["custom"] == "Custom Sport"


### PR DESCRIPTION
## Summary
- add default sport catalog fallback so /v0/sports includes supported sports even when the database is sparse
- seed table tennis during database bootstrapping
- cover the sports endpoint with tests for default catalog and custom entries

## Testing
- pytest backend/tests/test_sports_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68df67ba84a88323a28c41f7ff0cc462