### PR TITLE
Sanitize unhandled 500 responses while preserving exception logging

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,7 +169,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
     problem = ProblemDetail(
         title="Internal Server Error",
         status=500,
-        detail=str(exc),
+        detail="An unexpected error occurred",
         code="internal_server_error",
     )
     return JSONResponse(

--- a/backend/tests/test_unhandled_exception_logging.py
+++ b/backend/tests/test_unhandled_exception_logging.py
@@ -26,8 +26,10 @@ def test_unhandled_exception_logs_traceback(caplog):
         response = client.get("/boom")
 
     assert response.status_code == 500
+    payload = response.json()
+    assert payload["detail"] == "An unexpected error occurred"
+    assert "boom" not in response.text
     record = next((r for r in caplog.records if r.message == "Unhandled exception"), None)
     assert record is not None
     assert record.exc_info[0] is ValueError
     assert "ValueError: boom" in caplog.text
-


### PR DESCRIPTION
### Motivation
- Prevent leaking internal exception text to API clients for HTTP 500 responses by returning a generic, user-safe message. 
- Preserve server-side diagnostics (traceback / structured logging) so errors remain debuggable in logs/Sentry.

### Description
- Updated `unhandled_exception_handler` in `backend/app/main.py` to return a generic `detail` value `"An unexpected error occurred"` for 500 responses instead of `str(exc)`.
- Kept structured server-side logging by retaining `logger.error("Unhandled exception", exc_info=(type(exc), exc, exc.__traceback__))` so the traceback is still captured.
- Extended `backend/tests/test_unhandled_exception_logging.py` to assert that the 500 response does not contain the raw exception text and that the internal exception is still logged.

### Testing
- Ran `pytest -q backend/tests/test_unhandled_exception_logging.py` and the test suite passed (`1 passed`).
- The updated test `test_unhandled_exception_logs_traceback` verifies both the sanitized response payload and that the exception traceback is present in logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59a3bafd48323bb043958a59c4f27)