### PR TITLE
Restore leaderboard back link after SPA navigation

### DIFF
--- a/apps/web/src/lib/navigation-history.ts
+++ b/apps/web/src/lib/navigation-history.ts
@@ -1,0 +1,2 @@
+export const CURRENT_ROUTE_STORAGE_KEY = "__cst_current_route";
+export const PREVIOUS_ROUTE_STORAGE_KEY = "__cst_previous_route";


### PR DESCRIPTION
## Summary
- inject a before-interactive navigation tracker script that records the last route in session storage
- update the leaderboard back link effect to read the tracked route (or fall back to the document referrer) before rendering
- add shared navigation history storage keys for reuse

## Testing
- `pnpm vitest run src/app/leaderboard/leaderboard.test.tsx` *(fails: two existing tests rely on overflow and infinite scroll interactions that did not reproduce in this headless run)*

------
https://chatgpt.com/codex/tasks/task_e_68df73fe89bc8323863ccac6489b3cf1