### PR TITLE
Add backend pytest workflow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ pnpm install --filter @cst/web --frozen-lockfile
 pnpm test -- --runInBand
 ```
 
+### Backend tests
+
+Run pytest from the repository root so it can pick up `pytest.ini`. Ensure the
+backend database connection string is set; the test suite expects a Postgres
+database you can destroy and recreate.
+
+```bash
+export DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_test
+pytest
+```
+
+The CI-style invocation matches the same command used in automation:
+
+```bash
+pytest
+```
+
 Deploy: Single VPS with Docker Compose; Caddy for HTTPS; nightly pg_dump backups
 
 Monorepo Layout


### PR DESCRIPTION
### Motivation
- Provide clear local instructions for running the backend test suite, including the expected `DATABASE_URL` format and the same CI-style invocation developers should use.

### Description
- Updated `README.md` to add a "Backend tests" section that documents running `pytest` from the repository root with an example `DATABASE_URL` (`postgresql+asyncpg://postgres:postgres@localhost:5432/crosssport_test`) and notes that CI uses `pytest` as the invocation.

### Testing
- No automated tests were run because this is a documentation-only change; the repository and CI test commands remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870dd95fdc83238553cf36b6a64336)