### PR TITLE
fix(web): normalize workspace-prefixed vitest test paths

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start -p 3000",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "node scripts/run-vitest.mjs"
   },
   "dependencies": {
     "@zxcvbn-ts/core": "^3.0.4",

--- a/apps/web/scripts/run-vitest.mjs
+++ b/apps/web/scripts/run-vitest.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+
+const stripWorkspacePrefix = (arg) => {
+  if (arg.startsWith('-')) {
+    return arg;
+  }
+
+  if (arg.startsWith('apps/web/')) {
+    return arg.slice('apps/web/'.length);
+  }
+
+  return arg;
+};
+
+const args = process.argv.slice(2).map(stripWorkspacePrefix);
+const result = spawnSync('pnpm', ['exec', 'vitest', ...args], {
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
### Motivation
- Running `pnpm --filter @cst/web test ...` from the repository root can pass workspace-prefixed paths like `apps/web/...` which are invalid inside the package, causing tests not to be discovered.

### Description
- Replace the `@cst/web` `test` script with a small wrapper `node scripts/run-vitest.mjs` that normalizes arguments before invoking `vitest`.
- Add `apps/web/scripts/run-vitest.mjs` which strips a leading `apps/web/` from positional arguments while preserving flags and other args, then runs `pnpm exec vitest` with the normalized args.
- The change preserves existing behavior for already-correct package-relative paths and preserves stdout/stderr and the exit code from `vitest`.

### Testing
- Ran `pnpm --filter @cst/web test --watch=false apps/web/src/app/leaderboard/leaderboard.test.tsx` and the test suite passed.
- Ran `pnpm --filter @cst/web test --watch=false src/app/leaderboard/leaderboard.test.tsx` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6eba855f88323bbf70f5815c0c907)