### PR TITLE
Add i18n translations for record forms

### DIFF
--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -13,6 +13,7 @@ import {
 import { flushSync } from "react-dom";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { apiFetch, type ApiError } from "../../../lib/api";
 import { invalidateMatchesCache } from "../../../lib/useApiSWR";
 import { invalidateNotificationsCache } from "../../../lib/useNotifications";
@@ -769,6 +770,8 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
     [playerNameById, duplicateNameSet],
   );
   const locale = useLocale();
+  const commonT = useTranslations("Common");
+  const recordT = useTranslations("Record");
   const dateExample = useMemo(() => getDateExample(locale), [locale]);
   const uses24HourTime = useMemo(
     () => usesTwentyFourHourClock(locale),
@@ -1681,11 +1684,11 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
             </label>
           </div>
           <label className="form-field" htmlFor="record-location">
-            <span className="form-label">Location</span>
+            <span className="form-label">{recordT("fields.location.label")}</span>
             <input
               id="record-location"
               type="text"
-              placeholder="Location"
+              placeholder={recordT("fields.location.placeholder")}
               value={location}
               onChange={(e) => setLocation(e.target.value)}
             />
@@ -1701,11 +1704,12 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
               onChange={(e) => setIsFriendly(e.target.checked)}
               aria-describedby={friendlyHintId}
             />
-            <span className="form-label">Mark as friendly</span>
+            <span className="form-label">
+              {recordT("fields.friendly.label")}
+            </span>
           </label>
           <p id={friendlyHintId} className="form-hint">
-            Friendly matches appear in match history but do not impact leaderboards
-            or player statistics.
+            {recordT("fields.friendly.hint")}
           </p>
         </fieldset>
 
@@ -2222,7 +2226,9 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
         )}
 
         <button type="submit" disabled={isAnonymous || submitting}>
-          {submitting ? "Saving..." : "Save"}
+          {submitting
+            ? commonT("status.saving")
+            : commonT("actions.save")}
         </button>
       </form>
     </main>

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { apiFetch } from "../../../lib/api";
 import { invalidateMatchesCache } from "../../../lib/useApiSWR";
 import { invalidateNotificationsCache } from "../../../lib/useNotifications";
@@ -340,6 +341,9 @@ export default function RecordPadelPage() {
   const [saving, setSaving] = useState(false);
   const [showSummaryValidation, setShowSummaryValidation] = useState(false);
   const locale = useLocale();
+  const commonT = useTranslations("Common");
+  const recordT = useTranslations("Record");
+  const recordPadelT = useTranslations("Record.padel");
   const [success, setSuccess] = useState(false);
   const saveSummaryId = useId();
 
@@ -698,11 +702,11 @@ export default function RecordPadelPage() {
             </label>
           </div>
           <label className="form-field" htmlFor="padel-location">
-            <span className="form-label">Location</span>
+            <span className="form-label">{recordT("fields.location.label")}</span>
             <input
               id="padel-location"
               type="text"
-              placeholder="Location"
+              placeholder={recordT("fields.location.placeholder")}
               value={location}
               onChange={(e) => setLocation(e.target.value)}
             />
@@ -718,11 +722,12 @@ export default function RecordPadelPage() {
               onChange={(e) => setIsFriendly(e.target.checked)}
               aria-describedby="padel-friendly-hint"
             />
-            <span className="form-label">Mark as friendly</span>
+            <span className="form-label">
+              {recordT("fields.friendly.label")}
+            </span>
           </label>
           <p id="padel-friendly-hint" className="form-hint">
-            Friendly matches appear in match history but do not impact leaderboards
-            or player statistics.
+            {recordT("fields.friendly.hint")}
           </p>
         </fieldset>
 
@@ -918,14 +923,14 @@ export default function RecordPadelPage() {
                         htmlFor={`padel-set-${idx + 1}-tiebreak-a`}
                       >
                         <span className="form-label">
-                          Tie-break points team A
+                          {recordPadelT("tieBreak.labelTeamA")}
                         </span>
                         <input
                           id={`padel-set-${idx + 1}-tiebreak-a`}
                           type="number"
                           min="0"
                           step="1"
-                          placeholder="Tie-break A"
+                          placeholder={recordPadelT("tieBreak.placeholderTeamA")}
                           value={s.tieBreakA}
                           onChange={(e) =>
                             handleTieBreakChange(idx, "A", e.target.value)
@@ -940,14 +945,14 @@ export default function RecordPadelPage() {
                         htmlFor={`padel-set-${idx + 1}-tiebreak-b`}
                       >
                         <span className="form-label">
-                          Tie-break points team B
+                          {recordPadelT("tieBreak.labelTeamB")}
                         </span>
                         <input
                           id={`padel-set-${idx + 1}-tiebreak-b`}
                           type="number"
                           min="0"
                           step="1"
-                          placeholder="Tie-break B"
+                          placeholder={recordPadelT("tieBreak.placeholderTeamB")}
                           value={s.tieBreakB}
                           onChange={(e) =>
                             handleTieBreakChange(idx, "B", e.target.value)
@@ -970,14 +975,14 @@ export default function RecordPadelPage() {
           })}
         </div>
         <p id="padel-add-set-hint" className="form-hint">
-          Add another set if the match extended beyond the recorded sets.
+          {recordPadelT("hints.addSet")}
         </p>
         <button
           type="button"
           onClick={addSet}
           aria-describedby="padel-add-set-hint"
         >
-          Add Set
+          {recordT("actions.addSet")}
         </button>
 
         {globalError && (
@@ -988,12 +993,11 @@ export default function RecordPadelPage() {
 
         {success && (
           <p role="status" className="success">
-            Match recorded!
+            {recordT("messages.matchRecorded")}
           </p>
         )}
         <p id="padel-save-hint" className="form-hint">
-          Save once each side has at least one player and completed sets are
-          entered as needed.
+          {recordT("hints.save")}
         </p>
         <div id={saveSummaryId} aria-live="polite">
           <p
@@ -1043,7 +1047,7 @@ export default function RecordPadelPage() {
             cursor: buttonCursor,
           }}
         >
-          {saving ? "Saving..." : "Save"}
+          {saving ? commonT("status.saving") : commonT("actions.save")}
         </button>
       </form>
     </main>

--- a/apps/web/src/messages/en-AU.json
+++ b/apps/web/src/messages/en-AU.json
@@ -8,7 +8,8 @@
       "logout": "Logout",
       "loadMoreMatches": "Load more matches",
       "viewAllMatches": "View all matches",
-      "moreInfo": "More info"
+      "moreInfo": "More info",
+      "save": "Save"
     },
     "status": {
       "loading": "Loading…",
@@ -16,7 +17,8 @@
       "updatingSports": "Updating sports…",
       "loadingSports": "Loading sports…",
       "updatingMatches": "Updating matches…",
-      "loadingRecentMatches": "Loading recent matches…"
+      "loadingRecentMatches": "Loading recent matches…",
+      "saving": "Saving…"
     },
     "errors": {
       "loadMoreMatches": "Unable to load more matches. Please try again."
@@ -102,5 +104,37 @@
   "NotFound": {
     "title": "Page not found",
     "returnHome": "Return home"
+  },
+  "Record": {
+    "actions": {
+      "addSet": "Add Set"
+    },
+    "fields": {
+      "location": {
+        "label": "Location",
+        "placeholder": "Location"
+      },
+      "friendly": {
+        "label": "Mark as friendly",
+        "hint": "Friendly matches appear in match history but do not impact leaderboards or player statistics."
+      }
+    },
+    "hints": {
+      "save": "Save once each side has at least one player and completed sets are entered as needed."
+    },
+    "messages": {
+      "matchRecorded": "Match recorded!"
+    },
+    "padel": {
+      "hints": {
+        "addSet": "Add another set if the match extended beyond the recorded sets."
+      },
+      "tieBreak": {
+        "labelTeamA": "Tie-break points team A",
+        "labelTeamB": "Tie-break points team B",
+        "placeholderTeamA": "Tie-break A",
+        "placeholderTeamB": "Tie-break B"
+      }
+    }
   }
 }

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -8,7 +8,8 @@
       "logout": "Logout",
       "loadMoreMatches": "Load more matches",
       "viewAllMatches": "View all matches",
-      "moreInfo": "More info"
+      "moreInfo": "More info",
+      "save": "Save"
     },
     "status": {
       "loading": "Loading…",
@@ -16,7 +17,8 @@
       "updatingSports": "Updating sports…",
       "loadingSports": "Loading sports…",
       "updatingMatches": "Updating matches…",
-      "loadingRecentMatches": "Loading recent matches…"
+      "loadingRecentMatches": "Loading recent matches…",
+      "saving": "Saving…"
     },
     "errors": {
       "loadMoreMatches": "Unable to load more matches. Please try again."
@@ -102,5 +104,37 @@
   "NotFound": {
     "title": "Page not found",
     "returnHome": "Return home"
+  },
+  "Record": {
+    "actions": {
+      "addSet": "Add Set"
+    },
+    "fields": {
+      "location": {
+        "label": "Location",
+        "placeholder": "Location"
+      },
+      "friendly": {
+        "label": "Mark as friendly",
+        "hint": "Friendly matches appear in match history but do not impact leaderboards or player statistics."
+      }
+    },
+    "hints": {
+      "save": "Save once each side has at least one player and completed sets are entered as needed."
+    },
+    "messages": {
+      "matchRecorded": "Match recorded!"
+    },
+    "padel": {
+      "hints": {
+        "addSet": "Add another set if the match extended beyond the recorded sets."
+      },
+      "tieBreak": {
+        "labelTeamA": "Tie-break points team A",
+        "labelTeamB": "Tie-break points team B",
+        "placeholderTeamA": "Tie-break A",
+        "placeholderTeamB": "Tie-break B"
+      }
+    }
   }
 }

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -8,7 +8,8 @@
       "logout": "Cerrar sesión",
       "loadMoreMatches": "Cargar más partidos",
       "viewAllMatches": "Ver todos los partidos",
-      "moreInfo": "Más información"
+      "moreInfo": "Más información",
+      "save": "Guardar"
     },
     "status": {
       "loading": "Cargando…",
@@ -16,7 +17,8 @@
       "updatingSports": "Actualizando deportes…",
       "loadingSports": "Cargando deportes…",
       "updatingMatches": "Actualizando partidos…",
-      "loadingRecentMatches": "Cargando partidos recientes…"
+      "loadingRecentMatches": "Cargando partidos recientes…",
+      "saving": "Guardando…"
     },
     "errors": {
       "loadMoreMatches": "No se pueden cargar más partidos. Inténtalo de nuevo."
@@ -102,5 +104,37 @@
   "NotFound": {
     "title": "Página no encontrada",
     "returnHome": "Volver al inicio"
+  },
+  "Record": {
+    "actions": {
+      "addSet": "Añadir set"
+    },
+    "fields": {
+      "location": {
+        "label": "Ubicación",
+        "placeholder": "Ubicación"
+      },
+      "friendly": {
+        "label": "Marcar como amistoso",
+        "hint": "Los partidos amistosos aparecen en el historial pero no afectan a las clasificaciones ni a las estadísticas de los jugadores."
+      }
+    },
+    "hints": {
+      "save": "Guarda cuando cada lado tenga al menos un jugador y se hayan introducido los sets completados necesarios."
+    },
+    "messages": {
+      "matchRecorded": "¡Partido registrado!"
+    },
+    "padel": {
+      "hints": {
+        "addSet": "Añade otro set si el partido se prolongó más allá de los sets registrados."
+      },
+      "tieBreak": {
+        "labelTeamA": "Puntos de desempate equipo A",
+        "labelTeamB": "Puntos de desempate equipo B",
+        "placeholderTeamA": "Desempate A",
+        "placeholderTeamB": "Desempate B"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use next-intl translations for record sport form and padel record UI labels
- add shared copy for record form actions and hints across supported locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df7019351083238bf00f3eb22ce186