### PR TITLE
Widen leaderboard layout

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -286,6 +286,10 @@ img {
   padding: clamp(16px, 4vw, 32px);
 }
 
+.container--wide {
+  width: min(1280px, 100% - 32px);
+}
+
 .heading {
   margin-top: 0;
   color: var(--color-heading);

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1921,7 +1921,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   }, [hasMore, loadMore, leaders.length, shouldVirtualize]);
 
   return (
-    <main className="container">
+    <main className="container container--wide">
       <p className="sr-only" aria-live="polite">
         {statusMessage}
       </p>


### PR DESCRIPTION
### Motivation
- Reduce horizontal scrolling on leaderboard pages by increasing the content width so columns can display left-to-right without triggering a scrollbar.
- Make the leaderboard take advantage of larger viewports while keeping the existing container behavior for other pages.

### Description
- Added a new `.container--wide` modifier to `apps/web/src/app/globals.css` with `width: min(1280px, 100% - 32px)`.
- Applied the `container--wide` class to the leaderboard wrapper in `apps/web/src/app/leaderboard/leaderboard.tsx` by changing `<main className="container">` to `<main className="container container--wide">`.
- This widens the leaderboard layout only, leaving other pages using the default `.container` width.

### Testing
- Started the app locally with `pnpm --filter web dev`, which compiled the `/leaderboard` page successfully.
- Ran a Playwright script to open `/leaderboard?sport=bowling` and capture a screenshot artifact of the page.
- The leaderboard request returned a `500` due to a missing `INTERNAL_API_BASE_URL`/`NEXT_PUBLIC_API_BASE_URL` environment variable, so full end-to-end data rendering could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638d439540832380ae62cb1a9e70cb)