### PR TITLE
Add client directive to NoMatchesGuidance component

### DIFF
--- a/apps/web/src/app/players/[id]/NoMatchesGuidance.tsx
+++ b/apps/web/src/app/players/[id]/NoMatchesGuidance.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from "next/link";
 
 interface NoMatchesGuidanceProps {


### PR DESCRIPTION
## Summary
- add the `use client` directive to the NoMatchesGuidance component so it can be imported by other client modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df73e1ebcc8323b1b965be2c44936f