### PR TITLE
Fix Postgres player stats filtering

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -425,7 +425,9 @@ async def _load_match_summaries_for_players(
         return {}
 
     is_sqlite = session.bind.dialect.name == "sqlite"
-    json_each = func.json_each if is_sqlite else func.jsonb_array_elements
+    json_each = (
+        func.json_each if is_sqlite else func.jsonb_array_elements_text
+    )
     mp = aliased(MatchParticipant)
     player_values = json_each(mp.player_ids).table_valued("value").alias("player_values")
     player_id_value = _json_text_value(player_values.c.value, is_sqlite=is_sqlite)
@@ -1086,7 +1088,9 @@ async def _compute_player_stats(
 ) -> PlayerStatsOut:
     mp = aliased(MatchParticipant)
     is_sqlite = session.bind.dialect.name == "sqlite"
-    json_each = func.json_each if is_sqlite else func.jsonb_array_elements
+    json_each = (
+        func.json_each if is_sqlite else func.jsonb_array_elements_text
+    )
     json_array_length = (
         func.json_array_length if is_sqlite else func.jsonb_array_length
     )

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -417,6 +417,12 @@ def test_player_stats_postgresql_json_handling(client_and_session, monkeypatch):
     )
     monkeypatch.setattr(
         players.func,
+        "jsonb_array_elements_text",
+        players.func.json_each,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        players.func,
         "jsonb_array_length",
         players.func.json_array_length,
         raising=False,


### PR DESCRIPTION
## Summary
- ensure player statistics use `jsonb_array_elements_text` on PostgreSQL so player ids are matched correctly
- update the PostgreSQL JSON handling test harness to monkeypatch the new helper when simulating PostgreSQL on SQLite

## Testing
- pytest backend/tests/test_player_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68e492dc2a188323a6d8625d49a82f27