### PR TITLE
Handle numeric versus record values

### DIFF
--- a/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
+++ b/apps/web/src/app/players/[id]/PlayerCharts.test.tsx
@@ -68,17 +68,27 @@ describe("PlayerCharts", () => {
       },
     ];
 
-    render(<PlayerCharts matches={matches} />);
+    render(
+      <PlayerCharts
+        matches={matches}
+        rollingWinPct={[0.5, 0.25]}
+        ratingHistory={{ values: [1200, 1180], label: "Padel Elo" }}
+      />,
+    );
 
     const winRate = readJson<Array<{ date: string; winRate: number }>>("win-rate");
     expect(winRate).toHaveLength(2);
     expect(winRate[0].date).toBe("Match 1");
     expect(winRate[1].date).toBe("1/1/24");
+    expect(winRate[0].winRate).toBeCloseTo(0.5);
+    expect(winRate[1].winRate).toBeCloseTo(0.25);
 
     const ranking = readJson<Array<{ date: string; rank: number }>>("ranking-history");
     expect(ranking).toHaveLength(2);
-    expect(ranking[0].date).toBe("Match 1");
-    expect(ranking[1].date).toBe("1/1/24");
+    expect(ranking[0].date).toBe("Padel Elo 1");
+    expect(ranking[1].date).toBe("Padel Elo 2");
+    expect(ranking[0].rank).toBe(1);
+    expect(ranking[1].rank).toBe(21);
 
     const heatmap = readJson<Array<{ x: number; y: number; v: number }>>("heatmap");
     expect(heatmap).toHaveLength(1);

--- a/apps/web/src/lib/player-stats.test.ts
+++ b/apps/web/src/lib/player-stats.test.ts
@@ -112,6 +112,31 @@ describe("normalizeVersusRecords", () => {
         wins: 4,
         losses: 2,
         winPct: 1,
+        chemistry: null,
+      },
+    ]);
+  });
+
+  it("coerces numeric identifiers and stringified metrics", () => {
+    const records = normalizeVersusRecords([
+      {
+        playerId: 42,
+        playerName: "Jordan",
+        wins: "6",
+        losses: "4",
+        winPct: "0.6",
+        total: "10",
+      },
+    ]);
+    expect(records).toEqual([
+      {
+        playerId: "42",
+        playerName: "Jordan",
+        wins: 6,
+        losses: 4,
+        winPct: 0.6,
+        total: 10,
+        chemistry: null,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- relax player versus record normalization to accept numeric identifiers and string based stats
- update optional number parsing to support string input for totals and chemistry values
- extend unit coverage to confirm coercion behaviour for mixed-type versus records

## Testing
- ./node_modules/.bin/vitest run --config vitest.config.mts src/lib/player-stats.test.ts "src/app/players/[id]/PlayerCharts.test.tsx" "src/app/players/[id]/page.sections.test.tsx"

------
https://chatgpt.com/codex/tasks/task_e_68e49750b650832380da67c1ce43cf77