### PR TITLE
Add login gating banner to record forms

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -154,6 +154,35 @@ img {
   gap: 1rem;
 }
 
+.form-banner {
+  border-radius: 8px;
+  border: 1px solid rgba(26, 115, 232, 0.25);
+  background: rgba(26, 115, 232, 0.12);
+  color: var(--color-text);
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+}
+
+.form-banner a {
+  color: var(--color-accent-blue);
+  font-weight: 600;
+}
+
+.form-banner a:hover,
+.form-banner a:focus-visible {
+  text-decoration: underline;
+}
+
+.form-disabled-wrapper {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.form-disabled-wrapper[disabled] {
+  opacity: 0.65;
+}
+
 .form-fieldset {
   border: 1px solid rgba(10, 31, 68, 0.12);
   border-radius: 8px;

--- a/apps/web/src/app/record/disc-golf/page.test.tsx
+++ b/apps/web/src/app/record/disc-golf/page.test.tsx
@@ -8,6 +8,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 import RecordDiscGolfPage from "./page";
+import { useSessionSnapshot } from "../../../lib/useSessionSnapshot";
 
 const useSearchParamsMock = vi.fn<URLSearchParams, []>();
 const pushMock = vi.fn();
@@ -33,11 +34,22 @@ vi.mock("../../../lib/useNotifications", () => ({
     notificationMocks.invalidateNotificationsCacheMock,
 }));
 
+vi.mock("../../../lib/useSessionSnapshot", () => ({
+  useSessionSnapshot: vi.fn(),
+}));
+
+const mockedUseSessionSnapshot = vi.mocked(useSessionSnapshot);
+
 const originalFetch = global.fetch;
 
 describe("RecordDiscGolfPage", () => {
   beforeEach(() => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams("mid=m1"));
+    mockedUseSessionSnapshot.mockReturnValue({
+      isAdmin: false,
+      isLoggedIn: true,
+      userId: "user-1",
+    });
   });
 
   afterEach(() => {
@@ -51,6 +63,7 @@ describe("RecordDiscGolfPage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (global as any).fetch;
     }
+    mockedUseSessionSnapshot.mockReset();
   });
 
   it("posts hole events", async () => {


### PR DESCRIPTION
## Summary
- gate the shared record form and padel page on `useSessionSnapshot`, showing a login banner, skipping player loads, and blocking submission when logged out
- style the new login banner and wrapper fieldset so anonymous sessions see disabled inputs
- update padel, disc golf, and shared record form tests to mock the session hook and assert the login-required behaviour

## Testing
- pnpm --filter @cst/web exec vitest run src/app/record/padel/page.test.tsx
- pnpm --filter @cst/web exec vitest run src/app/record/[sport]/page.test.tsx
- pnpm --filter @cst/web exec vitest run src/app/record/disc-golf/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df644f6b808323813bcd60ba72b358