### PR TITLE
Add ability to clear notification badge

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -771,6 +771,14 @@ textarea {
   overflow-y: auto;
 }
 
+.notification-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
 .notification-panel__list {
   list-style: none;
   margin: 0;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -732,6 +732,10 @@ export async function markNotificationRead(notificationId: string): Promise<void
   await apiFetch(`/v0/notifications/${notificationId}/read`, { method: "POST" });
 }
 
+export async function markAllNotificationsRead(): Promise<void> {
+  await apiFetch("/v0/notifications/read-all", { method: "POST" });
+}
+
 export async function updatePlayerLocation(
   playerId: string,
   data: PlayerLocationPayload

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -153,6 +153,7 @@ def test_comment_and_match_notifications_flow():
             headers=_auth_headers(owner_token),
         ).json()
         assert "match_recorded" in [item["type"] for item in owner_notifs["items"]]
+        assert owner_notifs["unreadCount"] > 0
 
         opponent_notifs = client.get(
             "/notifications",
@@ -166,3 +167,15 @@ def test_comment_and_match_notifications_flow():
             headers=_auth_headers(opponent_token),
         )
         assert mark_resp.status_code == 204
+
+        clear_resp = client.post(
+            "/notifications/read-all",
+            headers=_auth_headers(owner_token),
+        )
+        assert clear_resp.status_code == 204
+
+        cleared_notifs = client.get(
+            "/notifications",
+            headers=_auth_headers(owner_token),
+        ).json()
+        assert cleared_notifs["unreadCount"] == 0


### PR DESCRIPTION
## Summary
- add an API route to mark all notifications as read and cover it with tests
- expose the client helper and surface a "Clear badge" action when the bell shows unread items but no list entries
- adjust styles and component tests for the updated notification panel

## Testing
- pytest backend/tests/test_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68e47bbf7c3883238c2a3fa67351655d