### PR TITLE
Lazy-load virtualization for LeaderboardTable

### DIFF
--- a/apps/web/src/app/leaderboard/components/LeaderboardTable.test.tsx
+++ b/apps/web/src/app/leaderboard/components/LeaderboardTable.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { act } from "react";
+import { ALL_SPORTS } from "../constants";
+import type { Leader } from "../hooks/useLeaderboardData";
+import LeaderboardTable from "./LeaderboardTable";
+
+vi.mock("./VirtualizedLeaderboardList", () => ({
+  default: ({
+    children,
+    itemData,
+    itemCount,
+    onItemsRendered,
+  }: {
+    children: (props: { index: number; style: React.CSSProperties; data: Leader[] }) => React.ReactNode;
+    itemData: Leader[];
+    itemCount: number;
+    onItemsRendered?: (props: { visibleStartIndex: number; visibleStopIndex: number }) => void;
+  }) => {
+    onItemsRendered?.({
+      visibleStartIndex: Math.max(0, itemCount - 5),
+      visibleStopIndex: itemCount - 1,
+    });
+    return (
+      <div role="rowgroup" data-testid="virtualized-rowgroup">
+        {children({ index: 0, style: {}, data: itemData })}
+      </div>
+    );
+  },
+}));
+
+const mockIntersectionObservers: MockIntersectionObserver[] = [];
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  elements = new Set<Element>();
+  observe = vi.fn((element: Element) => {
+    this.elements.add(element);
+  });
+  disconnect = vi.fn();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    mockIntersectionObservers.push(this);
+  }
+
+  trigger(isIntersecting = true) {
+    const entries = Array.from(this.elements).map((element) => ({
+      isIntersecting,
+      target: element,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      time: 0,
+      boundingClientRect: element.getBoundingClientRect(),
+      intersectionRect: element.getBoundingClientRect(),
+      rootBounds: null,
+    })) as IntersectionObserverEntry[];
+    this.callback(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+const makeLeader = (rank: number): Leader => ({
+  rank,
+  playerId: `player-${rank}`,
+  playerName: `Player ${rank}`,
+  rating: 1000 + rank,
+  setsWon: rank,
+  setsLost: 1,
+});
+
+const baseProps = {
+  sport: ALL_SPORTS,
+  isBowling: false,
+  sortState: [],
+  onSortChange: vi.fn(),
+  getSortForColumn: vi.fn(),
+  getSortPriority: vi.fn(),
+  getAriaSort: vi.fn(() => "none" as const),
+  captionText: "Leaderboard results",
+  resultsTableId: "leaderboard-results",
+  resultsTableCaptionId: "leaderboard-results-caption",
+  formatSportName: vi.fn((value) => value ?? "Unknown"),
+  formatInteger: vi.fn((value) => (value == null ? "—" : String(value))),
+  formatRating: vi.fn((value) => (value == null ? "—" : String(value))),
+  formatDecimal: vi.fn((value) => (value == null ? "—" : String(value))),
+  formatWinProbability: vi.fn((value) => (value == null ? "—" : `${value}%`)),
+  getWinProbability: vi.fn(() => null),
+};
+
+describe("LeaderboardTable virtualization", () => {
+  beforeEach(() => {
+    mockIntersectionObservers.length = 0;
+    // @ts-expect-error test mock
+    global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error cleanup test mock
+    delete global.IntersectionObserver;
+    vi.clearAllMocks();
+  });
+
+  it("keeps small lists in the regular rowgroup and triggers loadMore with IntersectionObserver", async () => {
+    const loadMore = vi.fn();
+
+    render(
+      <LeaderboardTable
+        {...baseProps}
+        leaders={Array.from({ length: 3 }, (_, i) => makeLeader(i + 1))}
+        hasMore
+        loadMore={loadMore}
+      />,
+    );
+
+    const bodyRowgroup = screen
+      .getAllByRole("rowgroup")
+      .find((group) => group.querySelector('[role="row"]'));
+    expect(bodyRowgroup).toBeInTheDocument();
+    expect(screen.queryByTestId("virtualized-rowgroup")).not.toBeInTheDocument();
+
+    await act(async () => {
+      mockIntersectionObservers.forEach((observer) => observer.trigger());
+    });
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it("renders large lists in the virtualized container and triggers loadMore from onItemsRendered", async () => {
+    const loadMore = vi.fn();
+
+    const { container } = render(
+      <LeaderboardTable
+        {...baseProps}
+        leaders={Array.from({ length: 55 }, (_, i) => makeLeader(i + 1))}
+        hasMore
+        loadMore={loadMore}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    Object.defineProperty(table, "scrollWidth", {
+      configurable: true,
+      value: 1000,
+    });
+    table.getBoundingClientRect = () =>
+      ({ width: 1000, height: 200, top: 0, left: 0, right: 1000, bottom: 200, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("virtualized-rowgroup")).toBeInTheDocument();
+    });
+    expect(loadMore).toHaveBeenCalled();
+    expect(
+      container.querySelector('div[aria-hidden="true"][style*="height: 1px"]'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/leaderboard/components/LeaderboardTable.tsx
+++ b/apps/web/src/app/leaderboard/components/LeaderboardTable.tsx
@@ -1,16 +1,18 @@
 import {
   CSSProperties,
+  Suspense,
   forwardRef,
   HTMLAttributes,
+  lazy,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { ALL_SPORTS, type LeaderboardSport } from "../constants";
 import type { Leader } from "../hooks/useLeaderboardData";
+import type { LeaderboardListChildProps } from "./VirtualizedLeaderboardList";
 import type {
   SortCriterion,
   SortDirection,
@@ -21,6 +23,8 @@ import { selectLeaderDerivedMetrics } from "../lib/leaderboardMetrics";
 const VIRTUALIZATION_THRESHOLD = 50;
 const VIRTUAL_ROW_HEIGHT = 40;
 const MAX_VIRTUALIZED_HEIGHT = 520;
+
+const VirtualizedLeaderboardList = lazy(() => import("./VirtualizedLeaderboardList"));
 
 type Props = {
   leaders: Leader[];
@@ -438,7 +442,7 @@ export default function LeaderboardTable({
   );
 
   const renderVirtualRow = useCallback(
-    ({ index, style, data }: ListChildComponentProps<Leader[]>) =>
+    ({ index, style, data }: LeaderboardListChildProps) =>
       buildRow(data[index], index, style),
     [buildRow],
   );
@@ -486,22 +490,24 @@ export default function LeaderboardTable({
         </div>
         <TableHeader />
         {shouldVirtualize ? (
-          <FixedSizeList
-            height={virtualizedListHeight}
-            width={tableWidth}
-            itemCount={leaders.length}
-            itemData={leaders}
-            itemSize={VIRTUAL_ROW_HEIGHT}
-            onItemsRendered={handleItemsRendered}
-            outerElementType={VirtualRowGroup}
-            itemKey={(index, data) => {
-              const row = data[index];
-              return `${row.rank}-${row.playerId}-${row.sport ?? ""}`;
-            }}
-            style={{ overflowX: "hidden" }}
-          >
-            {renderVirtualRow}
-          </FixedSizeList>
+          <Suspense fallback={null}>
+            <VirtualizedLeaderboardList
+              height={virtualizedListHeight}
+              width={tableWidth}
+              itemCount={leaders.length}
+              itemData={leaders}
+              itemSize={VIRTUAL_ROW_HEIGHT}
+              onItemsRendered={handleItemsRendered}
+              outerElementType={VirtualRowGroup}
+              itemKey={(index, data) => {
+                const row = data[index];
+                return `${row.rank}-${row.playerId}-${row.sport ?? ""}`;
+              }}
+              style={{ overflowX: "hidden" }}
+            >
+              {renderVirtualRow}
+            </VirtualizedLeaderboardList>
+          </Suspense>
         ) : (
           <div role="rowgroup">
             {leaders.map((row, index) => buildRow(row, index))}

--- a/apps/web/src/app/leaderboard/components/VirtualizedLeaderboardList.tsx
+++ b/apps/web/src/app/leaderboard/components/VirtualizedLeaderboardList.tsx
@@ -1,0 +1,12 @@
+import type { ComponentProps } from "react";
+import { FixedSizeList, type ListChildComponentProps } from "react-window";
+import type { Leader } from "../hooks/useLeaderboardData";
+
+export type LeaderboardListChildProps = ListChildComponentProps<Leader[]>;
+type VirtualizedLeaderboardListProps = ComponentProps<typeof FixedSizeList<Leader[]>>;
+
+export default function VirtualizedLeaderboardList(
+  props: VirtualizedLeaderboardListProps,
+) {
+  return <FixedSizeList {...props} />;
+}


### PR DESCRIPTION
### Motivation
- Avoid pulling the `react-window` virtualization bundle into the main leaderboard render path unless it is actually needed. 
- Keep small lists rendering exactly as before while enabling virtualization for large lists to improve runtime/bundle performance. 
- Preserve existing `shouldVirtualize` gating and existing `loadMore` behavior in both modes. 

### Description
- Removed the top-level `FixedSizeList` import from `LeaderboardTable` and introduced a lazy import using `React.lazy` + `Suspense` to load a small wrapper component only when `shouldVirtualize` is true. 
- Added `VirtualizedLeaderboardList.tsx` as a thin wrapper around `FixedSizeList` so the `react-window` code stays behind the dynamic boundary. 
- Kept the existing `shouldVirtualize` condition (`leaders.length > VIRTUALIZATION_THRESHOLD && tableWidth > 0`) and unchanged non-virtualized rendering for small lists. 
- Updated typing and the virtualized rendering path to use the wrapper component, and added `LeaderboardTable.test.tsx` that mocks the virtualized wrapper and a test `IntersectionObserver` to assert small lists render standard rowgroups and large lists render the virtualized container and call `loadMore` via `onItemsRendered`.

### Testing
- Ran `cd apps/web && CI=1 pnpm test src/app/leaderboard/components/LeaderboardTable.test.tsx`, which passed. 
- Ran `cd apps/web && CI=1 pnpm test src/app/leaderboard/leaderboard.test.tsx src/app/leaderboard/components/LeaderboardTable.test.tsx`, and all tests passed (37 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cb883b8883238316f30e0dd1b668)