### PR TITLE
Fix preferences radio styling and respect default leaderboard preference

### DIFF
--- a/apps/web/src/app/header.test.tsx
+++ b/apps/web/src/app/header.test.tsx
@@ -84,7 +84,7 @@ describe("Header navigation", () => {
     pushMock.mockClear();
 
     fireEvent.click(screen.getByRole("link", { name: "links.leaderboards" }));
-    expect(pushMock).toHaveBeenCalledWith("/leaderboard?sport=all");
+    expect(pushMock).toHaveBeenCalledWith("/leaderboard");
     expect(pushMock).toHaveBeenCalledTimes(1);
   });
 
@@ -106,7 +106,7 @@ describe("Header navigation", () => {
     pushMock.mockClear();
     fireEvent.click(menuToggle);
     fireEvent.click(screen.getByRole("link", { name: "links.leaderboards" }));
-    expect(pushMock).toHaveBeenCalledWith("/leaderboard?sport=all");
+    expect(pushMock).toHaveBeenCalledWith("/leaderboard");
     expect(pushMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/header.test.tsx
+++ b/apps/web/src/app/header.test.tsx
@@ -84,7 +84,7 @@ describe("Header navigation", () => {
     pushMock.mockClear();
 
     fireEvent.click(screen.getByRole("link", { name: "links.leaderboards" }));
-    expect(pushMock).toHaveBeenCalledWith("/leaderboard");
+    expect(pushMock).toHaveBeenCalledWith("/leaderboard/");
     expect(pushMock).toHaveBeenCalledTimes(1);
   });
 
@@ -106,7 +106,7 @@ describe("Header navigation", () => {
     pushMock.mockClear();
     fireEvent.click(menuToggle);
     fireEvent.click(screen.getByRole("link", { name: "links.leaderboards" }));
-    expect(pushMock).toHaveBeenCalledWith("/leaderboard");
+    expect(pushMock).toHaveBeenCalledWith("/leaderboard/");
     expect(pushMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/header.tsx
+++ b/apps/web/src/app/header.tsx
@@ -77,7 +77,7 @@ export default function Header() {
   const matchesHref = formatHref('/matches');
   const recordHref = formatHref('/record');
   const tournamentsHref = formatHref('/tournaments');
-  const leaderboardHref = formatHref('/leaderboard?sport=all');
+  const leaderboardHref = formatHref('/leaderboard');
   const profileHref = formatHref('/profile');
   const loginHref = formatHref('/login');
   const adminMatchesHref = formatHref('/admin/matches');

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -62,10 +62,6 @@ export default function LeaderboardIndexPage({
     redirectToLeaderboard(ALL_SPORTS, country, clubId);
   }
 
-  if (!rawSport) {
-    redirectToLeaderboard(ALL_SPORTS, country, clubId);
-  }
-
   const sport = sportParam ?? ALL_SPORTS;
 
   return (

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1243,10 +1243,16 @@ export default function ProfilePage() {
             <option key={zone} value={zone} />
           ))}
         </datalist>
-        <fieldset className="form-field" aria-describedby={PREFERENCES_TIME_FORMAT_HINT_ID}>
+        <fieldset
+          className="form-field"
+          aria-describedby={PREFERENCES_TIME_FORMAT_HINT_ID}
+        >
           <legend className="form-label">Preferred time format</legend>
           <div className="radio-group" style={{ flexWrap: "wrap", gap: "1rem" }}>
-            <label className="radio" style={{ display: "flex", gap: "0.5rem" }}>
+            <label
+              className="radio-group__option"
+              style={{ display: "flex", gap: "0.5rem" }}
+            >
               <input
                 type="radio"
                 name="preferences-time-format"
@@ -1265,7 +1271,10 @@ export default function ProfilePage() {
               />
               <span>24-hour (default)</span>
             </label>
-            <label className="radio" style={{ display: "flex", gap: "0.5rem" }}>
+            <label
+              className="radio-group__option"
+              style={{ display: "flex", gap: "0.5rem" }}
+            >
               <input
                 type="radio"
                 name="preferences-time-format"


### PR DESCRIPTION
### Motivation
- The preferred time format radio controls used a local class that produced an oversized double-circle visual, so they should use the shared radio-group styling.
- The leaderboard index forced a redirect to the all-sports view when the `sport` query param was missing, preventing the client from honoring a user’s saved default leaderboard sport.
- The header link and tests referenced `/leaderboard?sport=all`, which conflicts with the change to allow client-side default sport selection.

### Description
- Replace the local `radio` label markup with the shared `radio-group__option` class and adjust `fieldset` formatting in `apps/web/src/app/profile/page.tsx` to fix the radio appearance.
- Remove the unconditional server-side redirect when `sport` is absent from `apps/web/src/app/leaderboard/page.tsx` so the client can use saved preferences to choose a default sport.
- Update the header link to point to `/leaderboard` (no `sport=all` query) in `apps/web/src/app/header.tsx` and adjust `apps/web/src/app/header.test.tsx` expectations accordingly.

### Testing
- No unit or integration test suites were executed as part of this change (unit tests were not run).
- A Playwright attempt to capture a screenshot of the profile page run automatically failed due to a browser crash (SIGSEGV) in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7ae5e9548323b4f9da9992bd7898)