### PR TITLE
Improve multi-select theming for tournaments

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -46,6 +46,19 @@
   --color-feedback-error-bg: #fff5f5;
   --color-feedback-error-text: #8a1c1c;
   --color-text-danger-strong: #b91c1c;
+
+  /* Multi-select tokens */
+  --multiselect-surface: var(--color-surface);
+  --multiselect-border: #d4d4d8;
+  --multiselect-option-bg: var(--color-surface);
+  --multiselect-option-border: #e4e4e7;
+  --multiselect-option-bg-selected: #f4f4f5;
+  --multiselect-option-bg-active: #eef2ff;
+  --multiselect-option-border-active: #6366f1;
+  --multiselect-chip-bg: #eef2ff;
+  --multiselect-chip-border: #c7d2fe;
+  --multiselect-chip-text: #312e81;
+  --multiselect-chip-remove: #4338ca;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -89,6 +102,19 @@
     --color-feedback-error-bg: #3f1d1d;
     --color-feedback-error-text: #fecaca;
     --color-text-danger-strong: #f87171;
+
+    /* Multi-select tokens */
+    --multiselect-surface: var(--color-surface-elevated);
+    --multiselect-border: #334155;
+    --multiselect-option-bg: var(--color-surface-elevated);
+    --multiselect-option-border: #1e293b;
+    --multiselect-option-bg-selected: rgba(148, 163, 184, 0.18);
+    --multiselect-option-bg-active: rgba(96, 165, 250, 0.25);
+    --multiselect-option-border-active: #60a5fa;
+    --multiselect-chip-bg: rgba(96, 165, 250, 0.18);
+    --multiselect-chip-border: rgba(96, 165, 250, 0.35);
+    --multiselect-chip-text: #e2e8f0;
+    --multiselect-chip-remove: #bfdbfe;
   }
 }
 

--- a/apps/web/src/components/MultiSelect.tsx
+++ b/apps/web/src/components/MultiSelect.tsx
@@ -323,8 +323,9 @@ export default function MultiSelect({
                   gap: 6,
                   padding: "4px 8px",
                   borderRadius: 9999,
-                  backgroundColor: "#eef2ff",
-                  border: "1px solid #c7d2fe",
+                  backgroundColor: "var(--multiselect-chip-bg)",
+                  border: "1px solid var(--multiselect-chip-border)",
+                  color: "var(--multiselect-chip-text)",
                 }}
               >
                 <span>{option.name}</span>
@@ -336,7 +337,7 @@ export default function MultiSelect({
                   style={{
                     border: "none",
                     background: "transparent",
-                    color: "#4338ca",
+                    color: "var(--multiselect-chip-remove)",
                     cursor: "pointer",
                     padding: 0,
                     fontSize: 16,
@@ -382,10 +383,10 @@ export default function MultiSelect({
         ref={listRef}
         onScroll={handleScroll}
         style={{
-          border: "1px solid #d4d4d8",
+          border: "1px solid var(--multiselect-border)",
           borderRadius: 8,
           padding: 4,
-          backgroundColor: "#fff",
+          backgroundColor: "var(--multiselect-surface)",
           maxHeight: ITEM_HEIGHT * VISIBLE_ITEM_COUNT,
           overflowY: "auto",
         }}
@@ -403,6 +404,14 @@ export default function MultiSelect({
                 const isSelected = selectedIds.includes(option.id);
                 const isActive = activeOptionIndex === absoluteIndex;
                 const optionId = `${listboxId}-option-${option.id}`;
+                const optionBackgroundColor = isActive
+                  ? "var(--multiselect-option-bg-active)"
+                  : isSelected
+                  ? "var(--multiselect-option-bg-selected)"
+                  : "var(--multiselect-option-bg)";
+                const optionBorderColor = isActive
+                  ? "var(--multiselect-option-border-active)"
+                  : "var(--multiselect-option-border)";
                 return (
                   <div
                     id={optionId}
@@ -419,12 +428,8 @@ export default function MultiSelect({
                       padding: "8px 12px",
                       borderRadius: 8,
                       border: "1px solid",
-                      borderColor: isActive ? "#6366f1" : "#e4e4e7",
-                      backgroundColor: isActive
-                        ? "#eef2ff"
-                        : isSelected
-                        ? "#f4f4f5"
-                        : "#fff",
+                      borderColor: optionBorderColor,
+                      backgroundColor: optionBackgroundColor,
                       cursor: "pointer",
                     }}
                   >


### PR DESCRIPTION
## Summary
- add theme-aware design tokens for the multi-select control
- update the MultiSelect component to consume the new CSS variables for chips and options

## Testing
- pnpm test -- --runInBand *(fails: existing NextIntl context and tournament API test issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e471d2a2508323ad54bfb741da6c55