### PR TITLE
Format leaderboard ratings with decimals

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -266,7 +266,7 @@ describe("Leaderboard", () => {
     });
 
     const select = await screen.findByRole("combobox", {
-      name: /select a sport/i,
+      name: /more sports/i,
     });
     expect(select).toHaveValue("padel");
 
@@ -421,6 +421,10 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(screen.getByText("Alice")).toBeInTheDocument();
+    const aliceRatingCell = await screen.findByRole("cell", {
+      name: "1,200.0",
+    });
+    expect(aliceRatingCell).toHaveAttribute("title", "1200");
     expect(screen.queryByText("Cara")).not.toBeInTheDocument();
 
     await act(async () => {

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -545,6 +545,17 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     [],
   );
 
+  const formatRating = useCallback(
+    (value?: number | null) =>
+      value == null
+        ? "—"
+        : value.toLocaleString(undefined, {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 1,
+          }),
+    [],
+  );
+
   const formatDecimal = useCallback(
     (value?: number | null) =>
       value == null
@@ -1843,8 +1854,11 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                     {sport === ALL_SPORTS && (
                       <td style={cellStyle}>{rowSportName}</td>
                     )}
-                    <td style={cellStyle}>
-                      {row.rating != null ? Math.round(row.rating) : "—"}
+                    <td
+                      style={cellStyle}
+                      title={row.rating != null ? row.rating.toString() : undefined}
+                    >
+                      {formatRating(row.rating)}
                     </td>
                     {isBowling ? (
                       <>


### PR DESCRIPTION
## Summary
- display leaderboard ratings with one decimal place and add a tooltip showing the precise value
- update leaderboard tests to expect the decimal formatting and align with the overflow select label

## Testing
- pnpm vitest run leaderboard

------
https://chatgpt.com/codex/tasks/task_e_68df767a3bf08323aef726c5ad226dd1