### PR TITLE
Preserve leaderboard back link across query updates

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -314,8 +314,12 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
 
         const refPath = canonicalizePathname(candidate.pathname || "/");
         const currentPath = canonicalizePathname(currentUrl.pathname || "/");
+        const refSearch = candidate.search ?? "";
+        const currentSearch = currentUrl.search ?? "";
+        const refHash = candidate.hash ?? "";
+        const currentHash = currentUrl.hash ?? "";
 
-        if (refPath === currentPath) {
+        if (refPath === currentPath && refSearch === currentSearch && refHash === currentHash) {
           return prev ? null : prev;
         }
 


### PR DESCRIPTION
## Summary
- ensure the leaderboard back link persists when only the query string changes
- compare both the canonicalized path and URL search/hash segments before clearing the stored backlink

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7721ca148323b7ccfb40bd07c464