### PR TITLE
Fix players sorting test name selection

### DIFF
--- a/apps/web/src/app/__tests__/players.page.test.tsx
+++ b/apps/web/src/app/__tests__/players.page.test.tsx
@@ -117,7 +117,10 @@ describe('PlayersPage sorting', () => {
       container.querySelectorAll<HTMLAnchorElement>(
         '.player-list__item .player-list__card-link',
       ),
-    ).map((link) => link.textContent?.trim());
+    ).map(
+      (link) =>
+        link.querySelector<HTMLSpanElement>('.player-list__name')?.textContent?.trim(),
+    );
 
     expect(names).toEqual(['Addi', 'Amy', 'benni', 'bridget']);
   });


### PR DESCRIPTION
## Summary
- ensure the players sorting test reads only the player name text when building the expected order

## Testing
- pnpm --filter web test -- --run apps/web/src/app/__tests__/players.page.test.tsx *(fails: unrelated vitest suites require NextIntlClientProvider context)*

------
https://chatgpt.com/codex/tasks/task_e_68df7947c8508323b3a5f102a2ec62f2