### PR TITLE
Improve ClubSelect keyboard navigation and combobox accessibility

### DIFF
--- a/apps/web/src/components/ClubSelect.test.tsx
+++ b/apps/web/src/components/ClubSelect.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ClubSelect from "./filters/ClubSelect";
@@ -31,13 +31,14 @@ describe("ClubSelect", () => {
     await user.clear(searchInput);
     await user.type(searchInput, "Testclub");
 
-    const matchingOption = await screen.findByRole("option", {
+    const suggestionList = await screen.findByRole("listbox", {
+      name: "Club suggestions",
+    });
+    const matchingOption = within(suggestionList).getByRole("option", {
       name: "Test Club",
     });
     expect(matchingOption).toBeInTheDocument();
-    expect(
-      screen.queryByRole("option", { name: "Nordic Padel" })
-    ).not.toBeInTheDocument();
+    expect(within(suggestionList).queryByRole("option", { name: "Nordic Padel" })).not.toBeInTheDocument();
   });
 
   it("matches accents when searching for clubs", async () => {
@@ -54,7 +55,10 @@ describe("ClubSelect", () => {
     await user.clear(searchInput);
     await user.type(searchInput, "Sao Paulo");
 
-    const matchingOption = await screen.findByRole("option", {
+    const suggestionList = await screen.findByRole("listbox", {
+      name: "Club suggestions",
+    });
+    const matchingOption = within(suggestionList).getByRole("option", {
       name: "São Paulo Padel",
     });
     expect(matchingOption).toBeInTheDocument();
@@ -79,9 +83,7 @@ describe("ClubSelect", () => {
       name: "Club suggestions",
     });
     expect(suggestionList).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Select Nordic Padel" })
-    ).toBeVisible();
+    expect(within(suggestionList).getByRole("option", { name: "Nordic Padel" })).toBeVisible();
   });
 
   it("selects a club when a suggestion is chosen", async () => {
@@ -98,12 +100,65 @@ describe("ClubSelect", () => {
     const searchInput = screen.getByLabelText("Search clubs");
     await user.type(searchInput, "nord");
 
-    const suggestionButton = await screen.findByRole("button", {
-      name: "Select Nordic Padel",
+    const suggestionList = await screen.findByRole("listbox", {
+      name: "Club suggestions",
     });
-    await user.click(suggestionButton);
+    const suggestionOption = within(suggestionList).getByRole("option", {
+      name: "Nordic Padel",
+    });
+    await user.click(suggestionOption);
 
     expect(handleChange).toHaveBeenCalledWith("club-5");
+  });
+
+  it("supports ArrowDown/ArrowUp/Enter/Escape for suggestions", async () => {
+    fetchClubsMock.mockResolvedValue([
+      { id: "club-1", name: "Nordic Padel" },
+      { id: "club-2", name: "Padel Club" },
+      { id: "club-3", name: "Court Kings" },
+    ]);
+    const handleChange = vi.fn();
+
+    render(<ClubSelect value="" onChange={handleChange} />);
+
+    await waitFor(() => expect(fetchClubsMock).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByRole("combobox", { name: "Search clubs" });
+    await user.type(searchInput, "padel");
+
+    const listbox = await screen.findByRole("listbox", { name: "Club suggestions" });
+    expect(listbox).toBeVisible();
+    expect(searchInput).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{ArrowDown}");
+    expect(within(listbox).getByRole("option", { name: "Nordic Padel" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.keyboard("{ArrowDown}");
+    expect(within(listbox).getByRole("option", { name: "Padel Club" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.keyboard("{ArrowUp}");
+    expect(within(listbox).getByRole("option", { name: "Nordic Padel" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.keyboard("{Enter}");
+    expect(handleChange).toHaveBeenCalledWith("club-1");
+
+    await user.type(searchInput, "padel");
+    await screen.findByRole("listbox", { name: "Club suggestions" });
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("listbox", { name: "Club suggestions" })).not.toBeInTheDocument();
+    expect(searchInput).toHaveValue("");
   });
 
   it("uses provided options without fetching fallback data", async () => {

--- a/apps/web/src/components/filters/ClubSelect.tsx
+++ b/apps/web/src/components/filters/ClubSelect.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   type ChangeEvent,
   type FocusEvent,
+  type KeyboardEvent,
 } from "react";
 
 import { fetchClubs, type ClubSummary } from "../../lib/api";
@@ -70,6 +71,7 @@ export default function ClubSelect({
   );
   const [searchTerm, setSearchTerm] = useState("");
   const [dirtySearch, setDirtySearch] = useState(false);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const searchInputId = searchInputIdProp ?? `${reactId}-club-search`;
@@ -139,6 +141,7 @@ export default function ClubSelect({
     (event: ChangeEvent<HTMLInputElement>) => {
       setDirtySearch(true);
       setSearchTerm(event.target.value);
+      setActiveSuggestionIndex(-1);
     },
     []
   );
@@ -237,15 +240,75 @@ export default function ClubSelect({
   );
 
   const suggestionListId = `${reactId}-club-suggestions`;
+  const visibleMatchingOptions = useMemo(
+    () => matchingOptions.slice(0, 5),
+    [matchingOptions]
+  );
+  const hasSuggestions = searchTerm.trim().length > 0 && visibleMatchingOptions.length > 0;
+  const activeSuggestion =
+    activeSuggestionIndex >= 0 && activeSuggestionIndex < visibleMatchingOptions.length
+      ? visibleMatchingOptions[activeSuggestionIndex]
+      : null;
 
   const handleSuggestionSelect = useCallback(
     (club: ClubSummary) => {
       if (disabled) return;
       setDirtySearch(false);
       setSearchTerm(club.name);
+      setActiveSuggestionIndex(-1);
       onChange(club.id);
     },
     [disabled, onChange]
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown") {
+        if (!hasSuggestions) {
+          return;
+        }
+        event.preventDefault();
+        setActiveSuggestionIndex((previous) =>
+          previous < visibleMatchingOptions.length - 1 ? previous + 1 : 0
+        );
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        if (!hasSuggestions) {
+          return;
+        }
+        event.preventDefault();
+        setActiveSuggestionIndex((previous) =>
+          previous > 0 ? previous - 1 : visibleMatchingOptions.length - 1
+        );
+        return;
+      }
+      if (event.key === "Enter") {
+        if (!hasSuggestions || !activeSuggestion) {
+          return;
+        }
+        event.preventDefault();
+        handleSuggestionSelect(activeSuggestion);
+        return;
+      }
+      if (event.key === "Escape") {
+        if (!searchTerm && !hasSuggestions && activeSuggestionIndex < 0) {
+          return;
+        }
+        event.preventDefault();
+        setActiveSuggestionIndex(-1);
+        setDirtySearch(false);
+        setSearchTerm("");
+      }
+    },
+    [
+      activeSuggestion,
+      activeSuggestionIndex,
+      handleSuggestionSelect,
+      hasSuggestions,
+      searchTerm,
+      visibleMatchingOptions.length,
+    ]
   );
 
   return (
@@ -260,10 +323,14 @@ export default function ClubSelect({
           ref={searchInputRef}
           value={searchTerm}
           onChange={handleSearchChange}
+          onKeyDown={handleSearchKeyDown}
           onFocus={handleFocus}
           placeholder={placeholder}
+          role="combobox"
+          aria-expanded={hasSuggestions}
+          aria-activedescendant={activeSuggestion ? `${suggestionListId}-${activeSuggestion.id}` : undefined}
           aria-describedby={ariaDescribedBy}
-          aria-controls={searchTerm.trim() ? suggestionListId : undefined}
+          aria-controls={hasSuggestions ? suggestionListId : undefined}
           disabled={disabled}
           autoComplete="off"
           style={{ flex: 1 }}
@@ -279,7 +346,7 @@ export default function ClubSelect({
           Clear
         </button>
       </div>
-      {searchTerm.trim() && matchingOptions.length ? (
+      {hasSuggestions ? (
         <ul
           id={suggestionListId}
           role="listbox"
@@ -294,23 +361,26 @@ export default function ClubSelect({
             overflowY: "auto",
           }}
         >
-          {matchingOptions.slice(0, 5).map((club) => (
-            <li key={club.id}>
-              <button
-                type="button"
-                onClick={() => handleSuggestionSelect(club)}
-                style={{
-                  width: "100%",
-                  textAlign: "left",
-                  padding: "0.5rem 0.75rem",
-                  background: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                }}
-                aria-label={`Select ${club.name}`}
-              >
-                {club.name}
-              </button>
+          {visibleMatchingOptions.map((club, index) => (
+            <li
+              key={club.id}
+              id={`${suggestionListId}-${club.id}`}
+              role="option"
+              aria-selected={index === activeSuggestionIndex}
+              onMouseDown={(event) => {
+                event.preventDefault();
+              }}
+              onClick={() => handleSuggestionSelect(club)}
+              style={{
+                width: "100%",
+                textAlign: "left",
+                padding: "0.5rem 0.75rem",
+                background: index === activeSuggestionIndex ? "rgba(255,255,255,0.08)" : "transparent",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              {club.name}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
### Motivation

- Bring `ClubSelect` in line with the keyboard interaction model used by `CountrySelect` so keyboard users can navigate and commit inline suggestions.
- Improve accessibility by adding correct combobox/listbox semantics and stable ids for suggestions to make screen-reader behavior predictable.

### Description

- Track an `activeSuggestionIndex` state and derive the currently active suggestion from the truncated `matchingOptions` list so keyboard navigation can highlight options.
- Add `onKeyDown` handling on the search input to support `ArrowDown` / `ArrowUp` to move the active suggestion, `Enter` to commit the active suggestion via the same `handleSuggestionSelect` path, and `Escape` to clear/reset suggestion state.
- Apply combobox semantics to the search input with `role="combobox"` and wired `aria-expanded`, `aria-activedescendant`, and `aria-controls` to the suggestions list, and give each suggestion a stable `id` and `role="option"` with `aria-selected` when active.
- Ensure mouse clicks and keyboard commits both call the same selection handler (`handleSuggestionSelect` -> `onChange`) and update search state consistently, and update tests to assert against the listbox options and keyboard flows.

### Testing

- Ran the component tests for the changed file with `pnpm --filter @cst/web exec vitest run src/components/ClubSelect.test.tsx`, and the test file completed successfully (`6 tests` passed).
- Updated `apps/web/src/components/ClubSelect.test.tsx` to use `within(...)` scoping for listbox assertions and added a new test that verifies `ArrowDown`/`ArrowUp`/`Enter`/`Escape` behavior which passed under the test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c95e989c8323891d807591caf90b)