### PR TITLE
Refactor leaderboard derived metrics into shared helpers/selectors

### DIFF
--- a/apps/web/src/app/leaderboard/components/LeaderboardTable.tsx
+++ b/apps/web/src/app/leaderboard/components/LeaderboardTable.tsx
@@ -16,6 +16,7 @@ import type {
   SortDirection,
   SortableColumn,
 } from "../hooks/useSorting";
+import { selectLeaderDerivedMetrics } from "../lib/leaderboardMetrics";
 
 const VIRTUALIZATION_THRESHOLD = 50;
 const VIRTUAL_ROW_HEIGHT = 40;
@@ -350,11 +351,8 @@ export default function LeaderboardTable({
 
   const buildRow = useCallback(
     (row: Leader, index: number, style?: CSSProperties) => {
-      const won = row.setsWon ?? 0;
-      const lost = row.setsLost ?? 0;
-      const total = won + lost;
-      const winPct = !isBowling && total > 0 ? Math.round((won / total) * 100) : null;
-      const matchesPlayed = row.matchesPlayed ?? row.sets ?? null;
+      const derivedMetrics = selectLeaderDerivedMetrics(row);
+      const winPct = !isBowling ? derivedMetrics.winPercentage : null;
       const rowKey = `${row.rank}-${row.playerId}-${row.sport ?? ""}`;
       return (
         <div
@@ -398,7 +396,7 @@ export default function LeaderboardTable({
                 {formatDecimal(row.averageScore ?? null)}
               </div>
               <div role="cell" style={cellStyle}>
-                {formatInteger(matchesPlayed)}
+                {formatInteger(derivedMetrics.bowlingMatchesPlayed)}
               </div>
               <div role="cell" style={lastCellStyle}>
                 {formatDecimal(row.standardDeviation ?? null)}
@@ -413,10 +411,10 @@ export default function LeaderboardTable({
                 {row.setsLost ?? "—"}
               </div>
               <div role="cell" style={cellStyle}>
-                {total || "—"}
+                {derivedMetrics.matchesTotal || "—"}
               </div>
               <div role="cell" style={lastCellStyle}>
-                {winPct != null ? `${winPct}%` : "—"}
+                {winPct != null ? `${Math.round(winPct)}%` : "—"}
               </div>
             </>
           )}

--- a/apps/web/src/app/leaderboard/leaderboard.tsx
+++ b/apps/web/src/app/leaderboard/leaderboard.tsx
@@ -29,8 +29,13 @@ import {
 import EmptyState, { type EmptyStateContent } from "./components/EmptyState";
 import LeaderboardTable from "./components/LeaderboardTable";
 import { PREVIOUS_ROUTE_STORAGE_KEY } from "../../lib/navigation-history";
-import { useLeaderboardData, type ID, type Leader } from "./hooks/useLeaderboardData";
-import { useSorting, type SortableColumn } from "./hooks/useSorting";
+import { useLeaderboardData, type Leader } from "./hooks/useLeaderboardData";
+import { useSorting } from "./hooks/useSorting";
+import {
+  getSortComparableValue,
+  getWinProbabilityAgainstTopPlayer,
+  selectTopRatedLeader,
+} from "./lib/leaderboardMetrics";
 
 type Props = {
   sport: LeaderboardSport;
@@ -742,27 +747,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     [columnDescription, tableCaption],
   );
 
-  const topRatedLeader = useMemo<{ playerId: ID; rating: number } | null>(() => {
-    let topByRank: { playerId: ID; rating: number } | null = null;
-    let topByRating: { playerId: ID; rating: number } | null = null;
-
-    leaders.forEach((leader) => {
-      const rating = leader.rating;
-      if (typeof rating !== "number" || !Number.isFinite(rating)) {
-        return;
-      }
-
-      if (leader.rank === 1) {
-        topByRank = { playerId: leader.playerId, rating };
-      }
-
-      if (!topByRating || rating > topByRating.rating) {
-        topByRating = { playerId: leader.playerId, rating };
-      }
-    });
-
-    return topByRank ?? topByRating;
-  }, [leaders]);
+  const topRatedLeader = useMemo(() => selectTopRatedLeader(leaders), [leaders]);
 
   const hasAppliedFilters = Boolean(appliedCountry || appliedClubId);
   const canClear = hasAppliedFilters;
@@ -985,75 +970,46 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
     [locale],
   );
 
+  const winProbabilityByPlayerId = useMemo(
+    () =>
+      new Map(
+        leaders.map((leader) => [
+          leader.playerId,
+          getWinProbabilityAgainstTopPlayer(
+            leader,
+            topRatedLeader,
+            computeExpectedWinProbability,
+          ),
+        ]),
+      ),
+    [computeExpectedWinProbability, leaders, sport, topRatedLeader],
+  );
+
   const getWinProbability = useCallback(
-    (leader: Leader) => {
-      const topRatedPlayerId = topRatedLeader?.playerId;
-      const topRatedRating = topRatedLeader?.rating;
-      if (
-        typeof topRatedRating !== "number" ||
-        !Number.isFinite(topRatedRating) ||
-        topRatedPlayerId == null
-      ) {
-        return null;
-      }
-      if (leader.playerId === topRatedPlayerId) {
-        return null;
-      }
-      return computeExpectedWinProbability(leader.rating, topRatedRating);
-    },
-    [computeExpectedWinProbability, topRatedLeader],
+    (leader: Leader) => winProbabilityByPlayerId.get(leader.playerId) ?? null,
+    [winProbabilityByPlayerId],
   );
 
   const sortedLeaders = useMemo(() => {
     if (sortState.length === 0) {
       return leaders;
     }
-    const getComparableValue = (
-      leader: Leader,
-      column: SortableColumn,
-    ): number | string | null => {
-      switch (column) {
-        case "player":
-          return leader.playerName ?? "";
-        case "sport":
-          return leader.sport ? formatSportName(leader.sport) : "";
-        case "rating":
-          return leader.rating ?? null;
-        case "winChance":
-          return getWinProbability(leader);
-        case "wins":
-          return leader.setsWon ?? null;
-        case "losses":
-          return leader.setsLost ?? null;
-        case "matches": {
-          if (isBowling) {
-            return leader.matchesPlayed ?? leader.sets ?? null;
-          }
-          const won = leader.setsWon ?? 0;
-          const lost = leader.setsLost ?? 0;
-          const total = won + lost;
-          return total === 0 ? 0 : total;
-        }
-        case "winPercent": {
-          const won = leader.setsWon ?? 0;
-          const lost = leader.setsLost ?? 0;
-          const total = won + lost;
-          return total === 0 ? null : (won / total) * 100;
-        }
-        case "highestScore":
-          return leader.highestScore ?? null;
-        case "averageScore":
-          return leader.averageScore ?? null;
-        case "standardDeviation":
-          return leader.standardDeviation ?? null;
-        default:
-          return null;
-      }
-    };
     return [...leaders].sort((a, b) => {
       for (const criterion of sortState) {
-        const aValue = getComparableValue(a, criterion.column);
-        const bValue = getComparableValue(b, criterion.column);
+        const aValue = getSortComparableValue({
+          leader: a,
+          column: criterion.column,
+          isBowling,
+          formatSportName,
+          getWinProbability,
+        });
+        const bValue = getSortComparableValue({
+          leader: b,
+          column: criterion.column,
+          isBowling,
+          formatSportName,
+          getWinProbability,
+        });
         if (aValue == null && bValue == null) {
           continue;
         }
@@ -1091,7 +1047,7 @@ export default function Leaderboard({ sport, country, clubId }: Props) {
       }
       return (a.rank ?? 0) - (b.rank ?? 0);
     });
-  }, [getWinProbability, isBowling, leaders, sortCollator, sortState]);
+  }, [formatSportName, getWinProbability, isBowling, leaders, sortCollator, sortState]);
 
 
   return (

--- a/apps/web/src/app/leaderboard/lib/leaderboardMetrics.test.ts
+++ b/apps/web/src/app/leaderboard/lib/leaderboardMetrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Leader } from "../hooks/useLeaderboardData";
+import {
+  getBowlingMatchesPlayed,
+  getMatchesTotal,
+  getSortComparableValue,
+  getWinPercentage,
+  getWinProbabilityAgainstTopPlayer,
+  selectTopRatedLeader,
+} from "./leaderboardMetrics";
+
+const makeLeader = (overrides: Partial<Leader> = {}): Leader => ({
+  rank: 1,
+  playerId: "player-1",
+  playerName: "Player One",
+  ...overrides,
+});
+
+describe("leaderboardMetrics", () => {
+  it("falls back to highest rated leader when rank #1 has null rating", () => {
+    const leaders: Leader[] = [
+      makeLeader({ rank: 1, playerId: "p1", rating: null }),
+      makeLeader({ rank: 2, playerId: "p2", rating: 1200 }),
+      makeLeader({ rank: 3, playerId: "p3", rating: 1100 }),
+    ];
+
+    expect(selectTopRatedLeader(leaders)).toEqual({ playerId: "p2", rating: 1200 });
+  });
+
+  it("returns null win percentage when a player has zero matches", () => {
+    const leader = makeLeader({ setsWon: 0, setsLost: 0 });
+
+    expect(getMatchesTotal(leader)).toBe(0);
+    expect(getWinPercentage(leader)).toBeNull();
+  });
+
+  it("uses bowling matchesPlayed fallback to sets", () => {
+    const leaderWithMatches = makeLeader({ matchesPlayed: 14, sets: 20 });
+    const leaderWithSetsOnly = makeLeader({ matchesPlayed: null, sets: 9 });
+    const leaderWithoutStats = makeLeader({ matchesPlayed: null, sets: undefined });
+
+    expect(getBowlingMatchesPlayed(leaderWithMatches)).toBe(14);
+    expect(getBowlingMatchesPlayed(leaderWithSetsOnly)).toBe(9);
+    expect(getBowlingMatchesPlayed(leaderWithoutStats)).toBeNull();
+  });
+
+  it("returns null win probability for the top player", () => {
+    const computeExpectedWinProbability = vi.fn(() => 0.42);
+    const topRatedLeader = { playerId: "p1", rating: 1200 };
+    const leader = makeLeader({ playerId: "p1", rating: 1200 });
+
+    expect(
+      getWinProbabilityAgainstTopPlayer(
+        leader,
+        topRatedLeader,
+        computeExpectedWinProbability,
+      ),
+    ).toBeNull();
+    expect(computeExpectedWinProbability).not.toHaveBeenCalled();
+  });
+
+  it("reuses shared metric derivations for sorting values", () => {
+    const leader = makeLeader({
+      matchesPlayed: null,
+      sets: 8,
+      setsWon: 6,
+      setsLost: 2,
+      sport: "padel",
+    });
+
+    expect(
+      getSortComparableValue({
+        leader,
+        column: "matches",
+        isBowling: false,
+        formatSportName: (value) => String(value),
+        getWinProbability: () => null,
+      }),
+    ).toBe(8);
+
+    expect(
+      getSortComparableValue({
+        leader,
+        column: "matches",
+        isBowling: true,
+        formatSportName: (value) => String(value),
+        getWinProbability: () => null,
+      }),
+    ).toBe(8);
+
+    expect(
+      getSortComparableValue({
+        leader,
+        column: "winPercent",
+        isBowling: false,
+        formatSportName: (value) => String(value),
+        getWinProbability: () => null,
+      }),
+    ).toBe(75);
+  });
+});

--- a/apps/web/src/app/leaderboard/lib/leaderboardMetrics.ts
+++ b/apps/web/src/app/leaderboard/lib/leaderboardMetrics.ts
@@ -1,0 +1,146 @@
+import type { Leader, ID } from "../hooks/useLeaderboardData";
+import type { SortableColumn } from "../hooks/useSorting";
+
+type TopRatedLeader = { playerId: ID; rating: number };
+
+type WinProbabilityComputer = (
+  playerRating: number | null | undefined,
+  opponentRating: number | null | undefined,
+) => number | null;
+
+export type LeaderDerivedMetrics = {
+  matchesTotal: number;
+  winPercentage: number | null;
+  bowlingMatchesPlayed: number | null;
+};
+
+const leaderDerivedMetricsCache = new WeakMap<Leader, LeaderDerivedMetrics>();
+const topRatedLeaderCache = new WeakMap<Leader[], TopRatedLeader | null>();
+
+export const getMatchesTotal = (leader: Leader): number => {
+  const won = leader.setsWon ?? 0;
+  const lost = leader.setsLost ?? 0;
+  return won + lost;
+};
+
+export const getWinPercentage = (leader: Leader): number | null => {
+  const total = getMatchesTotal(leader);
+  if (total === 0) {
+    return null;
+  }
+  return ((leader.setsWon ?? 0) / total) * 100;
+};
+
+export const getBowlingMatchesPlayed = (leader: Leader): number | null =>
+  leader.matchesPlayed ?? leader.sets ?? null;
+
+export const selectLeaderDerivedMetrics = (leader: Leader): LeaderDerivedMetrics => {
+  const cached = leaderDerivedMetricsCache.get(leader);
+  if (cached) {
+    return cached;
+  }
+
+  const next = {
+    matchesTotal: getMatchesTotal(leader),
+    winPercentage: getWinPercentage(leader),
+    bowlingMatchesPlayed: getBowlingMatchesPlayed(leader),
+  };
+
+  leaderDerivedMetricsCache.set(leader, next);
+  return next;
+};
+
+export const selectTopRatedLeader = (leaders: Leader[]): TopRatedLeader | null => {
+  const cached = topRatedLeaderCache.get(leaders);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let topByRank: TopRatedLeader | null = null;
+  let topByRating: TopRatedLeader | null = null;
+
+  leaders.forEach((leader) => {
+    const rating = leader.rating;
+    if (typeof rating !== "number" || !Number.isFinite(rating)) {
+      return;
+    }
+
+    if (leader.rank === 1) {
+      topByRank = { playerId: leader.playerId, rating };
+    }
+
+    if (!topByRating || rating > topByRating.rating) {
+      topByRating = { playerId: leader.playerId, rating };
+    }
+  });
+
+  const selected = topByRank ?? topByRating;
+  topRatedLeaderCache.set(leaders, selected);
+  return selected;
+};
+
+export const getWinProbabilityAgainstTopPlayer = (
+  leader: Leader,
+  topRatedLeader: TopRatedLeader | null,
+  computeExpectedWinProbability: WinProbabilityComputer,
+): number | null => {
+  const topRatedPlayerId = topRatedLeader?.playerId;
+  const topRatedRating = topRatedLeader?.rating;
+  if (
+    typeof topRatedRating !== "number" ||
+    !Number.isFinite(topRatedRating) ||
+    topRatedPlayerId == null
+  ) {
+    return null;
+  }
+  if (leader.playerId === topRatedPlayerId) {
+    return null;
+  }
+
+  return computeExpectedWinProbability(leader.rating, topRatedRating);
+};
+
+type ComparableValueOptions = {
+  leader: Leader;
+  column: SortableColumn;
+  isBowling: boolean;
+  formatSportName: (sportId: string | null | undefined) => string;
+  getWinProbability: (leader: Leader) => number | null;
+};
+
+export const getSortComparableValue = ({
+  leader,
+  column,
+  isBowling,
+  formatSportName,
+  getWinProbability,
+}: ComparableValueOptions): number | string | null => {
+  const metrics = selectLeaderDerivedMetrics(leader);
+
+  switch (column) {
+    case "player":
+      return leader.playerName ?? "";
+    case "sport":
+      return leader.sport ? formatSportName(leader.sport) : "";
+    case "rating":
+      return leader.rating ?? null;
+    case "winChance":
+      return getWinProbability(leader);
+    case "wins":
+      return leader.setsWon ?? null;
+    case "losses":
+      return leader.setsLost ?? null;
+    case "matches":
+      return isBowling ? metrics.bowlingMatchesPlayed : metrics.matchesTotal;
+    case "winPercent":
+      return metrics.winPercentage;
+    case "highestScore":
+      return leader.highestScore ?? null;
+    case "averageScore":
+      return leader.averageScore ?? null;
+    case "standardDeviation":
+      return leader.standardDeviation ?? null;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
### Motivation
- Consolidate duplicated derived leaderboard logic (top-rated lookup, win probability, matches total, win% and bowling fallbacks) into a single place to reduce inconsistencies and duplication.
- Memoize heavy computations and avoid storing derived values in component state to improve performance and predictability.
- Make sorting and row rendering use the same derivations so behavior is consistent across UI and comparator logic.

### Description
- Added a new helper module `apps/web/src/app/leaderboard/lib/leaderboardMetrics.ts` that exposes selectors and helpers: `selectTopRatedLeader`, `getWinProbabilityAgainstTopPlayer`, `selectLeaderDerivedMetrics`, `getMatchesTotal`, `getWinPercentage`, `getBowlingMatchesPlayed`, and `getSortComparableValue`, with local memoization using `WeakMap`.
- Replaced inline derivation code in `leaderboard.tsx` with shared helpers, memoizing win probabilities in a `useMemo` keyed by `leaders`, `sport`, and the probability function, and using `getSortComparableValue` inside the sorting comparator.
- Updated `LeaderboardTable` to use `selectLeaderDerivedMetrics` for row rendering (matches total, win% formatting, bowling matches fallback) so formatting and sorting use the same derived values and no derived metrics are stored in component state.
- Added focused unit tests at `apps/web/src/app/leaderboard/lib/leaderboardMetrics.test.ts` to lock behavior for edge cases: null ratings, zero matches, bowling fallback, top-player win-probability, and sortable value outputs.

### Testing
- Ran `pnpm --filter @cst/web test --watch=false leaderboardMetrics` and the new helper tests passed.
- Ran `pnpm --filter @cst/web test --watch=false leaderboard` and the full leaderboard test suite passed (all relevant test files succeeded).
- All automated tests executed in CI-like commands completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c4126a9c83239a91c68bf0a199c2)