### PR TITLE
test(web): retain country/club filters when switching leaderboard sports tabs

### DIFF
--- a/apps/web/src/app/leaderboard/leaderboard.test.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.test.tsx
@@ -228,14 +228,19 @@ describe("Leaderboard", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
-  it("retains country and club filters when switching sports", async () => {
+  it("retains country and club filters when switching sports tabs", async () => {
     const user = userEvent.setup();
     const fetchMock = vi
       .fn()
       .mockResolvedValue({ ok: true, json: async () => [] });
     global.fetch = fetchMock as typeof fetch;
+    updateMockLocation("/leaderboard?sport=padel&country=SE&clubId=club-123");
 
-    await renderLeaderboard({ sport: "padel", country: "SE", clubId: "club-123" });
+    const view = await renderLeaderboard({
+      sport: "padel",
+      country: "SE",
+      clubId: "club-123",
+    });
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     replaceMock.mockClear();
@@ -249,6 +254,18 @@ describe("Leaderboard", () => {
     expect(url.searchParams.get("sport")).toBe("disc_golf");
     expect(url.searchParams.get("country")).toBe("SE");
     expect(url.searchParams.get("clubId")).toBe("club-123");
+
+    updateMockLocation("/leaderboard?sport=disc_golf&country=SE&clubId=club-123");
+    view.rerender(
+      <NextIntlClientProvider locale="en-GB" messages={enMessages}>
+        <Leaderboard sport="disc_golf" country="SE" clubId="club-123" />
+      </NextIntlClientProvider>,
+    );
+
+    const countrySelect = await screen.findByRole("combobox", { name: "Country" });
+    const clubSelect = await screen.findByRole("combobox", { name: "Club" });
+    expect(countrySelect).toHaveValue("Sweden");
+    expect(clubSelect).toHaveValue("club-123");
   });
 
   it("renders the leaderboard table inside a scrollable wrapper while loading", async () => {


### PR DESCRIPTION
### Motivation
- Ensure the leaderboard preserves region filters when a user navigates between sport tabs starting from a URL that already includes `sport`, `country`, and `clubId` query params.
- Verify that after client-side tab navigation the router update keeps the same `country` and `clubId` and that the filter controls reflect those values after rerendering with the new sport.

### Description
- Renamed the test to `retains country and club filters when switching sports tabs` and initialized the test location with `updateMockLocation("/leaderboard?sport=padel&country=SE&clubId=club-123")` before rendering.
- Rendered the component with `sport="padel"`, `country="SE"`, and `clubId="club-123"`, clicked the Disc Golf tab, and asserted the router `replace` URL includes `sport=disc_golf` while keeping `country=SE` and `clubId=club-123`.
- Rerendered the view with `sport="disc_golf"` and asserted the `Country` and `Club` controls still show `Sweden` and `club-123` respectively.

### Testing
- Ran `pnpm --filter @cst/web test -- leaderboard.test.tsx`, and the leaderboard test file passed (35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6eebcd7a88323a29e7db4ae5b9404)