### PR TITLE
Fix TypeScript issues in match sharing and stage schedule views

### DIFF
--- a/apps/web/src/app/matches/[mid]/ShareMatchButton.tsx
+++ b/apps/web/src/app/matches/[mid]/ShareMatchButton.tsx
@@ -218,7 +218,7 @@ export default function ShareMatchButton({
       const writeLines = (text: string, indent = 0) => {
         const availableWidth = maxWidth - indent;
         const lines = doc.splitTextToSize(text, availableWidth);
-        lines.forEach((line) => {
+        lines.forEach((line: string) => {
           ensureSpace(lineHeight);
           doc.text(line, 10 + indent, cursorY);
           cursorY += lineHeight;

--- a/apps/web/src/app/tournaments/stage-schedule.tsx
+++ b/apps/web/src/app/tournaments/stage-schedule.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import type { StageScheduleMatch } from "../../lib/api";
+import type {
+  StageScheduleMatch,
+  StageScheduleParticipant,
+} from "../../lib/api";
 import type { PlayerInfo } from "../../components/PlayerName";
 
 export type PlayerLookup =
@@ -52,17 +55,25 @@ export default function StageScheduleTable({
     );
   }
 
-  const sides = Array.from(
+  const uniqueSides = Array.from(
     new Set(
       matches.flatMap((match) =>
         match.participants
           .map((participant) => participant.side)
-          .filter((side): side is string => typeof side === "string" && side.length > 0)
+          .filter(
+            (
+              side
+            ): side is StageScheduleParticipant["side"] =>
+              typeof side === "string" && side.length > 0
+          )
       )
     )
-  ).sort((a, b) => a.localeCompare(b));
+  ) as StageScheduleParticipant["side"][];
 
-  const resolvedSides = sides.length > 0 ? sides : ["A", "B"];
+  const sides = uniqueSides.sort((a, b) => a.localeCompare(b));
+
+  const defaultSides: StageScheduleParticipant["side"][] = ["A", "B"];
+  const resolvedSides = sides.length > 0 ? sides : defaultSides;
 
   return (
     <section className="card" style={{ padding: 16 }}>


### PR DESCRIPTION
## Summary
- annotate the PDF line writer in the match share button so TypeScript understands the string type returned by jsPDF
- tighten the tournament stage schedule side filtering to use StageScheduleParticipant typing and provide a typed default fallback

## Testing
- npm run build -- --no-lint

------
https://chatgpt.com/codex/tasks/task_e_68df7f6dd6348323956f44b620fd420c