### PR TITLE
Add contextual leaderboard back navigation

### DIFF
--- a/apps/web/src/messages/en-AU.json
+++ b/apps/web/src/messages/en-AU.json
@@ -57,6 +57,16 @@
       "recordSportMatch": "Record a {sport} match"
     }
   },
+  "BackLink": {
+    "back": "\u2190 Back",
+    "home": "\u2190 Back to home",
+    "matches": "\u2190 Back to matches",
+    "players": "\u2190 Back to players",
+    "tournaments": "\u2190 Back to tournaments",
+    "record": "\u2190 Back to recording",
+    "leaderboards": "\u2190 Back to leaderboards",
+    "profile": "\u2190 Back to profile"
+  },
   "Matches": {
     "title": "Matches",
     "emptyInitial": "No matches yet.",

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -57,6 +57,16 @@
       "recordSportMatch": "Record a {sport} match"
     }
   },
+  "BackLink": {
+    "back": "\u2190 Back",
+    "home": "\u2190 Back to home",
+    "matches": "\u2190 Back to matches",
+    "players": "\u2190 Back to players",
+    "tournaments": "\u2190 Back to tournaments",
+    "record": "\u2190 Back to recording",
+    "leaderboards": "\u2190 Back to leaderboards",
+    "profile": "\u2190 Back to profile"
+  },
   "Matches": {
     "title": "Matches",
     "emptyInitial": "No matches yet.",

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -57,6 +57,16 @@
       "recordSportMatch": "Registrar un partido de {sport}"
     }
   },
+  "BackLink": {
+    "back": "\u2190 Volver",
+    "home": "\u2190 Volver al inicio",
+    "matches": "\u2190 Volver a partidos",
+    "players": "\u2190 Volver a jugadores",
+    "tournaments": "\u2190 Volver a torneos",
+    "record": "\u2190 Volver al registro",
+    "leaderboards": "\u2190 Volver a clasificaciones",
+    "profile": "\u2190 Volver al perfil"
+  },
   "Matches": {
     "title": "Partidos",
     "emptyInitial": "Todavía no hay partidos.",


### PR DESCRIPTION
## Summary
- add a contextual back link on the leaderboard page that honours the referrer and hides when unavailable
- provide translated back link strings for supported locales
- cover the new behaviour with vitest cases

## Testing
- pnpm vitest run -t "links back to matches when navigated from the matches page" src/app/leaderboard/leaderboard.test.tsx
- pnpm vitest run -t "falls back to a generic back label for unknown referrers" src/app/leaderboard/leaderboard.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68df6f51ade48323ba6fe0d648611ebe