### PR TITLE
Improve sorted leaderboard header affordance

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3363,6 +3363,36 @@ html.theme-dark .record-sport-card:hover {
   min-width: 360px;
 }
 
+.leaderboard-sortable-header-cell--active {
+  background: color-mix(
+    in srgb,
+    var(--color-accent-blue) 10%,
+    var(--leaderboard-table-header-bg)
+  ) !important;
+  box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--color-accent-blue) 65%, transparent);
+}
+
+.leaderboard-sortable-header-button {
+  transition: background-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.leaderboard-sortable-header-button:hover {
+  background: color-mix(in srgb, var(--color-accent-blue) 8%, transparent);
+}
+
+.leaderboard-sortable-header-button--active {
+  background: color-mix(in srgb, var(--color-accent-blue) 18%, transparent) !important;
+  color: var(--color-text-strong, var(--color-text));
+}
+
+.leaderboard-sortable-header-icon {
+  color: color-mix(in srgb, var(--color-text) 72%, transparent);
+}
+
+.leaderboard-sortable-header-icon--active {
+  color: var(--color-accent-blue);
+}
+
 .scoreboard-table .leaderboard-col-rank {
   width: 56px;
   text-align: center;

--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -1184,6 +1184,11 @@ describe("Leaderboard", () => {
 
     await user.click(screen.getByRole("button", { name: /^Rating\./i }));
     expect(getRenderedPlayerOrder()).toEqual(["Alice", "Bob", "Cara"]);
+    const ratingButton = screen.getByRole("button", { name: /^Rating\./i });
+    expect(ratingButton).toHaveClass("leaderboard-sortable-header-button--active");
+    expect(ratingButton.closest("[role='columnheader']")).toHaveClass(
+      "leaderboard-sortable-header-cell--active",
+    );
 
     await user.keyboard("[ShiftLeft>]");
     await user.click(screen.getByRole("button", { name: /^Matches\./i }));

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -1671,6 +1671,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       useNativeElements: boolean,
     ) => {
       const direction = getSortForColumn(column);
+      const isSorted = direction !== undefined;
       const ariaSort = getAriaSort(column);
       const sortPriority = getSortPriority(column);
       const actionHint =
@@ -1686,11 +1687,18 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         ? { "aria-sort": ariaSort, scope: "col" as const }
         : { role: "columnheader", "aria-sort": ariaSort };
       return (
-        <ColumnElement {...columnProps} style={style}>
+        <ColumnElement
+          {...columnProps}
+          style={style}
+          className={isSorted ? "leaderboard-sortable-header-cell--active" : undefined}
+        >
           <button
             type="button"
             onClick={(event) => toggleSort(column, event.shiftKey)}
             aria-label={`${label}. ${actionHint}${shiftHint}`}
+            className={`leaderboard-sortable-header-button${
+              isSorted ? " leaderboard-sortable-header-button--active" : ""
+            }`}
             style={{
               display: "inline-flex",
               alignItems: "center",
@@ -1699,14 +1707,13 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               margin: 0,
               border: "none",
               borderRadius: "0.45rem",
-              background:
-                direction == null
-                  ? "transparent"
-                  : "color-mix(in srgb, var(--color-accent-blue) 16%, var(--leaderboard-table-header-bg))",
-              color: "inherit",
+              background: "transparent",
+              color: isSorted
+                ? "var(--color-text-strong, var(--color-text))"
+                : "inherit",
               font: "inherit",
               cursor: "pointer",
-              fontWeight: direction == null ? 500 : 700,
+              fontWeight: isSorted ? 700 : 500,
             }}
           >
             <span>{label}</span>
@@ -1730,18 +1737,21 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
               </span>
             ) : null}
             <span
+              className={`leaderboard-sortable-header-icon${
+                isSorted ? " leaderboard-sortable-header-icon--active" : ""
+              }`}
               aria-hidden="true"
               style={{
-                fontSize: direction == null ? "0.88em" : "1em",
-                fontWeight: direction == null ? 500 : 800,
-                opacity: direction == null ? 0.8 : 1,
+                fontSize: isSorted ? "1.08em" : "0.98em",
+                fontWeight: isSorted ? 800 : 600,
+                opacity: isSorted ? 1 : 0.92,
               }}
             >
               {direction === "ascending"
-                ? "⬆"
+                ? "▲"
                 : direction === "descending"
-                  ? "⬇"
-                  : "⇅"}
+                  ? "▼"
+                  : "↕"}
             </span>
           </button>
         </ColumnElement>


### PR DESCRIPTION
### Motivation

- Make sorted leaderboard columns more visually prominent so users can immediately identify active sort(s).
- Replace low-contrast raw arrow characters with clearer directional glyphs and increase icon emphasis while preserving accessibility.

### Description

- In `renderSortableHeader` derive `isSorted` from the current `direction` with `const isSorted = direction !== undefined` and use it to drive active state styling.  
- Apply conditional classes to the column container and button: `leaderboard-sortable-header-cell--active`, `leaderboard-sortable-header-button--active`, and `leaderboard-sortable-header-icon--active` while keeping `aria-sort` and descriptive `aria-label` hints unchanged.  
- Replace the raw text arrows with clearer glyphs (`▲`, `▼`, `↕`) and increase their visual weight when active.  
- Move visual styles into `apps/web/src/app/globals.css` as reusable CSS rules for the new classes instead of relying on mixed inline styles.
- Extend `apps/web/src/app/leaderboard/leaderboard.test.tsx` to click a sortable header and assert that both the header button and its column header container receive the active classes.

### Testing

- Ran the leaderboard unit tests with `pnpm --filter @cst/web test --watch=false src/app/leaderboard/leaderboard.test.tsx` and observed all tests in that file pass: "1 passed (32 tests)".  
- An earlier test invocation using the package-root path (`apps/web/src/...`) returned no test files due to the package test runner path; the corrected command above was used for the validated run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ea7102708323915428491d40e86d)