### PR TITLE
Update padel player selection hints

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -238,8 +238,14 @@ describe("RecordPadelPage", () => {
     const form = saveButton.closest("form");
     expect(form).not.toBeNull();
 
-    const playerHints = await screen.findAllByText(/Add players to both sides\./i);
-    expect(playerHints).toHaveLength(2);
+    const sideAHint = await screen.findByText(
+      /Add at least one player to side A$/i,
+    );
+    expect(sideAHint).toBeInTheDocument();
+    const sideBHint = await screen.findByText(
+      /Add at least one player to side B$/i,
+    );
+    expect(sideBHint).toBeInTheDocument();
     expect(
       screen.queryByText(/Add at least one player to side B\./i),
     ).not.toBeInTheDocument();

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -425,12 +425,12 @@ export default function RecordPadelPage() {
     ? `Side A: ${sideAPlayerNames.join(", ")}`
     : showSummaryValidation
       ? "Add at least one player to side A."
-      : "Add players to both sides.";
+      : "Add at least one player to side A";
   const sideBSummaryMessage = hasSideBPlayers
     ? `Side B: ${sideBPlayerNames.join(", ")}`
     : showSummaryValidation
       ? "Add at least one player to side B."
-      : "Add players to both sides.";
+      : "Add at least one player to side B";
   const duplicatePlayersMessage = duplicatePlayerNames.length
     ? `Players cannot appear on both sides: ${duplicatePlayerNames.join(", ")}.`
     : null;


### PR DESCRIPTION
## Summary
- update the padel side summary defaults to prompt adding players to each specific side
- refresh the record padel UI copy test to assert the new helper messages

## Testing
- pnpm test -- run src/app/record/padel/page.test.tsx *(fails: unrelated leaderboard and profile vitest suites also run and currently fail)*

------
https://chatgpt.com/codex/tasks/task_e_68df6de5d2288323bef9e1474971739e