### PR TITLE
Fix players page test selectors for renamed player card link

### DIFF
--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -115,7 +115,7 @@ describe('PlayersPage sorting', () => {
 
     const names = Array.from(
       container.querySelectorAll<HTMLAnchorElement>(
-        '.player-list__item .player-list__link',
+        '.player-list__item .player-list__card-link',
       ),
     ).map((link) => link.textContent?.trim());
 


### PR DESCRIPTION
## Summary
- update the players page sorting test to target the new player card link class name

## Testing
- pnpm test -- players.page.test.tsx *(fails: existing vitest suite errors about missing NextIntlClientProvider context and other unrelated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68df77eb38308323add303f463868963