### PR TITLE
Fix match metadata separators

### DIFF
--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -51,15 +51,18 @@ function normalizeMetadataSegment(value: unknown): string | undefined {
 }
 
 function formatMatchMetadata(parts: Array<string | null | undefined>): string {
-  const normalizedParts = parts
-    .map((part) => normalizeMetadataSegment(part))
-    .filter((part): part is string => Boolean(part));
+  let metadata = '';
 
-  if (!normalizedParts.length) {
-    return '';
+  for (const part of parts) {
+    const normalized = normalizeMetadataSegment(part);
+    if (!normalized) {
+      continue;
+    }
+
+    metadata = metadata ? `${metadata} · ${normalized}` : normalized;
   }
 
-  return normalizedParts.join(' · ');
+  return metadata;
 }
 
 type MatchWithOptionalRuleset = EnrichedMatch & {

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -117,19 +117,22 @@ function formatSummary(
 const PLACEHOLDER_VALUES = new Set(["", "—", "Best of —"]);
 
 function formatMatchMetadata(parts: Array<string | null | undefined>): string {
-  const normalizedParts = parts
-    .map((part) => (typeof part === "string" ? part.trim() : part))
-    .filter((part): part is string => {
-      if (!part) return false;
-      const normalized = part.trim();
-      return normalized.length > 0 && !PLACEHOLDER_VALUES.has(normalized);
-    });
+  let metadata = "";
 
-  if (!normalizedParts.length) {
-    return "";
+  for (const part of parts) {
+    if (typeof part !== "string") {
+      continue;
+    }
+
+    const normalized = part.trim();
+    if (!normalized || PLACEHOLDER_VALUES.has(normalized)) {
+      continue;
+    }
+
+    metadata = metadata ? `${metadata} · ${normalized}` : normalized;
   }
 
-  return normalizedParts.join(" · ");
+  return metadata;
 }
 
 export default async function MatchesPage(


### PR DESCRIPTION
## Summary
- ensure the home page metadata formatter skips empty segments before adding separators
- apply the same metadata joining guard on the matches page to keep separators consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6a0ee8088323a32e7da18c34785a