### PR TITLE
Fix template response request argument and update auth test timezone

### DIFF
--- a/backend/app/routes/player.py
+++ b/backend/app/routes/player.py
@@ -38,6 +38,7 @@ async def player_profile(
 
     stats = await player_stats(player_id, session=session)
     return templates.TemplateResponse(
+        request,
         "player/profile.html",
-        {"request": request, "player": player_out, "stats": stats},
+        {"player": player_out, "stats": stats},
     )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,7 +3,7 @@ import sys
 import asyncio
 import uuid
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import jwt
 import pytest
 from sqlalchemy import select, func
@@ -356,7 +356,7 @@ def test_expired_token():
                 "sub": payload["sub"],
                 "username": payload.get("username"),
                 "is_admin": payload.get("is_admin"),
-                "exp": datetime.utcnow() - timedelta(seconds=1),
+                "exp": datetime.now(timezone.utc) - timedelta(seconds=1),
             },
             auth.get_jwt_secret(),
             algorithm=auth.JWT_ALG,


### PR DESCRIPTION
## Summary
- update the player profile route to use the new TemplateResponse signature
- refresh the expired token test to use a timezone-aware expiration timestamp

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e47593369883239aa59a86d3d6bc97