### PR TITLE
Fix player social link contrast in dark mode

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2147,6 +2147,38 @@ html.theme-dark .record-sport-card:hover {
   border-style: dashed;
 }
 
+.player-detail__social-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.player-detail__social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--color-text) 10%, var(--color-surface-elevated));
+  color: var(--color-text);
+  text-decoration: none;
+  border: 1px solid var(--color-border-subtle);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.player-detail__social-link:hover,
+.player-detail__social-link:focus-visible {
+  background: color-mix(in srgb, var(--color-accent-blue) 12%, var(--color-surface-elevated));
+  border-color: color-mix(in srgb, var(--color-accent-blue) 45%, var(--color-border-subtle));
+  color: var(--color-accent-blue);
+}
+
+.player-detail__social-link:focus-visible {
+  outline: 2px solid var(--color-accent-blue);
+  outline-offset: 2px;
+}
+
 .player-detail__view-nav {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -847,31 +847,14 @@ export default async function PlayerPage({
               </p>
             ) : null}
             {player.social_links && player.social_links.length ? (
-              <div
-                style={{
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: "0.5rem",
-                  marginTop: "0.75rem",
-                }}
-              >
+              <div className="player-detail__social-links">
                 {player.social_links.map((link) => (
                   <a
                     key={link.id}
                     href={link.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: "0.35rem",
-                      padding: "0.35rem 0.75rem",
-                      borderRadius: "9999px",
-                      backgroundColor: "#f4f4f4",
-                      color: "inherit",
-                      textDecoration: "none",
-                      border: "1px solid #e0e0e0",
-                    }}
+                    className="player-detail__social-link"
                     title={link.url}
                   >
                     <span aria-hidden="true">{iconForSocialLink(link)}</span>


### PR DESCRIPTION
### Motivation
- Social media pills on the player profile page used inline light-background styling which produced bright white pills in dark mode and made link text hard to read, so the theme-aware contrast needed to be fixed.

### Description
- Replaced the inline social-link markup in `apps/web/src/app/players/[id]/page.tsx` with semantic classes `player-detail__social-links` and `player-detail__social-link` to remove hardcoded colors.
- Added CSS rules to `apps/web/src/app/globals.css` that style social links using theme variables (`--color-text`, `--color-surface-elevated`, `--color-border-subtle`, `--color-accent-blue`) so foreground/background contrast adapts to both light and dark themes.
- Implemented hover and `:focus-visible` states and a visible focus ring to improve accessibility and keyboard navigation.
- Kept markup semantics and link behavior (`target="_blank" rel="noopener noreferrer"`) unchanged.

### Testing
- Ran the component test file with `cd apps/web && npm run test -- --run src/app/players/[id]/page.sections.test.tsx`, and the test suite passed (1 file, 2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58e772b988323b81c0013ade2484e)