### PR TITLE
Enforce login requirement on match recording form

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -161,6 +161,20 @@ img {
   margin: 0;
 }
 
+.login-required-banner {
+  border: 1px solid rgba(26, 115, 232, 0.3);
+  border-radius: 8px;
+  background: rgba(26, 115, 232, 0.08);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  color: rgba(10, 31, 68, 0.85);
+}
+
+.login-required-banner__action {
+  justify-self: start;
+}
+
 .form-subfieldset {
   border: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- require a logged-in session before allowing match recording and redirect anonymous users to the login page
- surface an inline banner with a login link and disable all form controls when the viewer is anonymous
- add styling and tests covering the anonymous banner and 401 handling logic

## Testing
- pnpm test -- run src/app/record/[sport]/page.test.tsx *(fails: suite runs additional specs that require optional dependencies such as jspdf)*

------
https://chatgpt.com/codex/tasks/task_e_68df6be0ed94832398e854cd7ffe5967