### PR TITLE
Add club selection to padel match form

### DIFF
--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -10,11 +10,13 @@ import { ensureTrailingSlash } from "../../../lib/routes";
 import { useLocale } from "../../../lib/LocaleContext";
 import {
   getDateExample,
+  getDatePlaceholder,
   getTimeExample,
   usesTwentyFourHourClock,
 } from "../../../lib/i18n";
 import { buildPlayedAtISOString } from "../../../lib/datetime";
 import { rememberLoginRedirect } from "../../../lib/loginRedirect";
+import ClubSelect from "../../../components/ClubSelect";
 
 interface Player {
   id: string;
@@ -315,6 +317,7 @@ interface CreateMatchPayload {
   bestOf: number;
   playedAt?: string;
   location?: string;
+  clubId?: string;
   isFriendly?: boolean;
 }
 
@@ -328,6 +331,7 @@ export default function RecordPadelPage() {
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
   const [location, setLocation] = useState("");
+  const [clubId, setClubId] = useState("");
   const [isFriendly, setIsFriendly] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [playerTouched, setPlayerTouched] = useState<
@@ -346,6 +350,7 @@ export default function RecordPadelPage() {
   const recordPadelT = useTranslations("Record.padel");
   const [success, setSuccess] = useState(false);
   const saveSummaryId = useId();
+  const clubHintId = useId();
 
   const playerNameById = useMemo(() => {
     const map = new Map<string, string>();
@@ -517,6 +522,10 @@ export default function RecordPadelPage() {
   };
 
   const dateExample = useMemo(() => getDateExample(locale), [locale]);
+  const datePlaceholder = useMemo(
+    () => getDatePlaceholder(locale),
+    [locale],
+  );
   const uses24HourTime = useMemo(
     () => usesTwentyFourHourClock(locale),
     [locale],
@@ -592,6 +601,10 @@ export default function RecordPadelPage() {
       const playedAt = buildPlayedAtISOString(date, time);
       if (playedAt) {
         payload.playedAt = playedAt;
+      }
+      const trimmedClubId = clubId.trim();
+      if (trimmedClubId) {
+        payload.clubId = trimmedClubId;
       }
       if (location) {
         payload.location = location;
@@ -672,6 +685,7 @@ export default function RecordPadelPage() {
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 lang={locale}
+                placeholder={datePlaceholder}
                 aria-describedby={`padel-date-format ${dateLocaleHintId}`}
               />
               <span id="padel-date-format" className="form-hint">
@@ -700,6 +714,23 @@ export default function RecordPadelPage() {
                 {timeHintText}
               </span>
             </label>
+          </div>
+          <div className="form-field">
+            <label className="form-label" htmlFor="padel-club-select">
+              {recordT("fields.club.label")}
+            </label>
+            <ClubSelect
+              value={clubId}
+              onChange={setClubId}
+              placeholder={recordT("fields.club.placeholder")}
+              searchInputId="padel-club-search"
+              selectId="padel-club-select"
+              searchLabel={recordT("fields.club.searchLabel")}
+              describedById={clubHintId}
+            />
+            <p id={clubHintId} className="form-hint">
+              {recordT("fields.club.hint")}
+            </p>
           </div>
           <label className="form-field" htmlFor="padel-location">
             <span className="form-label">{recordT("fields.location.label")}</span>

--- a/apps/web/src/messages/en-AU.json
+++ b/apps/web/src/messages/en-AU.json
@@ -120,6 +120,12 @@
       "addSet": "Add Set"
     },
     "fields": {
+      "club": {
+        "label": "Played at club",
+        "placeholder": "Example: Nordic Padel",
+        "hint": "Select the club where the match was played, or leave blank if it wasn't at a club.",
+        "searchLabel": "Played at club"
+      },
       "location": {
         "label": "Location",
         "placeholder": "Location"

--- a/apps/web/src/messages/en-GB.json
+++ b/apps/web/src/messages/en-GB.json
@@ -120,6 +120,12 @@
       "addSet": "Add Set"
     },
     "fields": {
+      "club": {
+        "label": "Played at club",
+        "placeholder": "Example: Nordic Padel",
+        "hint": "Select the club where the match was played, or leave blank if it wasn't at a club.",
+        "searchLabel": "Played at club"
+      },
       "location": {
         "label": "Location",
         "placeholder": "Location"

--- a/apps/web/src/messages/es-ES.json
+++ b/apps/web/src/messages/es-ES.json
@@ -120,6 +120,12 @@
       "addSet": "Añadir set"
     },
     "fields": {
+      "club": {
+        "label": "Club donde se jugó",
+        "placeholder": "Ejemplo: Nordic Padel",
+        "hint": "Selecciona el club donde se jugó el partido o déjalo en blanco si no fue en un club.",
+        "searchLabel": "Club donde se jugó"
+      },
       "location": {
         "label": "Ubicación",
         "placeholder": "Ubicación"

--- a/backend/alembic/versions/0028_match_club_id.py
+++ b/backend/alembic/versions/0028_match_club_id.py
@@ -1,0 +1,27 @@
+"""add club id to matches
+
+Revision ID: 0028_match_club_id
+Revises: 0027_notifications
+Create Date: 2024-05-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0028_match_club_id"
+down_revision = "0027_notifications"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "match",
+        sa.Column("club_id", sa.String(), sa.ForeignKey("club.id"), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("match", "club_id")
+

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -128,6 +128,7 @@ class Match(Base):
     sport_id = Column(String, ForeignKey("sport.id"), nullable=False)
     stage_id = Column(String, ForeignKey("stage.id"), nullable=True)
     ruleset_id = Column(String, ForeignKey("ruleset.id"), nullable=True)
+    club_id = Column(String, ForeignKey("club.id"), nullable=True)
     best_of = Column(Integer, nullable=True)
     played_at = Column(DateTime(timezone=True), nullable=True)
     location = Column(String, nullable=True)

--- a/backend/app/routers/matches.py
+++ b/backend/app/routers/matches.py
@@ -457,6 +457,7 @@ async def list_matches(
             bestOf=m.best_of,
             playedAt=_coerce_utc(m.played_at),
             location=m.location,
+            clubId=m.club_id,
             isFriendly=m.is_friendly,
             participants=[
                 MatchSummaryParticipantOut(
@@ -486,6 +487,7 @@ async def create_match(
         id=mid,
         sport_id=body.sport,
         ruleset_id=body.rulesetId,
+        club_id=body.clubId,
         best_of=body.bestOf,
         played_at=body.playedAt,
         location=body.location,
@@ -911,6 +913,7 @@ async def get_match(mid: str, session: AsyncSession = Depends(get_session)):
         bestOf=m.best_of,
         playedAt=_coerce_utc(m.played_at),
         location=m.location,
+        clubId=m.club_id,
         isFriendly=m.is_friendly,
         participants=[
             ParticipantOut(id=p.id, side=p.side, playerIds=p.player_ids) for p in parts

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -377,6 +377,7 @@ class MatchCreate(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    clubId: Optional[str] = None
     score: Optional[List[int]] = None
     sets: Optional[List[List[int]]] = None
     details: Optional[Dict[str, Any]] = None
@@ -385,6 +386,16 @@ class MatchCreate(BaseModel):
     @field_validator("playedAt")
     def _normalize_played_at(cls, v: datetime | None) -> datetime | None:
         return require_utc(v, field_name="playedAt")
+
+    @field_validator("clubId", mode="after")
+    @classmethod
+    def _normalize_club_id(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            trimmed = value.strip()
+            return trimmed or None
+        raise TypeError("clubId must be a string")
 
     @model_validator(mode="before")
     def _validate_participants(cls, data: Any) -> Any:
@@ -401,12 +412,23 @@ class MatchCreateByName(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    clubId: Optional[str] = None
     sets: Optional[List[Tuple[int, int]]] = None
     isFriendly: bool = False
 
     @field_validator("playedAt")
     def _normalize_played_at(cls, v: datetime | None) -> datetime | None:
         return require_utc(v, field_name="playedAt")
+
+    @field_validator("clubId", mode="after")
+    @classmethod
+    def _normalize_club_id(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            trimmed = value.strip()
+            return trimmed or None
+        raise TypeError("clubId must be a string")
 
     @model_validator(mode="before")
     def _validate_participants(cls, data: Any) -> Any:
@@ -769,6 +791,7 @@ class MatchSummaryOut(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    clubId: Optional[str] = None
     isFriendly: bool
     participants: List["MatchSummaryParticipantOut"] = Field(default_factory=list)
     summary: Optional[Dict[str, Any]] = None
@@ -817,6 +840,7 @@ class MatchOut(BaseModel):
     bestOf: Optional[int] = None
     playedAt: Optional[datetime] = None
     location: Optional[str] = None
+    clubId: Optional[str] = None
     isFriendly: bool
     participants: List[ParticipantOut] = Field(default_factory=list)
     events: List[ScoreEventOut] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- add a club selector to the padel match form with translated labels and hints and trim the selected id into the match payload
- surface optional club ids on match creation responses and persisted models, including a schema validator and a migration for the match table
- stub next-intl and the club selector in the padel form tests and cover the club id end-to-end, while keeping date placeholders locale aware

## Testing
- pnpm vitest run src/app/record/padel/page.test.tsx
- pytest tests/test_matches.py

------
https://chatgpt.com/codex/tasks/task_e_68e47d8a783483239b1690a019d04796