### PR TITLE
Rename leaderboard Clear actions to "Reset filters"

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -868,7 +868,7 @@ describe("Leaderboard", () => {
     expect(url.searchParams.get("clubId")).toBe("club-123");
 
     const clearButton = screen
-      .getAllByRole("button", { name: "Clear" })
+      .getAllByRole("button", { name: "Reset filters" })
       .find((button): button is HTMLButtonElement =>
         button.getAttribute("aria-controls") === "leaderboard-results"
       );
@@ -944,7 +944,7 @@ describe("Leaderboard", () => {
 
     expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
 
-    const clearButtons = screen.getAllByRole("button", { name: "Clear" });
+    const clearButtons = screen.getAllByRole("button", { name: "Reset filters" });
     const filterClear = clearButtons.find((button) =>
       button.getAttribute("aria-controls") === "leaderboard-results"
     );

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -2307,8 +2307,9 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                 opacity: canClear ? 1 : 0.7,
               }}
               disabled={!canClear}
+              aria-label="Reset filters"
             >
-              Clear
+              Reset filters
             </button>
           </div>
           <p
@@ -2340,6 +2341,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               <button
                 type="button"
                 onClick={handleClear}
+                aria-label="Reset filters"
                 style={{
                   padding: "0.4rem 0.9rem",
                   borderRadius: "4px",
@@ -2349,7 +2351,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
                   cursor: "pointer",
                 }}
               >
-                Clear region filters
+                Reset filters
               </button>
             </div>
           )}


### PR DESCRIPTION
### Motivation
- Clarify the leaderboard filter reset action and align accessible naming by replacing the vague "Clear" label with the explicit "Reset filters" text and aria label.

### Description
- Updated the main leaderboard filter reset button to display `Reset filters` and added `aria-label="Reset filters"` while preserving the existing `disabled` styling and state behaviors.
- Updated the regional/all-sports reset button to use the same `Reset filters` label and `aria-label` for consistency.
- Preserved the existing `handleClear` behavior which clears `filterErrors`, resets `country` and `clubId` to empty strings, and removes the `country` and `clubId` query params via `updateFiltersInQuery`.
- Updated `apps/web/src/app/leaderboard/leaderboard.test.tsx` assertions to look for `Reset filters` instead of `Clear`.

### Testing
- Ran `pnpm --filter @cst/web test src/app/leaderboard/leaderboard.test.tsx --watch=false` and the leaderboard test file executed successfully with 27 tests passing.
- An earlier incorrect test invocation (`pnpm --filter @cst/web test apps/web/src/app/leaderboard/leaderboard.test.tsx --watch=false`) reported no test files found due to the wrong path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6489d417883239573f3a6f5c1994e)