### PR TITLE
Add guidance for empty player views

### DIFF
--- a/apps/web/src/app/players/[id]/NoMatchesGuidance.tsx
+++ b/apps/web/src/app/players/[id]/NoMatchesGuidance.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+interface NoMatchesGuidanceProps {
+  className?: string;
+}
+
+export default function NoMatchesGuidance({
+  className,
+}: NoMatchesGuidanceProps) {
+  const classes = ["text-gray-600", className].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <p className={classes}>
+      No matches yet. {" "}
+      <Link className="underline" href="/record">
+        Record a match
+      </Link>{" "}
+      to see timeline and summaries.
+    </p>
+  );
+}

--- a/apps/web/src/app/players/[id]/PlayerCharts.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.tsx
@@ -6,6 +6,7 @@ import RankingHistoryChart, { RankingPoint } from '../../../components/charts/Ra
 import MatchHeatmap, { HeatmapDatum } from '../../../components/charts/MatchHeatmap';
 import { useLocale, useTimeZone } from '../../../lib/LocaleContext';
 import { formatDate } from '../../../lib/i18n';
+import NoMatchesGuidance from './NoMatchesGuidance';
 
 interface EnrichedMatch {
   playedAt: string | null;
@@ -76,7 +77,7 @@ export default function PlayerCharts({ matches }: { matches: EnrichedMatch[] }) 
         {hasMatches ? (
           <WinRateChart data={winRateData} />
         ) : (
-          <p className="text-sm text-gray-600">No matches found.</p>
+          <NoMatchesGuidance className="text-sm" />
         )}
       </div>
       <div>

--- a/apps/web/src/app/players/[id]/page.sections.test.tsx
+++ b/apps/web/src/app/players/[id]/page.sections.test.tsx
@@ -231,9 +231,12 @@ describe("PlayerPage optional sections", () => {
     expect(
       screen.queryByRole("heading", { name: "Matches" })
     ).not.toBeInTheDocument();
+    const guidanceMatcher = (_: string, element?: Element | null) =>
+      element?.textContent?.startsWith("No matches yet.") ?? false;
+    expect(screen.getByText(guidanceMatcher)).toBeInTheDocument();
     expect(
-      screen.getByText("No matches found.")
-    ).toBeInTheDocument();
+      screen.getAllByRole("link", { name: "Record a match" }).length
+    ).toBeGreaterThanOrEqual(1);
     expect(
       screen.queryByRole("heading", { name: "Recent Opponents" })
     ).not.toBeInTheDocument();
@@ -265,8 +268,6 @@ describe("PlayerPage optional sections", () => {
     expect(
       screen.queryByRole("heading", { name: "Season Summary" })
     ).not.toBeInTheDocument();
-    expect(
-      screen.getAllByText("No matches found.").length
-    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(guidanceMatcher).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { apiFetch, fetchClubs, withAbsolutePhotoUrl } from "../../../lib/api";
 import PlayerCharts from "./PlayerCharts";
+import NoMatchesGuidance from "./NoMatchesGuidance";
 import PlayerComments from "./comments-client";
 import PlayerDetailErrorBoundary, {
   type PlayerDetailError,
@@ -773,7 +774,7 @@ export default async function PlayerPage({
                   </ul>
                 </section>
               ) : (
-                <p>No matches found.</p>
+                <NoMatchesGuidance />
               )
             ) : seasons.length ? (
               <section>
@@ -790,7 +791,7 @@ export default async function PlayerPage({
                 </ul>
               </section>
             ) : (
-              <p>No matches found.</p>
+              <NoMatchesGuidance />
             )}
 
             {recentOpponents.length ? (


### PR DESCRIPTION
## Summary
- add a reusable guidance component that links to the match recording page when a player has no matches
- surface the guidance in the player timeline, season summary, and performance charts when there are no recorded matches
- update the player sections test expectations to cover the new guidance copy and link

## Testing
- pnpm test src/app/players/[id]/page.sections.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df70e004d08323ac26f03c01b299d9