### PR TITLE
Use neutral focus styling for form inputs

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -98,7 +98,7 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 3px solid var(--color-accent-red);
+  outline: 3px solid var(--color-accent-blue);
   outline-offset: 2px;
 }
 
@@ -342,6 +342,12 @@ textarea {
   width: 100%;
   background-color: var(--color-surface);
   color: inherit;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--color-accent-blue);
 }
 
 textarea {


### PR DESCRIPTION
## Summary
- change the global focus outline color from red to blue so focused controls no longer resemble errors
- set focused inputs, selects, and textareas to use a blue border color while keeping red reserved for validation states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6c0d00908323b70650d2d0a32e81