### PR TITLE
Use bowling highest score for leaderboard ranking and rating

### DIFF
--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -109,18 +109,10 @@ async def leaderboard(
     total_entries = len(all_rows) if all_rows is not None else 0
     if not isinstance(total_entries, int):
         total_entries = int(total_entries or 0)
-    # Map player_id -> current rank and rating
-    current_rank_map = {
-        row.Rating.player_id: i + 1 for i, row in enumerate(all_rows)
-    }
-    current_rating_map = {
-        row.Rating.player_id: row.Rating.value for row in all_rows
-    }
-    rows = all_rows[offset : offset + limit]
-    distribution = _rating_distribution([row.Rating.value for row in all_rows])
+    all_player_ids = [r.Rating.player_id for r in all_rows]
 
     # Precompute set stats for players returned by the ranking query.
-    player_ids = [r.Rating.player_id for r in rows]
+    player_ids = [r.Rating.player_id for r in all_rows]
     set_stats = {pid: {"won": 0, "lost": 0} for pid in player_ids}
 
     if player_ids:
@@ -208,6 +200,42 @@ async def leaderboard(
                 "standard_deviation": float(std_dev),
             }
 
+    rating_value_map: dict[str, float] = {
+        row.Rating.player_id: row.Rating.value for row in all_rows
+    }
+    if base_sport_id == "bowling":
+        for pid in all_player_ids:
+            bowling = bowling_stats.get(pid)
+            if isinstance(bowling, dict):
+                highest_score = bowling.get("highest_score")
+                if isinstance(highest_score, (int, float)):
+                    rating_value_map[pid] = float(highest_score)
+        all_rows.sort(
+            key=lambda row: (
+                rating_value_map.get(row.Rating.player_id, float("-inf")),
+                bowling_stats.get(row.Rating.player_id, {}).get(
+                    "average_score", float("-inf")
+                ),
+                row.Rating.value,
+            ),
+            reverse=True,
+        )
+
+    current_rank_map = {
+        row.Rating.player_id: i + 1 for i, row in enumerate(all_rows)
+    }
+    current_rating_map = {
+        row.Rating.player_id: rating_value_map.get(row.Rating.player_id, row.Rating.value)
+        for row in all_rows
+    }
+    rows = all_rows[offset : offset + limit]
+    distribution = _rating_distribution(
+        [
+            rating_value_map.get(row.Rating.player_id, row.Rating.value)
+            for row in all_rows
+        ]
+    )
+
     # Build rating history for the sport using RATING score events
     rating_stmt = (
         select(ScoreEvent)
@@ -251,7 +279,10 @@ async def leaderboard(
     prev_rank_map = {pid: i + 1 for i, (pid, _) in enumerate(prev_sorted)}
 
     leaders = []
-    current_subset_ratings = {row.Rating.player_id: row.Rating.value for row in rows}
+    current_subset_ratings = {
+        row.Rating.player_id: rating_value_map.get(row.Rating.player_id, row.Rating.value)
+        for row in rows
+    }
     for r in rows:
         pid = r.Rating.player_id
         stats = set_stats.get(pid, {"won": 0, "lost": 0})
@@ -273,17 +304,18 @@ async def leaderboard(
             bowling.get("standard_deviation") if isinstance(bowling, dict) else None
         )
         win_probabilities = {}
+        player_rating = rating_value_map.get(pid, r.Rating.value)
         for opp_id, opp_rating in current_subset_ratings.items():
             if opp_id == pid:
                 continue
-            win_probabilities[opp_id] = _elo_win_probability(r.Rating.value, opp_rating)
+            win_probabilities[opp_id] = _elo_win_probability(player_rating, opp_rating)
 
         leaders.append(
             LeaderboardEntryOut(
                 rank=curr_rank,
                 playerId=pid,
                 playerName=r.Player.name,
-                rating=r.Rating.value,
+                rating=rating_value_map.get(pid, r.Rating.value),
                 rankChange=prev_rank - curr_rank,
                 sets=won + lost,
                 setsWon=won,

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -360,7 +360,11 @@ def test_bowling_leaderboard_includes_score_stats():
         resp = client.get("/leaderboards", params={"sport": "bowling"})
         assert resp.status_code == 200
         data = resp.json()
+        assert [entry["playerId"] for entry in data["leaders"]] == ["b1", "b3", "b2"]
         leaders = {entry["playerId"]: entry for entry in data["leaders"]}
+        assert leaders["b1"]["rating"] == 220
+        assert leaders["b3"]["rating"] == 190
+        assert leaders["b2"]["rating"] == 180
         assert leaders["b1"]["matchesPlayed"] == 2
         assert leaders["b1"]["highestScore"] == 220
         assert leaders["b1"]["averageScore"] == pytest.approx(215.0)
@@ -373,7 +377,7 @@ def test_bowling_leaderboard_includes_score_stats():
         assert leaders["b3"]["highestScore"] == 190
         assert leaders["b3"]["averageScore"] == pytest.approx(190.0)
         assert leaders["b3"]["standardDeviation"] == pytest.approx(0.0)
-        assert data["ratingDistribution"]["maximum"] == 1010
+        assert data["ratingDistribution"]["maximum"] == 220
         assert leaders["b1"]["winProbabilities"]["b2"] == pytest.approx(
-            leaderboards._elo_win_probability(1010, 1000)
+            leaderboards._elo_win_probability(220, 180)
         )


### PR DESCRIPTION
### Motivation
- Bowling leaderboards should rank players by their best bowling performance regardless of opponents, so the displayed rating and ordering must reflect each player’s highest game score rather than Elo/rating values derived from match outcomes.

### Description
- Compute bowling-specific stats (`matches_played`, `highest_score`, `average_score`, `standard_deviation`) from match `details` and derive a `rating_value_map` that uses `highest_score` for bowling players when present in `backend/app/routers/leaderboards.py`.
- Re-sort `all_rows` for `bowling` by `highest_score` (with `average_score` and original rating as tie-breakers) and expose the derived value as the response `rating` and in win-probability calculations.
- Use the bowling-derived values when building the rating distribution so histogram/percentiles reflect bowling scores.
- Update `backend/tests/test_leaderboards.py` to assert the new bowling ordering, the displayed `rating` values, the distribution maximum, and that `winProbabilities` are computed using the bowling-derived ratings.

### Testing
- Ran `pytest backend/tests/test_leaderboards.py -q` and the suite passed with `7 passed`.
- Updated test assertions in `backend/tests/test_leaderboards.py` to validate the new bowling ranking and rating behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c300a80c8323b587165b4ba89e23)