### PR TITLE
Prevent leaderboard header wrapping

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1525,6 +1525,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       textAlign: "left" as const,
       padding: "4px 16px 4px 0",
       background: "var(--leaderboard-table-header-bg)",
+      whiteSpace: "nowrap" as const,
     }),
     [],
   );


### PR DESCRIPTION
### Motivation
- Long header labels in the leaderboard can wrap to a second line and make the table look awkward. 
- Table header cells need a no-wrap rule so column headings remain on a single line and the layout stays tidy.

### Description
- Add `whiteSpace: "nowrap"` to the `headerCellStyle` used for leaderboard header cells in `apps/web/src/app/leaderboard/leaderboard.tsx`.
- The `lastHeaderCellStyle` continues to inherit from `headerCellStyle` so sticky header behavior is preserved.

### Testing
- Started the dev server with `pnpm --filter web dev --hostname 0.0.0.0 --port 3000`, which reported Next.js ready (startup succeeded). 
- Attempted a visual regression capture with Playwright to verify the header, but Chromium crashed with a SIGSEGV and the screenshot step failed. 
- No automated unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b20347108323b01f2cfc80aa6397)