### PR TITLE
Improve keyboard accessibility for cards and forms

### DIFF
--- a/apps/web/src/app/admin/matches/page.tsx
+++ b/apps/web/src/app/admin/matches/page.tsx
@@ -179,23 +179,35 @@ export default function AdminMatchesPage() {
       )}
       <ul className="match-list">
         {matches.map((m) => (
-          <li key={m.id} className="card match-item">
-            <MatchParticipants sides={m.participants} style={{ fontWeight: 500 }} />
-            <div className="match-meta">
-              {formatSummary(m.summary)}
-              {m.summary ? " · " : ""}
-              {m.sport} · Best of {m.bestOf ?? "—"} ·{" "}
-              {m.playedAt ? formatMatchDate(m.playedAt) : "—"} ·{" "}
-              {m.location ?? "—"}
-            </div>
-            <div>
-              <Link href={`/matches/${m.id}`}>More info</Link>
-              <button
-                onClick={() => handleDelete(m.id)}
-                style={{ marginLeft: 8 }}
+          <li key={m.id} className="match-list__item">
+            <div className="card match-item">
+              <Link
+                href={`/matches/${m.id}`}
+                className="match-item--link"
+                tabIndex={0}
               >
-                Delete
-              </button>
+                <MatchParticipants
+                  sides={m.participants}
+                  style={{ fontWeight: 500 }}
+                />
+                <div className="match-meta">
+                  {formatSummary(m.summary)}
+                  {m.summary ? " · " : ""}
+                  {m.sport} · Best of {m.bestOf ?? "—"} · {" "}
+                  {m.playedAt ? formatMatchDate(m.playedAt) : "—"} · {" "}
+                  {m.location ?? "—"}
+                </div>
+                <span className="match-item__cta">More info</span>
+              </Link>
+              <div className="match-item__actions">
+                <button
+                  onClick={() => handleDelete(m.id)}
+                  className="link-button"
+                  type="button"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
           </li>
         ))}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -941,6 +941,10 @@ textarea {
   gap: 0.75rem;
 }
 
+.match-list__item {
+  list-style: none;
+}
+
 .player-detail__view-nav {
   display: flex;
   flex-wrap: wrap;
@@ -996,13 +1000,35 @@ textarea {
 }
 
 .player-list__item {
+  list-style: none;
+}
+
+.player-list__card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   padding: 0.75rem;
   background: var(--color-surface);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+}
+
+.player-list__card-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+  outline: none;
+}
+
+.player-list__card-link:hover {
+  text-decoration: underline;
+}
+
+.player-list__card-link:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 3px;
 }
 
 .player-list__row {
@@ -1013,14 +1039,8 @@ textarea {
   gap: 0.5rem;
 }
 
-.player-list__link {
+.player-list__name {
   font-weight: 600;
-  text-decoration: none;
-  color: inherit;
-}
-
-.player-list__link:hover {
-  text-decoration: underline;
 }
 
 .player-list__stats {
@@ -1119,7 +1139,40 @@ textarea {
 }
 
 .match-item {
-  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.match-item--link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+  outline: none;
+}
+
+.match-item--link:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 3px;
+}
+
+.match-item__cta {
+  font-weight: 600;
+  color: var(--color-accent-blue);
+  text-decoration: underline;
+  align-self: flex-start;
+}
+
+.match-item--link:hover .match-item__cta {
+  text-decoration: none;
+}
+
+.match-item__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .player-name {

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -545,19 +545,21 @@ export default function HomePageClient({
             <p className="sr-only">{commonT('status.loadingRecentMatches')}</p>
             <ul className="match-list">
               {Array.from({ length: 3 }).map((_, i) => (
-                <li key={`match-skeleton-${i}`} className="card match-item">
-                  <div
-                    className="skeleton"
-                    style={{ width: '60%', height: '1em', marginBottom: '4px' }}
-                  />
-                  <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
+                <li key={`match-skeleton-${i}`} className="match-list__item">
+                  <div className="card match-item" aria-hidden>
+                    <div
+                      className="skeleton"
+                      style={{ width: '60%', height: '1em', marginBottom: '4px' }}
+                    />
+                    <div className="skeleton" style={{ width: '40%', height: '0.8em' }} />
+                  </div>
                 </li>
               ))}
             </ul>
           </div>
         ) : matches.length === 0 ? (
           matchError ? (
-            <p role="alert">
+            <p role="alert" aria-live="assertive">
               {homeT('matchesError')}{' '}
               <button
                 type="button"
@@ -586,17 +588,19 @@ export default function HomePageClient({
               ]);
 
               return (
-                <li key={m.id} className="card match-item">
-                  <MatchParticipants
-                    sides={Object.values(m.players)}
-                    style={{ fontWeight: 500 }}
-                  />
-                  <div className="match-meta">{metadataText || '—'}</div>
-                  <div>
-                    <Link href={ensureTrailingSlash(`/matches/${m.id}`)}>
-                      {commonT('match.details')}
-                    </Link>
-                  </div>
+                <li key={m.id} className="match-list__item">
+                  <Link
+                    href={ensureTrailingSlash(`/matches/${m.id}`)}
+                    className="card match-item match-item--link"
+                    tabIndex={0}
+                  >
+                    <MatchParticipants
+                      sides={Object.values(m.players)}
+                      style={{ fontWeight: 500 }}
+                    />
+                    <div className="match-meta">{metadataText || '—'}</div>
+                    <span className="match-item__cta">{commonT('match.details')}</span>
+                  </Link>
                 </li>
               );
             })}

--- a/apps/web/src/app/matches/page.tsx
+++ b/apps/web/src/app/matches/page.tsx
@@ -212,18 +212,22 @@ export default async function MatchesPage(
                 .map(([, players]) => players);
 
               return (
-                <li key={m.id} className="card match-item">
-                  <MatchParticipants sides={participantSides} />
-                  <div className="match-meta">
-                    {summaryText}
-                    {summaryText && metadataText ? " · " : ""}
-                    {metadataText}
-                  </div>
-                  <div>
-                    <Link href={ensureTrailingSlash(`/matches/${m.id}`)}>
+                <li key={m.id} className="match-list__item">
+                  <Link
+                    href={ensureTrailingSlash(`/matches/${m.id}`)}
+                    className="card match-item match-item--link"
+                    tabIndex={0}
+                  >
+                    <MatchParticipants sides={participantSides} />
+                    <div className="match-meta">
+                      {summaryText}
+                      {summaryText && metadataText ? " · " : ""}
+                      {metadataText}
+                    </div>
+                    <span className="match-item__cta">
                       {commonT('actions.moreInfo')}
-                    </Link>
-                  </div>
+                    </span>
+                  </Link>
                 </li>
               );
             })}

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -430,69 +430,81 @@ export default function PlayersPage() {
               <ul className="player-list">
                 {filteredPlayers.map((p) => (
                   <li key={p.id} className="player-list__item">
-                    <div className="player-list__row">
-                      <Link href={`/players/${p.id}`} className="player-list__link">
-                        <PlayerName player={p} />
+                    <div className="player-list__card">
+                      <Link
+                        href={`/players/${p.id}`}
+                        className="player-list__card-link"
+                        tabIndex={0}
+                      >
+                        <div className="player-list__row">
+                          <span className="player-list__name">
+                            <PlayerName player={p} />
+                          </span>
+                          <span className="player-list__stats">
+                            {(() => {
+                              const summary = p.matchSummary;
+                              if (!summary || summary.total <= 0) {
+                                return "No matches yet";
+                              }
+                              return formatMatchRecord(summary);
+                            })()}
+                          </span>
+                          {p.hidden && (
+                            <span className="player-list__status" aria-label="Hidden player">
+                              Hidden
+                            </span>
+                          )}
+                        </div>
                       </Link>
-                      <span className="player-list__stats">
-                        {(() => {
-                          const summary = p.matchSummary;
-                          if (!summary || summary.total <= 0) {
-                            return "No matches yet";
-                          }
-                          return formatMatchRecord(summary);
-                        })()}
-                      </span>
-                      {p.hidden && (
-                        <span className="player-list__status" aria-label="Hidden player">
-                          Hidden
-                        </span>
+                      {admin && (
+                        <div
+                          className="player-list__admin"
+                          role="group"
+                          aria-label={`Admin controls for ${p.name}`}
+                        >
+                          <label className="player-list__label" htmlFor={`country-${p.id}`}>
+                            Country:
+                          </label>
+                          <select
+                            id={`country-${p.id}`}
+                            aria-label={`Country for ${p.name}`}
+                            value={p.country_code ?? ""}
+                            onChange={(e) => handleCountryChange(p, e.target.value)}
+                            disabled={updatingLocation === p.id}
+                            className="input player-list__select"
+                          >
+                            <option value="">Unspecified</option>
+                            {COUNTRY_OPTIONS.map((option) => (
+                              <option key={option.code} value={option.code}>
+                                {option.name}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            className="player-list__action player-list__toggle"
+                            onClick={() => handleToggleVisibility(p)}
+                            disabled={updatingVisibility === p.id}
+                          >
+                            {p.hidden ? "Unhide" : "Hide"}
+                          </button>
+                          <button
+                            type="button"
+                            className="player-list__action player-list__delete"
+                            onClick={() => handleDelete(p.id)}
+                          >
+                            Delete
+                          </button>
+                          <button
+                            type="button"
+                            className="player-list__action player-list__delete"
+                            onClick={() => handleDelete(p.id, true)}
+                          >
+                            Hard delete
+                          </button>
+                        </div>
                       )}
                     </div>
-                    {admin && (
-                      <div className="player-list__admin">
-                        <label className="player-list__label" htmlFor={`country-${p.id}`}>
-                          Country:
-                        </label>
-                        <select
-                          id={`country-${p.id}`}
-                          aria-label={`Country for ${p.name}`}
-                          value={p.country_code ?? ""}
-                          onChange={(e) => handleCountryChange(p, e.target.value)}
-                          disabled={updatingLocation === p.id}
-                          className="input player-list__select"
-                        >
-                          <option value="">Unspecified</option>
-                          {COUNTRY_OPTIONS.map((option) => (
-                            <option key={option.code} value={option.code}>
-                              {option.name}
-                            </option>
-                          ))}
-                        </select>
-                        <button
-                          type="button"
-                          className="player-list__action player-list__toggle"
-                          onClick={() => handleToggleVisibility(p)}
-                          disabled={updatingVisibility === p.id}
-                        >
-                          {p.hidden ? "Unhide" : "Hide"}
-                        </button>
-                        <button
-                          type="button"
-                          className="player-list__action player-list__delete"
-                          onClick={() => handleDelete(p.id)}
-                        >
-                          Delete
-                        </button>
-                        <button
-                          type="button"
-                          className="player-list__action player-list__delete"
-                          onClick={() => handleDelete(p.id, true)}
-                        >
-                          Hard delete
-                        </button>
-                      </div>
-                    )}
                   </li>
                 ))}
               </ul>
@@ -518,7 +530,12 @@ export default function PlayersPage() {
             />
           </div>
           {showNameError && (
-            <div id={nameInputErrorId} className="text-red-500 mt-2" role="alert">
+            <div
+              id={nameInputErrorId}
+              className="text-red-500 mt-2"
+              role="alert"
+              aria-live="assertive"
+            >
               Name must be 1-50 characters and contain only letters,
               numbers, spaces, hyphens, or apostrophes.
             </div>
@@ -562,7 +579,7 @@ export default function PlayersPage() {
         </div>
       )}
       {error && !playersLoadError && (
-        <div className="text-red-500 mt-2" role="alert">
+        <div className="text-red-500 mt-2" role="alert" aria-live="assertive">
           {error}
         </div>
       )}
@@ -575,29 +592,31 @@ function PlayerListSkeleton({ count = 6 }: { count?: number }) {
     <ul className="player-list" aria-hidden>
       {Array.from({ length: count }).map((_, index) => (
         <li key={`player-skeleton-${index}`} className="player-list__item">
-          <div className="player-list__row">
-            <span
-              className="skeleton"
-              style={{ width: "45%", maxWidth: "220px", height: "1rem" }}
-            />
-            <span
-              className="skeleton"
-              style={{ width: "30%", maxWidth: "140px", height: "0.8rem" }}
-            />
-          </div>
-          <div className="player-list__row" style={{ gap: "0.35rem" }}>
-            <span
-              className="skeleton"
-              style={{ width: "28%", maxWidth: "120px", height: "0.75rem" }}
-            />
-            <span
-              className="skeleton"
-              style={{ width: "22%", maxWidth: "100px", height: "0.75rem" }}
-            />
-            <span
-              className="skeleton"
-              style={{ width: "18%", maxWidth: "80px", height: "0.75rem" }}
-            />
+          <div className="player-list__card" aria-hidden>
+            <div className="player-list__row">
+              <span
+                className="skeleton"
+                style={{ width: "45%", maxWidth: "220px", height: "1rem" }}
+              />
+              <span
+                className="skeleton"
+                style={{ width: "30%", maxWidth: "140px", height: "0.8rem" }}
+              />
+            </div>
+            <div className="player-list__row" style={{ gap: "0.35rem" }}>
+              <span
+                className="skeleton"
+                style={{ width: "28%", maxWidth: "120px", height: "0.75rem" }}
+              />
+              <span
+                className="skeleton"
+                style={{ width: "22%", maxWidth: "100px", height: "0.75rem" }}
+              />
+              <span
+                className="skeleton"
+                style={{ width: "18%", maxWidth: "80px", height: "0.75rem" }}
+              />
+            </div>
           </div>
         </li>
       ))}

--- a/apps/web/src/app/record/[sport]/RecordSportForm.tsx
+++ b/apps/web/src/app/record/[sport]/RecordSportForm.tsx
@@ -1781,7 +1781,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
                       </div>
                     </div>
                     {entryErrorMessage && (
-                      <p className="error" role="alert">
+                      <p className="error" role="alert" aria-live="assertive">
                         {entryErrorMessage}
                       </p>
                     )}
@@ -2097,6 +2097,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
                 <p
                   className="form-hint error"
                   role="alert"
+                  aria-live="assertive"
                   id={duplicatePlayersHintId}
                 >
                   Duplicate player names returned: {duplicatePlayerNames.join(", ")}. Each
@@ -2220,7 +2221,7 @@ export default function RecordSportForm({ sportId }: RecordSportFormProps) {
         )}
 
         {error && (
-          <p role="alert" className="error">
+          <p role="alert" className="error" aria-live="assertive">
             {error}
           </p>
         )}


### PR DESCRIPTION
## Summary
- wrap player and match list cards in keyboard-focusable links and refresh styling to show focus states
- update admin match cards and record form alerts to use accessible semantics and aria-live feedback
- ensure match and player form errors announce changes for assistive technologies

## Testing
- `pnpm lint` *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df749eacd483239068172aa1d368ae