### PR TITLE
Add context-aware club filtering for leaderboard filters

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -590,6 +590,91 @@ describe("Leaderboard", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("resets an incompatible club when the country changes", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+    fetchClubsSpy
+      .mockResolvedValueOnce([
+        { id: "club-123", name: "Club 123" },
+        { id: "club-se", name: "Club Sweden" },
+      ])
+      .mockResolvedValueOnce([{ id: "club-us", name: "Club USA" }]);
+    updateMockLocation("/leaderboard/padel?country=SE&clubId=club-123");
+
+    await renderLeaderboard({ sport: "padel", country: "SE", clubId: "club-123" });
+
+    await waitFor(() =>
+      expect(fetchClubsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sport: "padel", country: "SE" }),
+      ),
+    );
+
+    const countrySelect = screen.getByRole("combobox", { name: "Country" });
+    await user.clear(countrySelect);
+    await user.type(countrySelect, "us");
+    await user.click(
+      await screen.findByRole("option", { name: /United States of America \(US\)/i }),
+    );
+
+    await waitFor(() =>
+      expect(fetchClubsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sport: "padel", country: "US" }),
+      ),
+    );
+
+    const clubSelect = screen.getByRole("combobox", { name: "Club" });
+    await waitFor(() => expect(clubSelect).toHaveValue(""));
+  });
+
+  it("narrows club options based on current sport and country", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch = fetchMock as typeof fetch;
+    fetchClubsSpy
+      .mockResolvedValueOnce([
+        { id: "club-123", name: "Club 123" },
+        { id: "club-se", name: "Club Sweden" },
+      ])
+      .mockResolvedValueOnce([{ id: "club-us", name: "Club USA" }]);
+    updateMockLocation("/leaderboard/padel?country=SE");
+
+    await renderLeaderboard({ sport: "padel", country: "SE" });
+
+    await waitFor(() =>
+      expect(fetchClubsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sport: "padel", country: "SE" }),
+      ),
+    );
+
+    let clubSelect = screen.getByRole("combobox", { name: "Club" });
+    expect(within(clubSelect).getByRole("option", { name: "Club 123" })).toBeInTheDocument();
+    expect(within(clubSelect).queryByRole("option", { name: "Club USA" })).not.toBeInTheDocument();
+
+    const countrySelect = screen.getByRole("combobox", { name: "Country" });
+    await user.clear(countrySelect);
+    await user.type(countrySelect, "us");
+    await user.click(
+      await screen.findByRole("option", { name: /United States of America \(US\)/i }),
+    );
+
+    await waitFor(() =>
+      expect(fetchClubsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sport: "padel", country: "US" }),
+      ),
+    );
+
+    clubSelect = screen.getByRole("combobox", { name: "Club" });
+    await waitFor(() =>
+      expect(within(clubSelect).getByRole("option", { name: "Club USA" })).toBeInTheDocument(),
+    );
+    expect(within(clubSelect).queryByRole("option", { name: "Club 123" })).not.toBeInTheDocument();
+  });
+
   it("shows validation feedback when the URL references unsupported filters", async () => {
     const fetchMock = vi
       .fn()
@@ -610,12 +695,6 @@ describe("Leaderboard", () => {
     expect(countryAlert).toHaveAttribute("role", "alert");
     expect(countryAlert).toHaveAttribute("id", "leaderboard-country-error");
 
-    const clubAlert = await screen.findByText(
-      "We don't recognise the club \"club-missing\". Please choose an option from the list.",
-    );
-    expect(clubAlert).toHaveAttribute("role", "alert");
-    expect(clubAlert).toHaveAttribute("id", "leaderboard-club-error");
-
     const countrySelect = screen.getByRole("combobox", { name: "Country" });
     expect(countrySelect).toHaveAttribute("aria-invalid", "true");
     expect(countrySelect).toHaveAttribute(
@@ -624,11 +703,7 @@ describe("Leaderboard", () => {
     );
 
     const clubSelect = screen.getByRole("combobox", { name: "Club" });
-    expect(clubSelect).toHaveAttribute("aria-invalid", "true");
-    expect(clubSelect).toHaveAttribute(
-      "aria-describedby",
-      expect.stringContaining("leaderboard-club-error"),
-    );
+    expect(clubSelect).not.toHaveAttribute("aria-invalid", "true");
 
     await waitFor(() =>
       expect(replaceMock).toHaveBeenCalledWith("/leaderboard/padel", { scroll: false }),

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -371,11 +371,22 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     return map;
   }, [clubOptions]);
 
+  const clubScopeSport = useMemo(() => {
+    if (sport === ALL_SPORTS || sport === MASTER_SPORT) {
+      return "";
+    }
+    return sport;
+  }, [sport]);
+
+  const clubScopeCountry = normalizeCountry(draftCountry);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const clubs = await fetchClubs({
+          sport: clubScopeSport || undefined,
+          country: clubScopeCountry || undefined,
           cache: "force-cache",
           next: { revalidate: 3600 },
         });
@@ -398,7 +409,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [clubScopeCountry, clubScopeSport]);
 
   useEffect(() => {
     if (country === undefined) {
@@ -535,6 +546,31 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     },
     [pathname, router, searchParamsString],
   );
+
+  useEffect(() => {
+    if (!clubsLoaded) {
+      return;
+    }
+    if (draftClubId && !clubIds.has(draftClubId)) {
+      setDraftClubId("");
+    }
+    const isAppliedCountryScope = appliedCountry === clubScopeCountry;
+    if (isAppliedCountryScope && appliedClubId && !clubIds.has(appliedClubId)) {
+      const nextFilters = { country: appliedCountry, clubId: "" };
+      setFilters((prev) =>
+        prev.clubId === "" ? prev : { country: prev.country, clubId: "" }
+      );
+      updateFiltersInQuery(nextFilters);
+    }
+  }, [
+    appliedClubId,
+    appliedCountry,
+    clubIds,
+    clubScopeCountry,
+    clubsLoaded,
+    draftClubId,
+    updateFiltersInQuery,
+  ]);
 
   useEffect(() => {
     updateFiltersInQuery(filters);
@@ -2208,6 +2244,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           <ClubSelect
             value={draftClubId}
             onChange={(next) => setDraftClubId(normalizeClubId(next))}
+            options={clubOptions}
             placeholder="Search for a club"
             searchInputId="leaderboard-club-search"
             selectId="leaderboard-club-select"

--- a/apps/web/src/components/ClubSelect.tsx
+++ b/apps/web/src/components/ClubSelect.tsx
@@ -24,6 +24,7 @@ function normalizeSearchText(text: string): string {
 interface ClubSelectProps {
   value: string;
   onChange: (clubId: string) => void;
+  options?: ClubSummary[];
   placeholder?: string;
   name?: string;
   disabled?: boolean;
@@ -41,6 +42,7 @@ type LoadStatus = "idle" | "loading" | "loaded" | "error";
 export default function ClubSelect({
   value,
   onChange,
+  options: providedOptions,
   placeholder = "Select a club",
   name,
   disabled = false,
@@ -54,7 +56,9 @@ export default function ClubSelect({
 }: ClubSelectProps) {
   const reactId = useId();
   const [options, setOptions] = useState<ClubSummary[]>([]);
-  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [status, setStatus] = useState<LoadStatus>(
+    providedOptions ? "loaded" : "idle",
+  );
   const [searchTerm, setSearchTerm] = useState("");
   const [dirtySearch, setDirtySearch] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -78,6 +82,9 @@ export default function ClubSelect({
     ariaLabel ?? (selectIdProp ? undefined : "Select club");
 
   const loadOptions = useCallback(async () => {
+    if (providedOptions) {
+      return;
+    }
     if (status === "loading" || status === "loaded") {
       return;
     }
@@ -93,7 +100,18 @@ export default function ClubSelect({
       console.error("Failed to load clubs", err);
       setStatus("error");
     }
-  }, [status]);
+  }, [providedOptions, status]);
+
+  useEffect(() => {
+    if (!providedOptions) {
+      return;
+    }
+    const sorted = [...providedOptions].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+    );
+    setOptions(sorted);
+    setStatus("loaded");
+  }, [providedOptions]);
 
   const handleFocus = useCallback(
     (event: FocusEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -163,10 +181,13 @@ export default function ClubSelect({
     if (disabled) {
       return;
     }
+    if (providedOptions) {
+      return;
+    }
     if (status === "idle") {
       void loadOptions();
     }
-  }, [disabled, loadOptions, status]);
+  }, [disabled, loadOptions, providedOptions, status]);
 
   useEffect(() => {
     if (dirtySearch) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -647,7 +647,11 @@ export async function fetchClubs(
   }
   const query = params.toString();
   const path = query ? `/v0/clubs?${query}` : "/v0/clubs";
-  const { sport: _sport, country: _country, ...init } = options ?? {};
+  const init = options ? { ...options } : undefined;
+  if (init) {
+    delete init.sport;
+    delete init.country;
+  }
   const res = await apiFetch(path, init);
   return res.json();
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -630,10 +630,25 @@ export interface ClubSummary {
   name: string;
 }
 
+export type FetchClubsOptions = ApiRequestInit & {
+  sport?: string | null;
+  country?: string | null;
+};
+
 export async function fetchClubs(
-  init?: ApiRequestInit
+  options?: FetchClubsOptions
 ): Promise<ClubSummary[]> {
-  const res = await apiFetch("/v0/clubs", init);
+  const params = new URLSearchParams();
+  if (options?.sport) {
+    params.set("sport", options.sport);
+  }
+  if (options?.country) {
+    params.set("country", options.country);
+  }
+  const query = params.toString();
+  const path = query ? `/v0/clubs?${query}` : "/v0/clubs";
+  const { sport: _sport, country: _country, ...init } = options ?? {};
+  const res = await apiFetch(path, init);
   return res.json();
 }
 

--- a/backend/app/routers/clubs.py
+++ b/backend/app/routers/clubs.py
@@ -1,11 +1,13 @@
-from fastapi import APIRouter, Depends, status
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
 from ..exceptions import ProblemDetail, http_problem
-from ..models import Club, User
+from ..models import Club, Player, Rating, User
 from ..schemas import ClubCreate, ClubOut
 from .admin import require_admin
 
@@ -41,6 +43,27 @@ async def create_club(
 
 
 @router.get("", response_model=list[ClubOut])
-async def list_clubs(session: AsyncSession = Depends(get_session)) -> list[ClubOut]:
-    rows = (await session.execute(select(Club).order_by(Club.name))).scalars().all()
+async def list_clubs(
+    sport: Annotated[str | None, Query(description="Optional sport id filter")] = None,
+    country: Annotated[
+        str | None, Query(description="Optional country/location filter")
+    ] = None,
+    session: AsyncSession = Depends(get_session),
+) -> list[ClubOut]:
+    stmt = select(Club)
+    if sport or country:
+        stmt = (
+            stmt.join(Player, Player.club_id == Club.id)
+            .where(Player.deleted_at.is_(None))
+            .distinct()
+        )
+        if sport:
+            stmt = stmt.join(
+                Rating,
+                (Rating.player_id == Player.id) & (Rating.sport_id == sport),
+            )
+        if country:
+            stmt = stmt.where(Player.location == country)
+
+    rows = (await session.execute(stmt.order_by(Club.name))).scalars().all()
     return [_to_club_out(club) for club in rows]

--- a/backend/tests/test_clubs.py
+++ b/backend/tests/test_clubs.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import db
 from app.exceptions import DomainException, ProblemDetail
-from app.models import Club, Player, RefreshToken, User
+from app.models import Club, Player, Rating, RefreshToken, Sport, User
 from app.routers import auth, clubs
 
 os.environ["ADMIN_SECRET"] = "admintest"
@@ -71,8 +71,10 @@ def setup_db():
                 tables=[
                     User.__table__,
                     RefreshToken.__table__,
+                    Sport.__table__,
                     Player.__table__,
                     Club.__table__,
+                    Rating.__table__,
                 ],
             )
 
@@ -180,5 +182,85 @@ def test_create_club_conflict(async_client) -> None:
         assert duplicate.status_code == 409
         payload = duplicate.json()
         assert payload["code"] == "club_exists"
+
+    loop.run_until_complete(scenario())
+
+
+def test_list_clubs_supports_country_and_sport_filters(async_client) -> None:
+    client, loop = async_client
+
+    async def scenario() -> None:
+        token = await create_admin_token(client)
+        for club_id, club_name in (
+            ("club-se-padel", "Club SE Padel"),
+            ("club-se-bowl", "Club SE Bowl"),
+            ("club-us-padel", "Club US Padel"),
+        ):
+            response = await client.post(
+                "/clubs",
+                json={"id": club_id, "name": club_name},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status_code in {201, 409}
+
+        async with db.AsyncSessionLocal() as session:
+            session.add_all(
+                [
+                    Sport(id="padel", name="Padel"),
+                    Sport(id="bowling", name="Bowling"),
+                ]
+            )
+            session.add_all(
+                [
+                    Player(
+                        id="player-se-padel",
+                        name="Player SE Padel",
+                        location="SE",
+                        club_id="club-se-padel",
+                    ),
+                    Player(
+                        id="player-se-bowl",
+                        name="Player SE Bowl",
+                        location="SE",
+                        club_id="club-se-bowl",
+                    ),
+                    Player(
+                        id="player-us-padel",
+                        name="Player US Padel",
+                        location="US",
+                        club_id="club-us-padel",
+                    ),
+                ]
+            )
+            session.add_all(
+                [
+                    Rating(id="rating-se-padel", player_id="player-se-padel", sport_id="padel", value=1000),
+                    Rating(id="rating-se-bowl", player_id="player-se-bowl", sport_id="bowling", value=1000),
+                    Rating(id="rating-us-padel", player_id="player-us-padel", sport_id="padel", value=1000),
+                ]
+            )
+            await session.commit()
+
+        country_only = await client.get("/clubs", params={"country": "SE"})
+        assert country_only.status_code == 200
+        assert [club["id"] for club in country_only.json()] == [
+            "club-se-bowl",
+            "club-se-padel",
+        ]
+
+        sport_and_country = await client.get(
+            "/clubs", params={"country": "SE", "sport": "padel"}
+        )
+        assert sport_and_country.status_code == 200
+        assert sport_and_country.json() == [
+            {"id": "club-se-padel", "name": "Club SE Padel"}
+        ]
+
+        sport_only = await client.get("/clubs", params={"sport": "padel"})
+        assert sport_only.status_code == 200
+        assert [club["id"] for club in sport_only.json()] == [
+            "club-se-padel",
+            "club-us-padel",
+        ]
 
     loop.run_until_complete(scenario())


### PR DESCRIPTION
### Motivation
- Provide club options scoped to the current leaderboard context so the Club filter only shows clubs relevant to the selected sport and/or country.
- Keep client-side validation and selected filter values aligned with the scoped club options so invalid/irrelevant clubs are cleared automatically.
- Expose a lightweight API contract so clients can request filtered clubs without fetching the full global club list.

### Description
- Extend `GET /clubs` to accept optional `sport` and `country` query params and return clubs that have active players (and `Rating` rows when `sport` is provided), implemented in `backend/app/routers/clubs.py`.
- Update the web API client `fetchClubs` in `apps/web/src/lib/api.ts` to accept `sport`/`country` via a new `FetchClubsOptions` type and build the query string accordingly.
- Allow `ClubSelect` to accept externally-provided `options` so callers can pass scoped club lists and avoid internal fetching when options are supplied (`apps/web/src/components/ClubSelect.tsx`).
- Make leaderboard UI load scoped club options based on the current `sport` + draft `country` context, pass `clubOptions` into `ClubSelect`, and automatically clear incompatible `draftClubId`/applied `clubId` values and update the URL when the scope changes (`apps/web/src/app/leaderboard/leaderboard.tsx`).
- Add backend tests covering `GET /clubs` with `country` and `sport` combinations and frontend tests that assert: country changes reset incompatible club selections and the club list narrows with country/sport scope (`backend/tests/test_clubs.py`, `apps/web/src/app/leaderboard/leaderboard.test.tsx`).

### Testing
- Ran `pytest backend/tests/test_clubs.py -q` and observed all tests pass (`4 passed`).
- Ran the leaderboard frontend tests with `pnpm vitest run src/app/leaderboard/leaderboard.test.tsx` and observed all leaderboard tests pass (`27 passed`).
- Iterated on failing assertions in the leaderboard tests and adjusted validation expectations so behavior matches scoped options (final test runs are green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e605f90fe083239bace52fd183ff7d)