### PR TITLE
Add Postgres smoke tests and CI job for DB parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,37 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: DATABASE_URL=sqlite+aiosqlite:///./ci.db pytest -q
 
+  test-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install pytest
+      - name: Run Postgres smoke tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pytest -q -m postgres
+
   web-tests:
     runs-on: ubuntu-latest
     steps:

--- a/backend/tests/test_postgres_smoke.py
+++ b/backend/tests/test_postgres_smoke.py
@@ -1,0 +1,46 @@
+import asyncio
+import os
+import sys
+
+import pytest
+from sqlalchemy import select
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend.app import db
+from backend.app.models import Sport, Team
+
+
+def _get_sessionmaker():
+    if db.AsyncSessionLocal is None:
+        db.get_engine()
+    return db.AsyncSessionLocal
+
+
+@pytest.mark.postgres
+def test_postgres_insert_and_query():
+    async def run():
+        sessionmaker = _get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(Sport(id="padel", name="Padel"))
+            await session.commit()
+            result = await session.execute(select(Sport).where(Sport.id == "padel"))
+            sport = result.scalar_one()
+            assert sport.name == "Padel"
+
+    asyncio.run(run())
+
+
+@pytest.mark.postgres
+def test_postgres_json_roundtrip():
+    async def run():
+        sessionmaker = _get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(Team(id="team-1", player_ids=["p1", "p2"]))
+            await session.commit()
+            result = await session.execute(select(Team).where(Team.id == "team-1"))
+            team = result.scalar_one()
+            assert team.player_ids == ["p1", "p2"]
+
+    asyncio.run(run())

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 pythonpath = .
 markers =
     preserve_schema: skip the automatic per-test schema reset when a test module manages its own database lifecycle
+    postgres: run the targeted PostgreSQL smoke tests


### PR DESCRIPTION
### Motivation

- Improve CI coverage against Postgres to reduce SQLite-specific gaps between CI and production.
- Provide a lightweight, targeted Postgres smoke test subset so full Postgres coverage is optional and CI stays fast.

### Description

- Add a `test-postgres` GitHub Actions job that starts a Postgres service and runs the targeted Postgres tests against it.
- Add `backend/tests/test_postgres_smoke.py` with two `@pytest.mark.postgres` smoke tests verifying a basic insert/query and JSON round-trip.
- Register a `postgres` pytest marker in `pytest.ini` so the subset can be selected via `-m postgres`.
- Keep the existing `test` job that runs the suite with a SQLite `DATABASE_URL` unchanged.

### Testing

- No automated tests were executed locally; CI will run the new `test-postgres` job which executes `pytest -q -m postgres` against the Postgres service.
- Existing SQLite test job remains configured to run `pytest` with `DATABASE_URL=sqlite+aiosqlite:///./ci.db` in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987171c8ba88323974a35d3daed38a8)