### PR TITLE
Centralize leaderboard sorting state in useSorting hook

### DIFF
--- a/apps/web/src/app/leaderboard/hooks/useSorting.test.ts
+++ b/apps/web/src/app/leaderboard/hooks/useSorting.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSorting } from "./useSorting";
+
+describe("useSorting", () => {
+  it("cycles unsorted -> descending -> ascending -> cleared", () => {
+    const { result } = renderHook(() => useSorting());
+
+    expect(result.current.sortState).toEqual([]);
+
+    act(() => {
+      result.current.toggleSort("rating");
+    });
+    expect(result.current.sortState).toEqual([
+      { column: "rating", direction: "descending" },
+    ]);
+    expect(result.current.getSortForColumn("rating")).toBe("descending");
+    expect(result.current.getSortPriority("rating")).toBe(1);
+    expect(result.current.getAriaSort("rating")).toBe("descending");
+
+    act(() => {
+      result.current.toggleSort("rating");
+    });
+    expect(result.current.sortState).toEqual([
+      { column: "rating", direction: "ascending" },
+    ]);
+    expect(result.current.getSortForColumn("rating")).toBe("ascending");
+    expect(result.current.getAriaSort("rating")).toBe("ascending");
+
+    act(() => {
+      result.current.toggleSort("rating");
+    });
+    expect(result.current.sortState).toEqual([]);
+    expect(result.current.getSortForColumn("rating")).toBeUndefined();
+    expect(result.current.getSortPriority("rating")).toBeNull();
+    expect(result.current.getAriaSort("rating")).toBe("none");
+  });
+
+  it("supports additive multi-column sorting transitions", () => {
+    const { result } = renderHook(() => useSorting());
+
+    act(() => {
+      result.current.toggleSort("rating", true);
+      result.current.toggleSort("player", true);
+    });
+
+    expect(result.current.sortState).toEqual([
+      { column: "rating", direction: "descending" },
+      { column: "player", direction: "descending" },
+    ]);
+    expect(result.current.getSortPriority("rating")).toBe(1);
+    expect(result.current.getSortPriority("player")).toBe(2);
+
+    act(() => {
+      result.current.toggleSort("rating", true);
+    });
+    expect(result.current.sortState).toEqual([
+      { column: "rating", direction: "ascending" },
+      { column: "player", direction: "descending" },
+    ]);
+
+    act(() => {
+      result.current.toggleSort("rating", true);
+    });
+    expect(result.current.sortState).toEqual([
+      { column: "player", direction: "descending" },
+    ]);
+    expect(result.current.getSortPriority("rating")).toBeNull();
+    expect(result.current.getSortPriority("player")).toBe(1);
+  });
+});

--- a/apps/web/src/app/leaderboard/hooks/useSorting.ts
+++ b/apps/web/src/app/leaderboard/hooks/useSorting.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from "react";
+
+export type SortDirection = "ascending" | "descending";
+
+export type SortableColumn =
+  | "player"
+  | "sport"
+  | "rating"
+  | "winChance"
+  | "wins"
+  | "losses"
+  | "matches"
+  | "winPercent"
+  | "highestScore"
+  | "averageScore"
+  | "standardDeviation";
+
+export type SortCriterion = { column: SortableColumn; direction: SortDirection };
+
+type AriaSort = "none" | SortDirection;
+
+export function useSorting(defaultSort: SortCriterion[] = []) {
+  const [sortState, setSortState] = useState<SortCriterion[]>(() => [...defaultSort]);
+
+  const toggleSort = useCallback((column: SortableColumn, additive = false) => {
+    setSortState((prev) => {
+      const existingIndex = prev.findIndex((criterion) => criterion.column === column);
+      const existing = existingIndex === -1 ? null : prev[existingIndex];
+
+      if (!additive) {
+        if (!existing) {
+          return [{ column, direction: "descending" }];
+        }
+        if (existing.direction === "descending") {
+          return [{ column, direction: "ascending" }];
+        }
+        return [];
+      }
+
+      if (!existing) {
+        return [...prev, { column, direction: "descending" }];
+      }
+
+      if (existing.direction === "descending") {
+        const next = [...prev];
+        next[existingIndex] = { column, direction: "ascending" };
+        return next;
+      }
+
+      return prev.filter((criterion) => criterion.column !== column);
+    });
+  }, []);
+
+  const getSortForColumn = useCallback(
+    (column: SortableColumn): SortDirection | undefined =>
+      sortState.find((criterion) => criterion.column === column)?.direction,
+    [sortState],
+  );
+
+  const getSortPriority = useCallback(
+    (column: SortableColumn): number | null => {
+      const index = sortState.findIndex((criterion) => criterion.column === column);
+      return index === -1 ? null : index + 1;
+    },
+    [sortState],
+  );
+
+  const getAriaSort = useCallback(
+    (column: SortableColumn): AriaSort => getSortForColumn(column) ?? "none",
+    [getSortForColumn],
+  );
+
+  return {
+    sortState,
+    toggleSort,
+    getSortForColumn,
+    getSortPriority,
+    getAriaSort,
+  };
+}

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -32,6 +32,7 @@ import {
 } from "./constants";
 import { PREVIOUS_ROUTE_STORAGE_KEY } from "../../lib/navigation-history";
 import { useLeaderboardData, type ID, type Leader } from "./hooks/useLeaderboardData";
+import { useSorting, type SortableColumn } from "./hooks/useSorting";
 
 type Props = {
   sport: LeaderboardSport;
@@ -206,21 +207,8 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   const [tableWidth, setTableWidth] = useState(0);
-  type SortDirection = "ascending" | "descending";
-  type SortableColumn =
-    | "player"
-    | "sport"
-    | "rating"
-    | "winChance"
-    | "wins"
-    | "losses"
-    | "matches"
-    | "winPercent"
-    | "highestScore"
-    | "averageScore"
-    | "standardDeviation";
-  type SortCriterion = { column: SortableColumn; direction: SortDirection };
-  const [sortCriteria, setSortCriteria] = useState<SortCriterion[]>([]);
+  const { sortState, toggleSort, getSortForColumn, getSortPriority, getAriaSort } =
+    useSorting([]);
   const previousFilterPropsRef = useRef<{
     country?: string | null;
     clubId?: string | null;
@@ -230,7 +218,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       sport,
       country: appliedCountry,
       club: appliedClubId,
-      sortState: sortCriteria,
+      sortState,
     });
 
 
@@ -1134,55 +1122,6 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     [],
   );
 
-  const getSortForColumn = useCallback(
-    (column: SortableColumn): SortDirection | undefined =>
-      sortCriteria.find((criterion) => criterion.column === column)?.direction,
-    [sortCriteria],
-  );
-
-  const getSortPriority = useCallback(
-    (column: SortableColumn): number | null => {
-      const index = sortCriteria.findIndex((criterion) => criterion.column === column);
-      return index === -1 ? null : index + 1;
-    },
-    [sortCriteria],
-  );
-
-  const toggleSort = useCallback((column: SortableColumn, additive = false) => {
-    setSortCriteria((prev) => {
-      const existingIndex = prev.findIndex((criterion) => criterion.column === column);
-      const existing = existingIndex === -1 ? null : prev[existingIndex];
-
-      if (!additive) {
-        if (!existing) {
-          return [{ column, direction: "descending" }];
-        }
-        if (existing.direction === "descending") {
-          return [{ column, direction: "ascending" }];
-        }
-        return [];
-      }
-
-      if (!existing) {
-        return [...prev, { column, direction: "descending" }];
-      }
-
-      if (existing.direction === "descending") {
-        const next = [...prev];
-        next[existingIndex] = { column, direction: "ascending" };
-        return next;
-      }
-
-      return prev.filter((criterion) => criterion.column !== column);
-    });
-  }, []);
-
-  type AriaSort = "none" | SortDirection;
-  const getAriaSort = useCallback(
-    (column: SortableColumn): AriaSort => getSortForColumn(column) ?? "none",
-    [getSortForColumn],
-  );
-
   const renderSortableHeader = useCallback(
     (
       column: SortableColumn,
@@ -1295,7 +1234,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
         <RowElement {...rowProps} style={headerRowStyle}>
           <ColumnElement
             {...columnHeaderProps}
-            aria-sort={sortCriteria.length > 0 ? "none" : "ascending"}
+            aria-sort={sortState.length > 0 ? "none" : "ascending"}
             style={headerCellStyle}
           >
             #
@@ -1401,7 +1340,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
   );
 
   const sortedLeaders = useMemo(() => {
-    if (sortCriteria.length === 0) {
+    if (sortState.length === 0) {
       return leaders;
     }
     const getComparableValue = (
@@ -1447,7 +1386,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       }
     };
     return [...leaders].sort((a, b) => {
-      for (const criterion of sortCriteria) {
+      for (const criterion of sortState) {
         const aValue = getComparableValue(a, criterion.column);
         const bValue = getComparableValue(b, criterion.column);
         if (aValue == null && bValue == null) {
@@ -1487,7 +1426,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       }
       return (a.rank ?? 0) - (b.rank ?? 0);
     });
-  }, [getWinProbability, isBowling, leaders, sortCollator, sortCriteria]);
+  }, [getWinProbability, isBowling, leaders, sortCollator, sortState]);
 
   useEffect(() => {
     const element = tableContainerRef.current;
@@ -1564,7 +1503,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
           }}
         >
           <div role="cell" style={cellStyle}>
-            {sortCriteria.length > 0 ? index + 1 : row.rank}
+            {sortState.length > 0 ? index + 1 : row.rank}
           </div>
           <div role="cell" style={cellStyle}>
             {row.playerName}
@@ -1628,7 +1567,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       isBowling,
       lastCellStyle,
       rowGridStyle,
-      sortCriteria,
+      sortState,
       sport,
       topRatedLeader,
     ],


### PR DESCRIPTION
### Motivation
- Centralize sorting state and logic for the leaderboard to avoid duplicated code and make behavior easier to test and reuse. 
- Separate concerns so the hook manages sort UI state while the leaderboard component retains responsibility for actual row ordering.

### Description
- Add `useSorting` at `apps/web/src/app/leaderboard/hooks/useSorting.ts` and move sorting-related types (`SortDirection`, `SortableColumn`, `SortCriterion`) into the module. 
- Implement `useSorting(defaultSort)` exposing `sortState`, `toggleSort(column, additive)`, `getSortForColumn`, `getSortPriority`, and `getAriaSort` to preserve existing shift-click/additive behaviour.
- Refactor `apps/web/src/app/leaderboard/leaderboard.tsx` to consume `useSorting`, remove the inline sort types/state/helpers, and pass `sortState` through to `useLeaderboardData` while keeping `sortedLeaders` (row ordering) in the component.
- Add unit tests at `apps/web/src/app/leaderboard/hooks/useSorting.test.ts` covering the sort cycle and additive multi-column transitions.

### Testing
- Ran `pnpm --dir apps/web exec vitest run src/app/leaderboard/hooks/useSorting.test.ts` and the test file passed.
- Ran `pnpm --dir apps/web exec vitest run src/app/leaderboard/leaderboard.test.tsx` and the leaderboard tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bddfa780832399c47a0ea7035bda)