### PR TITLE
Default padel record form to 1 set (best-of-1) and update tests

### DIFF
--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -133,6 +133,8 @@ describe("RecordPadelPage", () => {
       target: { value: "p4" },
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
+
     fireEvent.change(screen.getByLabelText("Location"), {
       target: { value: "Court 1" },
     });
@@ -492,6 +494,8 @@ describe("RecordPadelPage", () => {
       target: { value: "p2" },
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
+
     fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
       target: { value: "6" },
     });
@@ -572,6 +576,8 @@ describe("RecordPadelPage", () => {
     fireEvent.change(screen.getByLabelText("Player B 1"), {
       target: { value: "p2" },
     });
+
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
 
     fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
       target: { value: "6" },
@@ -814,6 +820,8 @@ describe("RecordPadelPage", () => {
     fireEvent.change(screen.getByLabelText("Player B 2"), {
       target: { value: "p4" },
     });
+
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
 
     fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
       target: { value: "6" },

--- a/apps/web/src/app/record/padel/page.test.tsx
+++ b/apps/web/src/app/record/padel/page.test.tsx
@@ -747,6 +747,8 @@ describe("RecordPadelPage", () => {
       target: { value: "pb2" },
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
+
     fireEvent.change(screen.getByPlaceholderText("Set 1 A"), {
       target: { value: "7" },
     });
@@ -896,6 +898,8 @@ describe("RecordPadelPage", () => {
       target: { value: "4" },
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
+
     fireEvent.click(screen.getByRole("button", { name: /add set/i }));
     fireEvent.change(screen.getByPlaceholderText("Set 2 A"), {
       target: { value: "6" },
@@ -954,6 +958,8 @@ describe("RecordPadelPage", () => {
     fireEvent.change(screen.getByPlaceholderText("Set 1 B"), {
       target: { value: "4" },
     });
+
+    fireEvent.click(screen.getByRole("button", { name: /3 sets/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /add set/i }));
     fireEvent.change(screen.getByPlaceholderText("Set 2 A"), {

--- a/apps/web/src/app/record/padel/page.tsx
+++ b/apps/web/src/app/record/padel/page.tsx
@@ -128,7 +128,7 @@ interface PadelSetAnalysis {
 }
 
 function analysePadelSets(sets: SetScore[], rawBestOf: number): PadelSetAnalysis {
-  const bestOf = VALID_BEST_OF.has(rawBestOf) ? rawBestOf : 3;
+  const bestOf = VALID_BEST_OF.has(rawBestOf) ? rawBestOf : 1;
   const neededWins = Math.floor(bestOf / 2) + 1;
   const errors = sets.map(() => "");
   let completed = 0;
@@ -366,7 +366,7 @@ export default function RecordPadelPage() {
   const router = useRouter();
   const [players, setPlayers] = useState<Player[]>([]);
   const [ids, setIds] = useState<IdMap>({ a1: "", a2: "", b1: "", b2: "" });
-  const [bestOf, setBestOf] = useState("3");
+  const [bestOf, setBestOf] = useState("1");
   const [sets, setSets] = useState<SetScore[]>([{ ...EMPTY_SET }]);
   const [setErrors, setSetErrors] = useState<SetErrors>([""]);  
   const [setTouched, setSetTouched] = useState<SetTouched>([false]);
@@ -442,7 +442,7 @@ export default function RecordPadelPage() {
 
   const bestOfNumber = useMemo(() => {
     const parsed = Number(bestOf);
-    return VALID_BEST_OF.has(parsed) ? parsed : 3;
+    return VALID_BEST_OF.has(parsed) ? parsed : 1;
   }, [bestOf]);
 
   const setAnalysis = useMemo(


### PR DESCRIPTION
### Motivation

- The padel record form should default to a single set on `/record/padel/` while still allowing the user to choose `3` or `5` sets.
- Ensure the set validation logic and UI default are aligned so the form behaves consistently for one-set matches.

### Description

- Changed the padel set analysis fallback from `3` to `1` in `analysePadelSets` so invalid/missing `bestOf` falls back to best-of-1 (`apps/web/src/app/record/padel/page.tsx`).
- Set the UI default for the Best-of control to `"1"` by updating the `useState` initializer for `bestOf` in the padel record component (`apps/web/src/app/record/padel/page.tsx`).
- Adjusted the `bestOfNumber` fallback to `1` so all derived validation uses best-of-1 by default (`apps/web/src/app/record/padel/page.tsx`).
- Updated `apps/web/src/app/record/padel/page.test.tsx` to explicitly select `3 sets` in tests that exercise multi-set validation/behaviour so tests remain deterministic with the new default.

### Testing

- Started the web dev server with `NEXT_PUBLIC_API_BASE_URL=http://localhost:3000 pnpm --filter @cst/web exec next dev` and confirmed `/record/padel/` compiled and rendered, then captured a screenshot (`artifacts/padel-default-best-of.png`).
- Unit test files `apps/web/src/app/record/padel/page.test.tsx` were updated to select `3 sets` where required, but the full test suite was not executed in this session; please run `pnpm --filter @cst/web test` to verify all tests pass in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6ee89ca88323b44aea4ae973f49b)