### PR TITLE
Remove placeholder text from record date inputs

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -18,7 +18,6 @@ import { invalidateNotificationsCache } from "../../../lib/useNotifications";
 import { useLocale } from "../../../lib/LocaleContext";
 import {
   getDateExample,
-  getDatePlaceholder,
   getTimeExample,
   usesTwentyFourHourClock,
 } from "../../../lib/i18n";
@@ -766,7 +765,6 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
     [playerNameById, duplicateNameSet],
   );
   const locale = useLocale();
-  const datePlaceholder = useMemo(() => getDatePlaceholder(locale), [locale]);
   const dateExample = useMemo(() => getDateExample(locale), [locale]);
   const uses24HourTime = useMemo(
     () => usesTwentyFourHourClock(locale),
@@ -1613,7 +1611,6 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 lang={locale}
-                placeholder={datePlaceholder}
                 aria-describedby={`record-date-format ${dateLocaleHintId}`}
               />
               <span id="record-date-format" className="form-hint">

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -9,7 +9,6 @@ import { ensureTrailingSlash } from "../../../lib/routes";
 import { useLocale } from "../../../lib/LocaleContext";
 import {
   getDateExample,
-  getDatePlaceholder,
   getTimeExample,
   usesTwentyFourHourClock,
 } from "../../../lib/i18n";
@@ -513,7 +512,6 @@ export default function RecordPadelPage() {
     setSetErrors((prev) => [...prev, ""]);
   };
 
-  const datePlaceholder = useMemo(() => getDatePlaceholder(locale), [locale]);
   const dateExample = useMemo(() => getDateExample(locale), [locale]);
   const uses24HourTime = useMemo(
     () => usesTwentyFourHourClock(locale),
@@ -670,7 +668,6 @@ export default function RecordPadelPage() {
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 lang={locale}
-                placeholder={datePlaceholder}
                 aria-describedby={`padel-date-format ${dateLocaleHintId}`}
               />
               <span id="padel-date-format" className="form-hint">


### PR DESCRIPTION
## Summary
- stop supplying hard-coded date placeholders on record forms so browsers can localize the control
- continue surfacing locale-aware examples alongside the inputs for clarity

## Testing
- pnpm --filter @cst/web lint *(fails: pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df6e4dc3508323a4ab64cbb7aafd30