### PR TITLE
Add searchable CountrySelect combobox behavior

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -524,10 +524,12 @@ describe("Leaderboard", () => {
 
     await waitFor(() => expect(fetchClubsSpy).toHaveBeenCalled());
 
-    const countrySelect = (await screen.findByRole("combobox", {
+    const countrySelect = await screen.findByRole("combobox", {
       name: "Country",
-    })) as HTMLSelectElement;
-    await user.selectOptions(countrySelect, "SE");
+    });
+    await user.clear(countrySelect);
+    await user.type(countrySelect, "swed");
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
 
     const clubSelect = (await screen.findByRole("combobox", {
       name: "Club",
@@ -567,7 +569,9 @@ describe("Leaderboard", () => {
 
     const user = userEvent.setup();
     const countrySelect = screen.getByRole("combobox", { name: "Country" });
-    await user.selectOptions(countrySelect, "SE");
+    await user.clear(countrySelect);
+    await user.type(countrySelect, "swed");
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
 
     const clubSelect = screen.getByRole("combobox", { name: "Club" });
     await user.selectOptions(clubSelect, "club-123");
@@ -727,8 +731,8 @@ describe("Leaderboard", () => {
       </NextIntlClientProvider>,
     );
 
-    const countrySelect = (await screen.findByRole("combobox", { name: "Country" })) as HTMLSelectElement;
-    await waitFor(() => expect(countrySelect.value).toBe("SE"));
+    const countrySelect = await screen.findByRole("combobox", { name: "Country" });
+    await waitFor(() => expect(countrySelect).toHaveValue("Sweden"));
   });
 
   it("preserves additional query params when updating filters", async () => {
@@ -742,8 +746,10 @@ describe("Leaderboard", () => {
 
     await renderLeaderboard({ sport: "padel" });
 
-    const countrySelect = (await screen.findByLabelText("Country")) as HTMLSelectElement;
-    await user.selectOptions(countrySelect, "SE");
+    const countrySelect = await screen.findByLabelText("Country");
+    await user.clear(countrySelect);
+    await user.type(countrySelect, "swed");
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
     const applyButton = screen.getByRole("button", { name: "Apply" });
 
     const initialCallCount = replaceMock.mock.calls.length;

--- a/apps/web/src/components/CountrySelect.test.tsx
+++ b/apps/web/src/components/CountrySelect.test.tsx
@@ -1,0 +1,60 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CountrySelect from "./CountrySelect";
+
+describe("CountrySelect", () => {
+  it("filters options by country name and code", async () => {
+    render(<CountrySelect value="" onChange={() => {}} />);
+
+    const user = userEvent.setup();
+    const input = screen.getByRole("combobox");
+
+    await user.type(input, "swed");
+    expect(await screen.findByRole("option", { name: /Sweden \(SE\)/i })).toBeVisible();
+
+    await user.clear(input);
+    await user.type(input, "us");
+    expect(await screen.findByRole("option", { name: /United States of America \(US\)/i })).toBeVisible();
+  });
+
+  it("supports keyboard navigation and enter to select", async () => {
+    const handleChange = vi.fn();
+    render(<CountrySelect value="" onChange={handleChange} />);
+
+    const user = userEvent.setup();
+    const input = screen.getByRole("combobox");
+
+    await user.type(input, "swed");
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+    expect(handleChange).toHaveBeenCalledWith("SE");
+  });
+
+  it("closes suggestions on escape", async () => {
+    render(<CountrySelect value="" onChange={() => {}} />);
+
+    const user = userEvent.setup();
+    const input = screen.getByRole("combobox");
+
+    await user.type(input, "can");
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("preserves empty option equivalent for clearing", async () => {
+    const handleChange = vi.fn();
+    render(<CountrySelect value="US" onChange={handleChange} />);
+
+    const user = userEvent.setup();
+    const input = screen.getByRole("combobox");
+
+    await user.click(input);
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(handleChange).toHaveBeenCalledWith("");
+  });
+});

--- a/apps/web/src/components/CountrySelect.tsx
+++ b/apps/web/src/components/CountrySelect.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ChangeEvent, type SelectHTMLAttributes } from "react";
+import {
+  type InputHTMLAttributes,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { COUNTRY_OPTIONS } from "../lib/countries";
 
@@ -9,7 +16,7 @@ export type CountrySelectProps = {
   onChange: (countryCode: string) => void;
   placeholder?: string;
   includeEmptyOption?: boolean;
-} & Omit<SelectHTMLAttributes<HTMLSelectElement>, "value" | "onChange">;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">;
 
 export default function CountrySelect({
   value,
@@ -18,19 +25,201 @@ export default function CountrySelect({
   includeEmptyOption = true,
   ...rest
 }: CountrySelectProps) {
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const nextValue = event.target.value.trim().toUpperCase();
-    onChange(nextValue);
+  const reactId = useId();
+  const listboxId = `${reactId}-country-listbox`;
+  const selectedOption = useMemo(
+    () => COUNTRY_OPTIONS.find((option) => option.code === value) ?? null,
+    [value],
+  );
+
+  const [inputValue, setInputValue] = useState(selectedOption?.name ?? "");
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const shouldKeepOpenOnBlurRef = useRef(false);
+
+  useEffect(() => {
+    setInputValue(selectedOption?.name ?? "");
+  }, [selectedOption]);
+
+  const filteredOptions = useMemo(() => {
+    const search = inputValue.trim().toLowerCase();
+    const countryMatches = COUNTRY_OPTIONS.filter((option) => {
+      if (!search) {
+        return true;
+      }
+      return (
+        option.name.toLowerCase().includes(search) ||
+        option.code.toLowerCase().includes(search)
+      );
+    });
+
+    if (includeEmptyOption) {
+      return [{ code: "", name: placeholder }, ...countryMatches];
+    }
+    return countryMatches;
+  }, [includeEmptyOption, inputValue, placeholder]);
+
+  const activeOption =
+    activeIndex >= 0 && activeIndex < filteredOptions.length
+      ? filteredOptions[activeIndex]
+      : null;
+
+  const commitSelection = (countryCode: string) => {
+    const normalizedValue = countryCode.trim().toUpperCase();
+    const option = COUNTRY_OPTIONS.find((entry) => entry.code === normalizedValue);
+    onChange(normalizedValue);
+    setInputValue(option?.name ?? "");
+    setIsOpen(false);
+    setActiveIndex(-1);
   };
 
   return (
-    <select value={value} onChange={handleChange} {...rest}>
-      {includeEmptyOption ? <option value="">{placeholder}</option> : null}
-      {COUNTRY_OPTIONS.map((option) => (
-        <option key={option.code} value={option.code}>
-          {option.name}
-        </option>
-      ))}
-    </select>
+    <div style={{ position: "relative" }}>
+      <input
+        {...rest}
+        type="text"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-autocomplete="list"
+        aria-controls={listboxId}
+        aria-activedescendant={activeOption ? `${listboxId}-${activeOption.code || "empty"}` : undefined}
+        autoComplete="off"
+        value={inputValue}
+        placeholder={placeholder}
+        onFocus={() => {
+          setIsOpen(true);
+        }}
+        onBlur={() => {
+          if (shouldKeepOpenOnBlurRef.current) {
+            shouldKeepOpenOnBlurRef.current = false;
+            return;
+          }
+          setIsOpen(false);
+          setActiveIndex(-1);
+          setInputValue(selectedOption?.name ?? "");
+        }}
+        onChange={(event) => {
+          setInputValue(event.target.value);
+          setIsOpen(true);
+          setActiveIndex(-1);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            if (!isOpen) {
+              setIsOpen(true);
+              setActiveIndex(filteredOptions.length ? 0 : -1);
+              return;
+            }
+            if (!filteredOptions.length) {
+              return;
+            }
+            setActiveIndex((previous) =>
+              previous < filteredOptions.length - 1 ? previous + 1 : 0,
+            );
+            return;
+          }
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            if (!isOpen) {
+              setIsOpen(true);
+              setActiveIndex(filteredOptions.length ? filteredOptions.length - 1 : -1);
+              return;
+            }
+            if (!filteredOptions.length) {
+              return;
+            }
+            setActiveIndex((previous) =>
+              previous > 0 ? previous - 1 : filteredOptions.length - 1,
+            );
+            return;
+          }
+          if (event.key === "Enter") {
+            if (!isOpen) {
+              return;
+            }
+            event.preventDefault();
+            if (activeOption) {
+              commitSelection(activeOption.code);
+              return;
+            }
+            if (filteredOptions.length === 1) {
+              commitSelection(filteredOptions[0].code);
+            }
+            return;
+          }
+          if (event.key === "Escape") {
+            if (!isOpen) {
+              return;
+            }
+            event.preventDefault();
+            setIsOpen(false);
+            setActiveIndex(-1);
+            setInputValue(selectedOption?.name ?? "");
+          }
+        }}
+      />
+
+      {isOpen ? (
+        <ul
+          id={listboxId}
+          role="listbox"
+          style={{
+            listStyle: "none",
+            margin: "0.25rem 0 0",
+            padding: "0.25rem",
+            position: "absolute",
+            zIndex: 20,
+            width: "100%",
+            maxHeight: "14rem",
+            overflowY: "auto",
+            border: "1px solid var(--color-border-subtle)",
+            borderRadius: "6px",
+            background: "var(--color-surface)",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+          }}
+        >
+          {filteredOptions.length ? (
+            filteredOptions.map((option, index) => {
+              const optionId = `${listboxId}-${option.code || "empty"}`;
+              const isActive = index === activeIndex;
+              return (
+                <li
+                  key={option.code || "__empty"}
+                  id={optionId}
+                  role="option"
+                  aria-selected={value === option.code}
+                  onMouseDown={() => {
+                    shouldKeepOpenOnBlurRef.current = true;
+                  }}
+                  onClick={() => {
+                    commitSelection(option.code);
+                  }}
+                  style={{
+                    cursor: "pointer",
+                    padding: "0.35rem 0.5rem",
+                    borderRadius: "4px",
+                    background: isActive
+                      ? "var(--color-surface-elevated, #f4f4f4)"
+                      : "transparent",
+                  }}
+                >
+                  {option.name}
+                  {option.code ? ` (${option.code})` : ""}
+                </li>
+              );
+            })
+          ) : (
+            <li
+              role="option"
+              aria-disabled
+              style={{ padding: "0.35rem 0.5rem", color: "var(--color-text-muted)" }}
+            >
+              No matching countries
+            </li>
+          )}
+        </ul>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the plain native `<select>` country control with a typeahead/combobox so users can search countries by name or code while keeping the existing `value` + `onChange(countryCode)` contract.
- Ensure the control is keyboard- and screen-reader-friendly with predictable selection and clear behavior for the leaderboard filters that expect ISO country codes.

### Description
- Replaced the `<select>` in `apps/web/src/components/CountrySelect.tsx` with an accessible combobox and `listbox` suggestion UI backed by `COUNTRY_OPTIONS` from `apps/web/src/lib/countries.ts` and preserving the `value`/`onChange` API (normalized ISO codes via `onChange` calls to uppercase codes).
- Added search-as-you-type filtering of countries by `name` and `code`, a top empty-equivalent option (`Select a country`) and clear-to-empty semantics.
- Implemented keyboard handling for `ArrowUp`/`ArrowDown` navigation, `Enter` to commit selection, `Escape` to close/reset, and correct ARIA attributes (`role="combobox"`, `role="listbox"`, `role="option"`, `aria-activedescendant`, etc.).
- Updated leaderboard tests to interact with the new combobox behavior (typing and keyboard selection) so `normalizeCountry`/`validateFilters` still receive ISO codes, and added component tests covering search matching, keyboard selection, Escape behavior, and clearing.

### Testing
- Ran the component + integration tests with Vitest for the modified files using `cd apps/web && pnpm vitest run src/components/CountrySelect.test.tsx src/app/leaderboard/leaderboard.test.tsx`. The final test run completed successfully with all relevant tests passing (`29 tests` across the two files passed).
- The tests exercise filtering by name and code, keyboard navigation/selection, Escape to close, empty/clear selection, and leaderboard filter flows that assert `country=SE` query behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ff96c2e883239293ef1e7f28cc39)